### PR TITLE
Default and palette resolver

### DIFF
--- a/src/prettyplot/__init__.py
+++ b/src/prettyplot/__init__.py
@@ -32,7 +32,7 @@ from prettyplot.utils.axes import (
 )
 
 # Theming
-from prettyplot.themes.colors import get_palette, list_palettes, show_palette
+from prettyplot.themes.colors import get_palette, list_palettes, show_palette, resolve_palette, DEFAULT_COLOR
 from prettyplot.themes.styles import (
     set_publication_style,
     set_minimal_style,
@@ -67,6 +67,9 @@ __all__ = [
     "get_palette",
     "list_palettes",
     "show_palette",
+    "resolve_palette",
+    # Color constants
+    "DEFAULT_COLOR",
     # Style functions
     "set_publication_style",
     "set_minimal_style",

--- a/src/prettyplot/themes/__init__.py
+++ b/src/prettyplot/themes/__init__.py
@@ -9,6 +9,8 @@ from prettyplot.themes.colors import (
     get_palette,
     list_palettes,
     show_palette,
+    resolve_palette,
+    DEFAULT_COLOR,
     PASTEL_CATEGORICAL,
     PASTEL_CATEGORICAL_MINIMAL,
     PASTEL_SEQUENTIAL_GREEN,
@@ -47,6 +49,9 @@ __all__ = [
     "get_palette",
     "list_palettes",
     "show_palette",
+    "resolve_palette",
+    # Color constants
+    "DEFAULT_COLOR",
     # Color palettes
     "PASTEL_CATEGORICAL",
     "PASTEL_CATEGORICAL_MINIMAL",


### PR DESCRIPTION
- Add DEFAULT_COLOR constant (#5d83c3) for consistent single-color plots
- Create resolve_palette() helper to handle both prettyplot and seaborn palettes
- Update barplot to use resolve_palette() for automatic palette detection
- Fix issue where pastel_categorical palette was not being detected
- Improve barplot to use 'color' parameter for single-color plots (no hue/split)
- Export DEFAULT_COLOR and resolve_palette from __init__.py files

The resolve_palette() function provides a unified interface for palette handling:
- Checks prettyplot palettes first, then falls back to seaborn
- Returns default color when palette is None
- Properly handles list/dict palette specifications