### PR TITLE
Add GitHub Pages deployment with shibuya theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system -e ".[docs]"
+
+      - name: Build documentation
+        run: |
+          cd docs
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,21 +40,27 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'shibuya'
 html_static_path = ['_static']
 html_logo = None
 html_favicon = None
 
 html_theme_options = {
-    'logo_only': False,
-    'display_version': True,
-    'prev_next_buttons_location': 'bottom',
-    'style_external_links': False,
-    'collapse_navigation': True,
-    'sticky_navigation': True,
-    'navigation_depth': 4,
-    'includehidden': True,
-    'titles_only': False
+    'github_url': 'https://github.com/jorgebotas/publiplots',
+    'nav_links': [
+        {
+            'title': 'Home',
+            'url': 'index',
+        },
+        {
+            'title': 'API Reference',
+            'url': 'api/modules',
+        },
+        {
+            'title': 'Examples',
+            'url': 'auto_examples/index',
+        },
+    ],
 }
 
 # -- Extension configuration -------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 docs = [
     "sphinx>=7.0.0",
     "sphinx-gallery>=0.15.0",
-    "sphinx-rtd-theme>=2.0.0",
+    "shibuya>=2024.0.0",
     "numpydoc>=1.6.0",
     "pillow>=10.0.0",
 ]


### PR DESCRIPTION
- Replace sphinx-rtd-theme with shibuya for cleaner documentation UI
- Configure shibuya theme with GitHub integration and navigation links
- Add GitHub Actions workflow for automated docs deployment to GitHub Pages
- Use uv for dependency management in CI workflow
- Workflow triggers on push to main, PRs, and manual dispatch