### PR TITLE
Fix block annotations in complex heatmap

### DIFF
--- a/src/publiplots/plot/complex_heatmap/annotations.py
+++ b/src/publiplots/plot/complex_heatmap/annotations.py
@@ -230,15 +230,19 @@ def block(
             # Case 2: DataFrame as matrix (wide format from complex_heatmap)
             if horizontal:
                 # Use columns for horizontal (top/bottom)
-                data_series = pd.Series(data.columns)
                 if order is not None:
-                    data_series = data_series.reindex(order)
+                    # Filter and reorder columns based on order
+                    data_series = pd.Series([col for col in order if col in data.columns])
+                else:
+                    data_series = pd.Series(data.columns)
                 data_df = data_series.to_frame().T
             else:
                 # Use index for vertical (left/right)
-                data_series = pd.Series(data.index)
                 if order is not None:
-                    data_series = data_series.reindex(order)
+                    # Filter and reorder index based on order
+                    data_series = pd.Series([idx for idx in order if idx in data.index])
+                else:
+                    data_series = pd.Series(data.index)
                 data_df = data_series.to_frame()
 
     elif isinstance(data, pd.Series):
@@ -362,7 +366,8 @@ def block(
                     'ha': 'center',
                     'va': 'center',
                     'color': 'black',
-                    'weight': 'normal'
+                    'weight': 'normal',
+                    'rotation': 90 if not horizontal else 0  # Rotate text for vertical blocks
                 }
                 text_defaults.update(text_kwargs)
 

--- a/src/publiplots/plot/complex_heatmap/builder.py
+++ b/src/publiplots/plot/complex_heatmap/builder.py
@@ -15,6 +15,7 @@ from publiplots.utils.offset import offset_patches, offset_lines, offset_collect
 from publiplots.utils.legend import legend as legend_from_utils
 from .dendrogram import cluster_data, dendrogram as dendrogram_plot
 from .ticklabels import ticklabels as ticklabels_plot
+from .annotations import block as block_annotation
 
 # Conversion constants
 MM2INCH = 1 / 25.4
@@ -982,9 +983,15 @@ class ComplexHeatmapBuilder:
 
         # Offset elements to align with heatmap cells
         # Heatmap cells are centered at 0.5, 1.5, 2.5...
-        # Categorical plots position elements at 0, 1, 2...
+        # Categorical plots (bars, violins, etc.) position elements at 0, 1, 2...
         # Shift by +0.5 to align with cell centers
-        if margin['align']:
+        #
+        # EXCEPTION: Block annotations already position rectangles at correct coordinates
+        # (0, 1, 2...) matching the heatmap coordinate system, so skip offsetting for them
+        is_block = (func is block_annotation or
+                   getattr(func, '__name__', '') == 'block')
+
+        if margin['align'] and not is_block:
             # For top/bottom margins: shift along x-axis (vertical)
             # For left/right margins: shift along y-axis (horizontal)
             orientation = "vertical" if position in ("top", "bottom") else "horizontal"


### PR DESCRIPTION
This commit addresses three issues with block annotations:

1. **Fix wide format handling**: When DataFrame is passed with boolean x/y parameters, correctly filter and reorder columns/index based on the order parameter. Previously, reindex() was being called on a Series of column/index names with integer index, which didn't work.

2. **Add default text rotation for y-axis blocks**: When plotting blocks vertically (horizontal=False), text is now rotated 90 degrees by default for better readability. This can still be overridden via text_kws parameter.

3. **Skip offsetting for block annotations**: Block annotations already position rectangles at the correct coordinates (0, 1, 2...) that match the heatmap coordinate system. The 0.5 offset is only needed for categorical plotting functions (bars, violins) that center their elements at integer positions. Added check to skip offsetting when the annotation function is 'block'.

These changes ensure block annotations work correctly with both long and wide format data, and properly align with heatmap cells without the incorrect shifting that was occurring before.