### PR TITLE
chore: 0.4.7 changelog + bump actions to Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -48,7 +48,7 @@ jobs:
           make html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build/html
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8
 
     - name: Build package
       run: |
         uv build
 
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -73,7 +73,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: "3.11"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
 
     - name: Build package
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2026-04-29
+
+### Added
+- `heatmap()` and `complex_heatmap()` builder with dot-heatmap and margin-plot support
+- Unified `edgecolor` parameter across `barplot`, `boxplot`, `violinplot`, `scatterplot`, `stripplot`, `swarmplot`, `pointplot`, and `raincloudplot`
+- `edgecolors` parameter on `create_legend_handles` (decouples edge from face in legend entries)
+- `as_categorical()` helper in `publiplots.utils` that guarantees `category` dtype
+- Optional `ax` parameter on `pp.legend()` (defaults to `plt.gca()`)
+- `rotate()` helper for axis-label rotation
+- Scatterplot colorbar rendering test coverage
+
+### Changed
+- `LegendBuilder` now uses mm-based positioning with automatic column overflow and a singleton per-axes pattern
+- Default text color set to black
+- Barplot skips seaborn `hue` when `hue == categorical_axis` (avoids unwanted dodge)
+
+### Fixed
+- `AttributeError: Can only use .cat accessor with a 'category' dtype` in `barplot` when the categorical axis column was object-dtype strings
+- Face/edge color bug in `barplot` when recoloring from palette
+- Legend overlap bug caused by inaccurate title-height measurement
+- Colorbar positioning bugs (vpad subtraction, xmargin/ymargin, remaining-space math)
+
+### Dependencies
+- Added `scipy>=1.10.0` (required by `heatmap` clustering)
+
+[0.4.7]: https://github.com/jorgebotas/publiplots/releases/tag/v0.4.7
+
 ## [0.4.6] - 2025-12-04
 
 ### Added


### PR DESCRIPTION
## Summary
- Add the `0.4.7` entry to `CHANGELOG.md` (was missing from the release — tag notes only).
- Bump GitHub Actions to majors that run on Node.js 24, ahead of the Sep 2026 deprecation (the last publish run flagged this warning).

### Action bumps
| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `astral-sh/setup-uv` | v3/v4 | v8 |

No behavioral change expected — majors are drop-in for the inputs/outputs we use.

## Test plan
- [ ] Docs workflow runs on this PR and builds the gallery successfully
- [ ] Next release firing `publish.yml` succeeds (unchanged logic, just newer action runtimes)