### PR TITLE
feat(legend): auto-collect legend_group + width-aware legend_column

### DIFF
--- a/docs/superpowers/handoff/2026-04-30-fixed-axes-pp-subplots.md
+++ b/docs/superpowers/handoff/2026-04-30-fixed-axes-pp-subplots.md
@@ -94,7 +94,18 @@ composer.save('figure_1.pdf')
 
 Each added figure is positioned such that its declared **axes rectangle** aligns to a shared grid. Panel labels ("A", "B", "C") placed at the top-left of each axes rectangle. Composer assumes every `fig` was made with `pp.subplots()` so it knows the axes offsets within the figure. For legacy figures, the composer could optionally take explicit panel positions.
 
-Scope notes for the composer (when it comes): SVG/PDF output, read axes rectangles from the figure's saved metadata, respect the letter-size coordinate system, support multi-panel layouts with span support.
+**Snap mode (IMPORTANT, added 2026-05-01):** the composer must align panels by **axes rectangle**, not by figure edges. `FigureLayout.axes_position(row, col)` already returns each axes' figure-fraction coordinates; multiply by figure mm size and you have absolute axes rectangles. The composer reads those for every figure it places and snaps the axes rectangles to the shared page grid. Decorations extend past the snap point without affecting the snap — so a left panel with a one-line title aligns cleanly with a right panel carrying a two-line title, which is the common publication case.
+
+Proposed API:
+```python
+composer.add(fig, row=0, col=0, snap="axes_top_left")   # default
+composer.add(fig, row=0, col=1, snap="axes_center")      # alternative
+composer.add(fig, row=0, col=2, snap="axes_right")       # for mirrored panels
+```
+
+Snapping anchor options should cover top-left, top-right, center, and a bbox mode (legacy — snap figure edges). Default to `axes_top_left` because it matches the conventional upper-left panel grid in papers.
+
+Scope notes for the composer (when it comes): SVG/PDF output, read axes rectangles from the figure's saved metadata, respect the letter-size coordinate system, support multi-panel layouts with span support, **snap by axes rectangle by default**.
 
 ## Concrete plan for PR #79
 

--- a/docs/superpowers/plans/2026-05-01-legend-auto-collection.md
+++ b/docs/superpowers/plans/2026-05-01-legend-auto-collection.md
@@ -1,0 +1,1978 @@
+# Legend Auto-Collection + Width-Aware Sizing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `pp.legend_group(anchor=..., collect=None|[names])` that auto-collects per-axes legend entries across a grid, plus `SubplotsAutoLayout` measuring the group width so `legend_column` is always automatic.
+
+**Architecture:** Introduce a shared `LegendEntry` dataclass + per-axes `_publiplots_legend_entries` store. Plot functions (in this PR: scatter / strip / swarm / point — the 4 that already stash) migrate to the new store. `MultiAxesLegendGroup` gains a `collect` kwarg and a `_materialize` pass that walks the grid on first draw, dedups by `(name, kind)`, and renders via the existing `LegendBuilder`. `SubplotsAutoLayout._measure` gains a fifth measurement (`legend_column`) that reads the rendered group width and feeds it into `FigureLayout.with_updated_reservations`. `pp.subplots()` drops the `legend_column` kwarg.
+
+**Tech Stack:** Python 3.11+, matplotlib, numpy, pytest (Agg backend for integration tests).
+
+**Worktree:** `.worktrees/legend-positioning` on `feat/legend-positioning`, branched from `main` after PR #80 merged. Baseline: 121 tests passing.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-legend-auto-collection-design.md` (authoritative — re-read before starting).
+
+---
+
+## Scope reminder
+
+**In-scope plot migrations (this PR):**
+- `src/publiplots/plot/scatter.py`
+- `src/publiplots/plot/strip.py`
+- `src/publiplots/plot/swarm.py`
+- `src/publiplots/plot/point.py`
+
+**Deferred to follow-up PRs (keep current behavior):**
+- `src/publiplots/plot/bar.py`
+- `src/publiplots/plot/box.py`
+- `src/publiplots/plot/violin.py`
+- `src/publiplots/plot/raincloud.py`
+- `src/publiplots/plot/heatmap.py`
+
+These 5 continue to render legends inline. `pp.legend_group` will not auto-collect their entries; users fall back to manual `group.add_legend(handles=...)` exactly as today for those plots.
+
+---
+
+## Rules of the road
+
+- TDD strictly: failing test first, verify fail, then implementation.
+- After EACH task, run the full suite `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`. Targets update as tasks land.
+- Commit after every task with a conventional-commits message. Never amend.
+- Do NOT modify public API surfaces beyond what each task specifies.
+- `unset VIRTUAL_ENV` before every python/pytest command — the shell alias to the lemur venv is a known trap on this machine.
+- Treat the 5 deferred plots as untouched — do not modify their files in this plan.
+
+---
+
+## File structure
+
+**Create:**
+- `src/publiplots/utils/legend_entries.py` — `LegendEntry`, `stash_entry`, `get_entries`, `resolve_legend_flags`, `entry_is_in_group`, `is_continuous_hue`.
+- `tests/test_legend_entries.py`
+- `tests/test_legend_group_auto_collect.py`
+- `tests/test_scatter_legend_stash.py`
+
+**Modify:**
+- `src/publiplots/utils/legend_group.py` — `collect` kwarg, `_materialize`, `claims`, `_render_entry`, figure registration.
+- `src/publiplots/layout/auto_layout.py` — `_measure_legend_column`, extend `_ALL_SIDES`, extend `_needs_update`.
+- `src/publiplots/layout/subplots.py` — drop `legend_column` kwarg; raise `TypeError` if passed.
+- `src/publiplots/utils/legend.py` — rewrite auto-mode (`legend()` public function + `_get_legend_data`) to read the new `LegendEntry` store with fallback to the legacy dict store.
+- `src/publiplots/plot/scatter.py` — migrate to stash `LegendEntry`.
+- `src/publiplots/plot/strip.py` — same.
+- `src/publiplots/plot/swarm.py` — same.
+- `src/publiplots/plot/point.py` — same.
+- `examples/plots/plot_14_edgecolor_control.py` — drop `legend_column=30` from the one `pp.subplots` call that still references a migrated plot (the 1×3 bar/box/scatter section; the 1×2 raincloud stays with manual `group.add_legend` because raincloud is NOT migrated).
+- `tests/test_subplots.py` — drop `test_subplots_legend_column_reserves_extra_width`; add width-awareness tests.
+
+---
+
+## Task 1: `LegendEntry` + entry store helpers
+
+Creates the foundation module that every other task imports from.
+
+**Files:**
+- Create: `src/publiplots/utils/legend_entries.py`
+- Create: `tests/test_legend_entries.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_legend_entries.py` with this exact content:
+
+```python
+"""Tests for legend_entries.py — entries, stashing, flag resolution."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+class _FakeHandle:
+    def __init__(self, fc="red"):
+        self._fc = fc
+    def get_facecolor(self):
+        return self._fc
+
+
+def test_legend_entry_build_is_deterministic():
+    e1 = LegendEntry.build("g", "hue", [_FakeHandle("red")], ["A"])
+    e2 = LegendEntry.build("g", "hue", [_FakeHandle("red")], ["A"])
+    assert e1.signature == e2.signature
+
+
+def test_legend_entry_different_handles_differ():
+    e1 = LegendEntry.build("g", "hue", [_FakeHandle("red")], ["A"])
+    e2 = LegendEntry.build("g", "hue", [_FakeHandle("blue")], ["A"])
+    assert e1.signature != e2.signature
+
+
+def test_legend_entry_name_and_kind_preserved():
+    e = LegendEntry.build("treatment", "size", [], [])
+    assert e.name == "treatment"
+    assert e.kind == "size"
+    assert e.handles == ()
+    assert e.labels == ()
+
+
+def test_stash_entry_creates_list_first_time():
+    fig, ax = plt.subplots()
+    assert get_entries(ax) == []
+    stash_entry(ax, LegendEntry.build("g", "hue", [], []))
+    assert len(get_entries(ax)) == 1
+
+
+def test_stash_entry_appends_in_order():
+    fig, ax = plt.subplots()
+    stash_entry(ax, LegendEntry.build("g1", "hue", [], []))
+    stash_entry(ax, LegendEntry.build("g2", "size", [], []))
+    names = [e.name for e in get_entries(ax)]
+    assert names == ["g1", "g2"]
+
+
+def test_resolve_legend_flags_true():
+    flags = resolve_legend_flags(True)
+    assert flags == {"hue": True, "size": True, "style": True, "marker": True}
+
+
+def test_resolve_legend_flags_false():
+    flags = resolve_legend_flags(False)
+    assert flags == {"hue": False, "size": False, "style": False, "marker": False}
+
+
+def test_resolve_legend_flags_dict_partial_missing_defaults_to_true():
+    flags = resolve_legend_flags({"hue": False})
+    assert flags == {"hue": False, "size": True, "style": True, "marker": True}
+
+
+def test_resolve_legend_flags_dict_full():
+    flags = resolve_legend_flags({"hue": True, "size": False, "style": False, "marker": False})
+    assert flags == {"hue": True, "size": False, "style": False, "marker": False}
+
+
+def test_resolve_legend_flags_rejects_bad_type():
+    with pytest.raises(TypeError, match="legend must be bool or dict"):
+        resolve_legend_flags(1)
+
+
+def test_entry_is_in_group_no_group():
+    fig, ax = plt.subplots()
+    entry = LegendEntry.build("g", "hue", [], [])
+    assert entry_is_in_group(fig, entry) is False
+
+
+def test_entry_is_in_group_with_claim():
+    """entry_is_in_group delegates to group.claims(name) — mock one."""
+    fig, ax = plt.subplots()
+    entry = LegendEntry.build("treatment", "hue", [], [])
+
+    class _FakeGroup:
+        def claims(self, name):
+            return name == "treatment"
+
+    fig._publiplots_legend_group = _FakeGroup()
+    assert entry_is_in_group(fig, entry) is True
+
+    other = LegendEntry.build("other", "hue", [], [])
+    assert entry_is_in_group(fig, other) is False
+
+
+def test_is_continuous_hue_true_for_scalar_mappable():
+    from matplotlib.cm import ScalarMappable
+    from matplotlib.colors import Normalize
+    sm = ScalarMappable(cmap="viridis", norm=Normalize(0, 1))
+    assert is_continuous_hue([sm]) is True
+
+
+def test_is_continuous_hue_false_for_empty():
+    assert is_continuous_hue([]) is False
+
+
+def test_is_continuous_hue_false_for_regular_handles():
+    assert is_continuous_hue([_FakeHandle()]) is False
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_entries.py -v`
+Expected: all FAIL with `ModuleNotFoundError: No module named 'publiplots.utils.legend_entries'`.
+
+- [ ] **Step 3: Create `src/publiplots/utils/legend_entries.py`**
+
+```python
+"""
+Shared legend-entry infrastructure.
+
+Plot functions stash LegendEntry objects on ax._publiplots_legend_entries.
+pp.legend(ax) reads from this store to render per-axis legends.
+pp.legend_group(anchor=ax) aggregates entries across a grid of axes.
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+import hashlib
+
+
+_LEGEND_KINDS = ("hue", "size", "style", "marker")
+
+
+@dataclass(frozen=True)
+class LegendEntry:
+    """A single stashed legend entry on an axes.
+
+    Attributes
+    ----------
+    name : str
+        The variable name the user passed to the plot function
+        (e.g. ``hue='treatment'`` -> ``name='treatment'``).
+    kind : str
+        One of ``"hue"``, ``"size"``, ``"style"``, ``"marker"``.
+    handles : tuple
+        Matplotlib-compatible handles. For continuous hue, the first
+        handle is a ``ScalarMappable`` (see :func:`is_continuous_hue`).
+    labels : tuple of str
+        Display labels. Empty for continuous hue (colorbar path).
+    signature : str
+        Short hash of (kind, labels, handle-type + key visual props).
+        Used by pp.legend_group for dedup and mismatch detection.
+    """
+    name: str
+    kind: str
+    handles: tuple
+    labels: tuple
+    signature: str
+
+    @classmethod
+    def build(cls, name, kind, handles, labels) -> "LegendEntry":
+        """Construct an entry with a computed signature."""
+        return cls(
+            name=name,
+            kind=kind,
+            handles=tuple(handles),
+            labels=tuple(labels),
+            signature=_hash_handles(handles, labels),
+        )
+
+
+def _hash_handles(handles, labels) -> str:
+    parts = []
+    for h, lab in zip(handles, labels):
+        parts.append(type(h).__name__)
+        parts.append(str(lab))
+        for attr in ("get_facecolor", "get_marker", "get_markersize",
+                     "get_linewidth"):
+            fn = getattr(h, attr, None)
+            if fn is not None:
+                try:
+                    parts.append(repr(fn()))
+                except Exception:
+                    pass
+    # If no labels but there ARE handles (continuous hue / colorbar),
+    # include the handle types at least.
+    if not labels and handles:
+        for h in handles:
+            parts.append(type(h).__name__)
+    return hashlib.sha1("|".join(parts).encode()).hexdigest()[:12]
+
+
+def stash_entry(ax, entry: LegendEntry) -> None:
+    """Append an entry to ``ax._publiplots_legend_entries``.
+
+    Creates the list attribute on first call. Order is preserved;
+    later calls append.
+    """
+    existing = getattr(ax, "_publiplots_legend_entries", None)
+    if existing is None:
+        existing = []
+        ax._publiplots_legend_entries = existing
+    existing.append(entry)
+
+
+def get_entries(ax) -> list:
+    """Return the ordered list of entries stashed on ``ax``."""
+    return list(getattr(ax, "_publiplots_legend_entries", []))
+
+
+def resolve_legend_flags(legend) -> dict:
+    """Convert ``legend=`` (bool | dict) to a per-kind include map.
+
+    - ``True``  -> all kinds True
+    - ``False`` -> all kinds False
+    - ``dict``  -> as given; missing keys default to True
+    """
+    if legend is True:
+        return {k: True for k in _LEGEND_KINDS}
+    if legend is False:
+        return {k: False for k in _LEGEND_KINDS}
+    if isinstance(legend, dict):
+        return {k: bool(legend.get(k, True)) for k in _LEGEND_KINDS}
+    raise TypeError(
+        f"legend must be bool or dict[str, bool], got {type(legend).__name__}"
+    )
+
+
+def entry_is_in_group(fig, entry: LegendEntry) -> bool:
+    """True if the figure's legend_group (if any) claims this entry."""
+    group = getattr(fig, "_publiplots_legend_group", None)
+    if group is None:
+        return False
+    return group.claims(entry.name)
+
+
+def is_continuous_hue(handles) -> bool:
+    """True if the handles list represents a continuous colormap.
+
+    Detection is by the presence of a ``ScalarMappable`` as the first
+    handle — categorical hue handles are publiplots' RectanglePatch /
+    MarkerPatch / etc., never ScalarMappable.
+    """
+    if not handles:
+        return False
+    try:
+        from matplotlib.cm import ScalarMappable
+    except ImportError:
+        return False
+    return isinstance(handles[0], ScalarMappable)
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_entries.py -v`
+Expected: all PASS (14 tests).
+
+- [ ] **Step 5: Run the full suite for regressions**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 121 baseline + 14 new = 135 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/utils/legend_entries.py tests/test_legend_entries.py
+git commit -m "feat(legend): LegendEntry + per-axes stash store"
+```
+
+---
+
+## Task 2: `MultiAxesLegendGroup.claims` + figure registration
+
+Adds the group-claim check and registers the group on the figure — no auto-collection yet. This lets future tasks gate per-axis rendering on group claims.
+
+**Files:**
+- Modify: `src/publiplots/utils/legend_group.py`
+- Create: `tests/test_legend_group_auto_collect.py` (stub; fleshes out in later tasks)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_legend_group_auto_collect.py`:
+
+```python
+"""Tests for MultiAxesLegendGroup auto-collect (PR #81)."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Claims + figure registration
+# ---------------------------------------------------------------------------
+
+
+def test_legend_group_registers_on_figure():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    group = pp.legend_group(anchor=axes[-1])
+    assert fig._publiplots_legend_group is group
+
+
+def test_legend_group_claims_collect_none_returns_true():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    group = pp.legend_group(anchor=axes[-1])
+    assert group.claims("anything") is True
+    assert group.claims("other") is True
+
+
+def test_legend_group_claims_with_collect_list():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    group = pp.legend_group(anchor=axes[-1], collect=["treatment"])
+    assert group.claims("treatment") is True
+    assert group.claims("dose") is False
+
+
+def test_legend_group_rejects_bare_string_collect():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    with pytest.raises(TypeError, match="list/tuple"):
+        pp.legend_group(anchor=axes[-1], collect="treatment")
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_group_auto_collect.py -v`
+Expected: all 4 FAIL — either `TypeError: unexpected kwarg 'collect'` or `AttributeError: claims`.
+
+- [ ] **Step 3: Modify `src/publiplots/utils/legend_group.py`**
+
+Replace the existing `MultiAxesLegendGroup.__init__` and the module-level `legend_group` factory with this version (keep the rest of the file as-is):
+
+```python
+"""
+Shared legend column across multiple subplots.
+
+MultiAxesLegendGroup composes one unified legend column anchored to a
+chosen axes even when individual legends/colorbars are attached to other
+axes in the same figure. This is the primary tool for complex subplot
+layouts.
+"""
+
+from typing import List, Optional, Sequence
+
+from matplotlib.axes import Axes
+from matplotlib.legend import Legend
+from matplotlib.cm import ScalarMappable
+from matplotlib.colorbar import Colorbar
+
+from publiplots.utils.legend import LegendBuilder
+
+
+class MultiAxesLegendGroup:
+    """
+    Unified legend column across multiple axes.
+
+    All elements share a single mm-based layout anchored to ``anchor``. Each
+    element can be attached to a different axes (via ``ax=`` on ``add_*``
+    calls) for hit-testing and picking; its POSITION is always computed
+    against the anchor's right edge regardless of which axes owns the artist.
+
+    Parameters
+    ----------
+    anchor : Axes
+        The axes whose right edge defines x=0 for the shared column.
+    collect : list or tuple of str, optional
+        Names of entries to auto-collect from across the grid's stashed
+        ``LegendEntry`` objects. ``None`` (default) collects everything.
+        A list filters and orders — e.g. ``collect=['treatment', 'dose']``
+        renders only those two names, in that order.
+    x_offset, y_offset, gap, column_spacing, vpad, max_width
+        Same meaning as :class:`LegendBuilder` — all in millimeters.
+    """
+
+    def __init__(
+        self,
+        anchor: Axes,
+        collect: Optional[Sequence[str]] = None,
+        x_offset: float = 2,
+        y_offset: Optional[float] = None,
+        gap: float = 2,
+        column_spacing: float = 5,
+        vpad: float = 5,
+        max_width: Optional[float] = None,
+    ):
+        self.anchor = anchor
+        if collect is not None:
+            if isinstance(collect, str) or not hasattr(collect, "__iter__"):
+                raise TypeError(
+                    "collect must be None or a list/tuple of names; "
+                    "got a bare string. Wrap in a list: collect=['name']"
+                )
+            collect = list(collect)
+        self._collect = collect
+        # Track whether _materialize has already run (set by Task 3).
+        self._materialized = False
+        self._warned_mismatch = False
+        # anchor_ax=anchor pins position math/reactor to the anchor regardless
+        # of self.ax swaps during add_* calls.
+        self._builder = LegendBuilder(
+            ax=anchor,
+            anchor_ax=anchor,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            gap=gap,
+            column_spacing=column_spacing,
+            vpad=vpad,
+            max_width=max_width,
+            external_to_axis=True,
+        )
+        # Register on the figure so plot functions can check claims.
+        anchor.get_figure()._publiplots_legend_group = self
+
+    def claims(self, name: str) -> bool:
+        """True if the group will render an entry with this name."""
+        if self._collect is None:
+            return True
+        return name in self._collect
+
+    def add_legend(
+        self,
+        handles: List,
+        label: str = "",
+        *,
+        ax: Optional[Axes] = None,
+        **kwargs,
+    ) -> Legend:
+        """Add a legend to the shared column.
+
+        The artist is attached to ax (defaults to anchor); position is
+        always computed against the anchor's right edge.
+        """
+        target_ax = ax if ax is not None else self.anchor
+        original_ax = self._builder.ax
+        try:
+            self._builder.ax = target_ax
+            legend = self._builder.add_legend(handles=handles, label=label, **kwargs)
+        finally:
+            self._builder.ax = original_ax
+        return legend
+
+    def add_colorbar(
+        self,
+        mappable: Optional[ScalarMappable] = None,
+        *,
+        ax: Optional[Axes] = None,
+        **kwargs,
+    ) -> Colorbar:
+        """Add a colorbar to the shared column. See add_legend for ax semantics."""
+        target_ax = ax if ax is not None else self.anchor
+        original_ax = self._builder.ax
+        try:
+            self._builder.ax = target_ax
+            cbar = self._builder.add_colorbar(mappable=mappable, **kwargs)
+        finally:
+            self._builder.ax = original_ax
+        return cbar
+
+
+def legend_group(
+    anchor: Axes,
+    *,
+    collect: Optional[Sequence[str]] = None,
+    x_offset: float = 2,
+    y_offset: Optional[float] = None,
+    gap: float = 2,
+    column_spacing: float = 5,
+    vpad: float = 5,
+    max_width: Optional[float] = None,
+) -> MultiAxesLegendGroup:
+    """Create a shared legend column anchored to ``anchor``.
+
+    See :class:`MultiAxesLegendGroup` for parameter docs.
+    """
+    return MultiAxesLegendGroup(
+        anchor=anchor,
+        collect=collect,
+        x_offset=x_offset,
+        y_offset=y_offset,
+        gap=gap,
+        column_spacing=column_spacing,
+        vpad=vpad,
+        max_width=max_width,
+    )
+```
+
+- [ ] **Step 4: Run the new tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_group_auto_collect.py -v`
+Expected: 4 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 135 + 4 = 139 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/utils/legend_group.py tests/test_legend_group_auto_collect.py
+git commit -m "feat(legend_group): collect kwarg + figure registration"
+```
+
+---
+
+## Task 3: `_materialize()` — auto-collection pass
+
+Walks the grid, dedups entries, filters by `collect=`, renders via the existing `add_legend` / `add_colorbar` dispatch.
+
+**Files:**
+- Modify: `src/publiplots/utils/legend_group.py`
+- Modify: `tests/test_legend_group_auto_collect.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_legend_group_auto_collect.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# _materialize — auto-collection
+# ---------------------------------------------------------------------------
+
+from publiplots.utils.legend_entries import LegendEntry, stash_entry
+
+
+def _stub_handle(color="red"):
+    """Minimal object with a get_facecolor method for signature hashing."""
+    class H:
+        def __init__(self, c):
+            self._c = c
+        def get_facecolor(self):
+            return self._c
+    return H(color)
+
+
+def _stash_on_axes(ax, name, kind, color="red", labels=("A",)):
+    entry = LegendEntry.build(
+        name=name, kind=kind,
+        handles=[_stub_handle(color) for _ in labels],
+        labels=labels,
+    )
+    stash_entry(ax, entry)
+
+
+def test_materialize_dedups_identical_entries_across_axes():
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    _stash_on_axes(axes[1], "treatment", "hue")
+    _stash_on_axes(axes[2], "treatment", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    group._materialize()
+    # Only one legend element added to the builder (not 3).
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 1
+
+
+def test_materialize_collects_distinct_names_across_axes():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    _stash_on_axes(axes[1], "dose", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 2
+
+
+def test_materialize_with_collect_filter_drops_unlisted_names():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    _stash_on_axes(axes[1], "dose", "hue")
+    group = pp.legend_group(anchor=axes[-1], collect=["treatment"])
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 1
+
+
+def test_materialize_collect_list_preserves_order():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "dose", "hue")
+    _stash_on_axes(axes[1], "treatment", "hue")
+    # First-in-axes-order is dose; but collect says treatment first.
+    group = pp.legend_group(anchor=axes[-1], collect=["treatment", "dose"])
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 2
+    # Legend.get_title().get_text() gives the "label" of each legend.
+    titles = [e[1].get_title().get_text() for e in legend_elements]
+    assert titles == ["treatment", "dose"]
+
+
+def test_materialize_is_idempotent():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    group._materialize()
+    count_after_first = len(group._builder.elements)
+    group._materialize()
+    count_after_second = len(group._builder.elements)
+    assert count_after_first == count_after_second
+
+
+def test_materialize_mismatched_signature_warns_once():
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue", color="red")
+    _stash_on_axes(axes[1], "treatment", "hue", color="blue")   # different palette
+    _stash_on_axes(axes[2], "treatment", "hue", color="green")  # yet another
+    group = pp.legend_group(anchor=axes[-1])
+    with pytest.warns(UserWarning, match="differs between axes"):
+        group._materialize()
+    # Warn-once: calling _materialize again should not re-warn.
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)  # fail if any warning fires
+        # Reset the _materialized flag so it re-runs the collection
+        group._materialized = False
+        group._materialize()  # must not warn again
+
+
+def test_materialize_no_publiplots_axes_is_noop():
+    """Group on a plt.subplots figure (no _publiplots_axes) must not crash."""
+    fig, ax = plt.subplots()
+    group = pp.legend_group(anchor=ax)
+    group._materialize()
+    assert group._builder.elements == []
+
+
+def test_materialize_manual_and_auto_coexist():
+    from publiplots.utils.legend import create_legend_handles
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    # Manual add BEFORE materialize
+    group.add_legend(
+        handles=create_legend_handles(labels=["x"], colors=["#000"], alpha=0.5, linewidth=1.0),
+        label="manual",
+    )
+    # Now materialize
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    # One manual + one auto-collected treatment entry.
+    assert len(legend_elements) == 2
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_group_auto_collect.py -v -k "materialize"`
+Expected: 8 FAIL with `AttributeError: _materialize`.
+
+- [ ] **Step 3: Add `_materialize`, `_render_entry`, and warning helpers to `src/publiplots/utils/legend_group.py`**
+
+Add these imports near the top of the file (alongside existing imports):
+
+```python
+import warnings
+
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    get_entries,
+    is_continuous_hue,
+)
+```
+
+Then add these methods to `MultiAxesLegendGroup` (after `claims` and before `add_legend`):
+
+```python
+    def _materialize(self) -> None:
+        """Collect stashed entries from every grid axes and render them.
+
+        Called by SubplotsAutoLayout during the settle pass (Task 6).
+        Idempotent — subsequent calls after the first return immediately.
+        """
+        if self._materialized:
+            return
+        self._materialized = True
+
+        fig = self.anchor.get_figure()
+        axes_matrix = getattr(fig, "_publiplots_axes", None)
+        if axes_matrix is None:
+            return
+
+        seen = {}  # (name, kind) -> LegendEntry
+        order = []  # list of (name, kind) in collection order
+        for row in axes_matrix:
+            for ax in row:
+                for entry in get_entries(ax):
+                    if self._collect is not None and entry.name not in self._collect:
+                        continue
+                    key = (entry.name, entry.kind)
+                    if key in seen:
+                        if seen[key].signature != entry.signature and not self._warned_mismatch:
+                            warnings.warn(
+                                f"legend entry {entry.name!r} ({entry.kind}) "
+                                "differs between axes; group uses first occurrence",
+                                UserWarning,
+                                stacklevel=2,
+                            )
+                            self._warned_mismatch = True
+                        continue
+                    seen[key] = entry
+                    order.append(key)
+
+        if self._collect is not None:
+            # Stable sort by the user's collect order; ties (same name with
+            # different kinds) stay in the order they were encountered.
+            order.sort(key=lambda k: (self._collect.index(k[0]), 0))
+
+        for key in order:
+            self._render_entry(seen[key])
+
+    def _render_entry(self, entry: LegendEntry) -> None:
+        """Route to add_legend (categorical) or add_colorbar (continuous)."""
+        if entry.kind == "hue" and is_continuous_hue(entry.handles):
+            mappable = entry.handles[0]
+            self.add_colorbar(mappable=mappable, label=entry.name)
+        else:
+            self.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )
+```
+
+Note: `add_legend` does not currently take a `labels=` kwarg — it derives labels from the handles. Leave as-is for the auto-collect path; dedup ensures the correct handles are passed through.
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_group_auto_collect.py -v -k "materialize"`
+Expected: 8 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 139 + 8 = 147 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/utils/legend_group.py tests/test_legend_group_auto_collect.py
+git commit -m "feat(legend_group): _materialize() auto-collection pass"
+```
+
+---
+
+## Task 4: `pp.subplots()` — drop `legend_column` kwarg
+
+Makes `legend_column` auto-only. `FigureLayout.legend_column` stays as an internal data field, populated by `SubplotsAutoLayout` (next task). `pp.subplots()` raises if the user tries to pass the kwarg.
+
+**Files:**
+- Modify: `src/publiplots/layout/subplots.py`
+- Modify: `tests/test_subplots.py`
+
+- [ ] **Step 1: Write the failing test and delete the obsolete one**
+
+Delete `test_subplots_legend_column_reserves_extra_width` from `tests/test_subplots.py` (grep for that name; the whole function goes). Replace with (or append below the existing `pp.subplots` API tests):
+
+```python
+def test_subplots_rejects_legend_column_kwarg():
+    with pytest.raises(TypeError, match="legend_column"):
+        pp.subplots(axes_size=(50, 30), legend_column=30)
+```
+
+- [ ] **Step 2: Run the tests and verify the new one fails**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_subplots.py::test_subplots_rejects_legend_column_kwarg -v`
+Expected: FAIL. (The signature still accepts `legend_column`.)
+
+- [ ] **Step 3: Modify `src/publiplots/layout/subplots.py`**
+
+Find the `subplots()` signature around lines 28-44 and remove the `legend_column: float = 0.0,` parameter. The new signature must be:
+
+```python
+def subplots(
+    nrows: int = 1,
+    ncols: int = 1,
+    *,
+    axes_size: Union[Tuple[float, float], float, None] = None,
+    sharex: Union[bool, str] = False,
+    sharey: Union[bool, str] = False,
+    title_space: Optional[float] = None,
+    xlabel_space: Optional[float] = None,
+    ylabel_space: Optional[float] = None,
+    right: Optional[float] = None,
+    hspace: Optional[float] = None,
+    wspace: Optional[float] = None,
+    outer_pad: Optional[float] = None,
+    **fig_kw,
+):
+```
+
+Add the rejection check — find the block where `figsize` is rejected (around `if "figsize" in fig_kw:`) and append:
+
+```python
+    if "legend_column" in fig_kw:
+        raise TypeError(
+            "pp.subplots() no longer accepts legend_column. Attach a "
+            "pp.legend_group(anchor=...) to the figure; the column is "
+            "auto-sized based on the rendered group width."
+        )
+```
+
+Find the `FigureLayout(...)` construction call and change `legend_column=float(legend_column),` to the literal `legend_column=0.0,`. (The auto-layout hook will update it on first draw — Task 5 wires that.)
+
+Remove the `legend_column` entries from the user_values dict / resolved dict handling (they should no longer be referenced in this function).
+
+Remove the `if legend_column < 0:` validation block — no more user input to validate.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_subplots.py::test_subplots_rejects_legend_column_kwarg -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 147 + 1 (new) - 1 (deleted) = 147 passed. Scan the output carefully — any test that passed `legend_column=` to `pp.subplots` will now fail. Those tests must be updated (remove the kwarg; `pp.subplots` still creates a figure sized identically because `legend_column` was previously user-supplied and is now always 0 until Task 5 runs).
+
+If there are other existing tests that pass `legend_column=` — update them inline as part of this task. Expected affected test: `test_subplots_legend_column_reserves_extra_width` (delete per step 1) and possibly any that use `legend_column` on a real figure — check via grep:
+
+Run: `grep -rn "legend_column" tests/`
+
+Update or remove any matches. Re-run the full suite until green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/layout/subplots.py tests/test_subplots.py
+git commit -m "feat(layout): drop legend_column kwarg from pp.subplots"
+```
+
+---
+
+## Task 5: `SubplotsAutoLayout._measure_legend_column`
+
+Adds width-awareness. Calls `group._materialize()` (idempotent) from within the measurement so the first settle pass creates artists to measure.
+
+**Files:**
+- Modify: `src/publiplots/layout/auto_layout.py`
+- Modify: `tests/test_subplots.py` (append width-awareness tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_subplots.py` (after the existing SubplotsAutoLayout tests):
+
+```python
+# ---------------------------------------------------------------------------
+# Width-awareness: legend_column auto-sizing
+# ---------------------------------------------------------------------------
+
+from publiplots.utils.legend_entries import LegendEntry, stash_entry
+
+
+def _stub_handle(color="red"):
+    class H:
+        def __init__(self, c):
+            self._c = c
+        def get_facecolor(self):
+            return self._c
+    return H(color)
+
+
+def test_legend_column_is_zero_without_group():
+    fig, ax = pp.subplots(axes_size=(50, 30))
+    # No pp.legend_group call.
+    fig.canvas.draw()
+    assert fig._publiplots_layout.legend_column == 0.0
+
+
+def test_legend_column_auto_grows_with_group():
+    from publiplots.utils.legend import create_legend_handles
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    # Stash so auto-collect picks something up
+    stash_entry(
+        axes[0],
+        LegendEntry.build(
+            "g", "hue",
+            handles=create_legend_handles(labels=["A", "B"], colors=["#000", "#fff"],
+                                          alpha=0.5, linewidth=1.0),
+            labels=("A", "B"),
+        ),
+    )
+    pp.legend_group(anchor=axes[-1])
+    fig.savefig("/tmp/test_legend_column_auto.png")
+    layout = fig._publiplots_layout
+    assert layout.legend_column > 5.0, (
+        f"legend_column should have grown; got {layout.legend_column}"
+    )
+
+
+def test_legend_column_stays_small_with_empty_group():
+    """No stashed entries and no manual adds -> group has no artists ->
+    legend_column stays near zero."""
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    pp.legend_group(anchor=axes[-1])
+    # No stashing, no manual add_legend calls.
+    fig.savefig("/tmp/test_legend_column_empty.png")
+    layout = fig._publiplots_layout
+    assert layout.legend_column < 2.0, (
+        f"legend_column should stay near 0; got {layout.legend_column}"
+    )
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_subplots.py -v -k "legend_column"`
+Expected: the two "with group" tests FAIL — `auto_grows_with_group` because `legend_column` is never updated, `stays_small_with_empty_group` probably already passes but keep it for the contract. `is_zero_without_group` passes.
+
+- [ ] **Step 3: Modify `src/publiplots/layout/auto_layout.py`**
+
+Add `legend_column` to the auto-measurable set:
+
+```python
+_ALL_SIDES = {"title_space", "xlabel_space", "ylabel_space", "right", "legend_column"}
+```
+
+In `_measure()`, after the existing per-side tuple measurement loop (and before the `return measured` line), add:
+
+```python
+        if "legend_column" not in self._locked:
+            measured["legend_column"] = self._measure_legend_column()
+```
+
+In `_needs_update()`, replace the existing tuple-only comparison body with a branching version:
+
+```python
+    def _needs_update(self, measured: Dict[str, ...]) -> bool:
+        for side, new_val in measured.items():
+            current = getattr(self._layout, side)
+            if side == "legend_column":
+                if abs(new_val - current) >= _UPDATE_THRESHOLD_MM:
+                    return True
+            else:
+                # tuple comparison (per-row / per-col reservations)
+                if len(new_val) != len(current):
+                    return True
+                for nv, cv in zip(new_val, current):
+                    if abs(nv - cv) >= _UPDATE_THRESHOLD_MM:
+                        return True
+        return False
+```
+
+Add these two new methods to the class (after `_needs_update` and before `_apply` or wherever fits cleanly):
+
+```python
+    def _measure_legend_column(self) -> float:
+        """mm width past the anchor axes' right edge, plus 1 mm padding."""
+        group = getattr(self._fig, "_publiplots_legend_group", None)
+        if group is None:
+            return 0.0
+
+        # Force collection so artists exist to measure.
+        group._materialize()
+        if not group._builder.elements:
+            return 0.0
+
+        dpi = self._fig.dpi
+        if dpi <= 0:
+            return 0.0
+
+        anchor_bb = group.anchor.get_window_extent()
+        max_x1 = anchor_bb.x1
+        for _, obj in group._builder.elements:
+            extent = self._artist_window_extent(obj)
+            if extent is None:
+                continue
+            max_x1 = max(max_x1, extent.x1)
+        overhang_px = max_x1 - anchor_bb.x1
+        if overhang_px <= 0:
+            return 0.0
+        return overhang_px / dpi * 25.4 + 1.0
+
+    def _artist_window_extent(self, obj):
+        """Duck-typed window-extent accessor (Legend/Colorbar/Text)."""
+        if hasattr(obj, "get_window_extent"):
+            try:
+                return obj.get_window_extent()
+            except Exception:
+                pass
+        if hasattr(obj, "ax"):  # Colorbar stores geometry on .ax
+            return obj.ax.get_window_extent()
+        return None
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_subplots.py -v -k "legend_column"`
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 147 + 3 = 150 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/layout/auto_layout.py tests/test_subplots.py
+git commit -m "feat(layout): SubplotsAutoLayout measures legend_group width"
+```
+
+---
+
+## Task 6: Rewrite `pp.legend(ax)` auto-mode to use the new store
+
+Replaces the legacy `_get_legend_data` reader with one that reads `ax._publiplots_legend_entries`. For backward compat with axes that have the legacy `_legend_data` attribute (e.g. third-party extensions), fall back.
+
+**Files:**
+- Modify: `src/publiplots/utils/legend.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_legend_entries.py`:
+
+```python
+def test_pp_legend_auto_reads_new_store():
+    """pp.legend(ax) in auto mode should render from stashed LegendEntry."""
+    import matplotlib.pyplot as plt
+    import publiplots as pp
+    from publiplots.utils.legend import create_legend_handles
+
+    fig, ax = pp.subplots(axes_size=(60, 40))
+    ax.scatter([0, 1, 2], [0, 1, 0])
+    stash_entry(
+        ax,
+        LegendEntry.build(
+            "group", "hue",
+            handles=create_legend_handles(
+                labels=["A", "B"], colors=["#111", "#222"],
+                alpha=0.5, linewidth=1.0,
+            ),
+            labels=("A", "B"),
+        ),
+    )
+    builder = pp.legend(ax)  # auto mode
+    fig.canvas.draw()
+    # At least one legend artist should exist on the axes now.
+    from matplotlib.legend import Legend
+    legends = [c for c in ax.get_children() if isinstance(c, Legend)]
+    assert len(legends) >= 1
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_entries.py -v -k "pp_legend_auto_reads_new_store"`
+Expected: FAIL — `pp.legend` reads the old store, which is absent here.
+
+- [ ] **Step 3: Update `src/publiplots/utils/legend.py`**
+
+Add to the top of the file (near other `publiplots.utils` imports):
+
+```python
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    get_entries,
+    is_continuous_hue,
+)
+```
+
+Find the existing auto-mode block in the `legend()` function (around lines 1451-1472, starting with `if auto:`). Replace with:
+
+```python
+    # Auto mode
+    if auto:
+        # Prefer the new LegendEntry store.
+        entries = get_entries(ax)
+        if entries:
+            seen = set()  # (name, kind) dedup within one axes
+            for entry in entries:
+                key = (entry.name, entry.kind)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if entry.kind == "hue" and is_continuous_hue(entry.handles):
+                    builder.add_colorbar(
+                        mappable=entry.handles[0],
+                        label=entry.name,
+                    )
+                else:
+                    builder.add_legend(
+                        handles=list(entry.handles),
+                        label=entry.name,
+                        **kwargs,
+                    )
+        else:
+            # Back-compat: read legacy _legend_data dict store (plot
+            # functions not migrated in PR #81 still use this path).
+            legend_data = _get_legend_data(ax)
+            if legend_data:
+                if 'hue' in legend_data:
+                    hue_data = legend_data['hue'].copy()
+                    if hue_data.get('type') == 'colorbar':
+                        hue_data.pop('type', None)
+                        builder.add_colorbar(**hue_data)
+                    else:
+                        builder.add_legend(**hue_data, **kwargs)
+                if 'size' in legend_data:
+                    size_data = legend_data['size'].copy()
+                    builder.add_legend(**size_data, **kwargs)
+                if 'style' in legend_data:
+                    style_data = legend_data['style'].copy()
+                    builder.add_legend(**style_data, **kwargs)
+
+    return builder
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_legend_entries.py -v -k "pp_legend_auto_reads_new_store"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 150 + 1 = 151 passed. The legacy-store fallback path keeps existing scatter/strip/swarm/point tests passing until Tasks 7-10 migrate them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/utils/legend.py tests/test_legend_entries.py
+git commit -m "feat(legend): auto-mode reads LegendEntry store with legacy fallback"
+```
+
+---
+
+## Task 7: Migrate `scatter.py` to stash `LegendEntry`
+
+Replaces the current `legend_data` dict assignment with `stash_entry` calls per kind. Also threads the new `legend=` kwarg semantics: accepts `bool | dict`, routes through `resolve_legend_flags`, suppresses per-axis rendering for entries claimed by a `legend_group`.
+
+**Files:**
+- Modify: `src/publiplots/plot/scatter.py`
+- Create: `tests/test_scatter_legend_stash.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_scatter_legend_stash.py`:
+
+```python
+"""Tests for scatterplot legend stashing via LegendEntry."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import pytest
+
+import publiplots as pp
+from publiplots.utils.legend_entries import get_entries
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _scatter_df(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 30
+    return pd.DataFrame({
+        "x": rng.normal(size=n),
+        "y": rng.normal(size=n),
+        "g": rng.choice(["A", "B", "C"], size=n),
+        "m": rng.uniform(1, 5, size=n),
+    })
+
+
+def test_scatterplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_scatterplot_stashes_size_entry():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(data=df, x="x", y="y", size="m")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("m", "size") in names_kinds
+
+
+def test_scatterplot_legend_dict_suppresses_hue():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(
+        data=df, x="x", y="y", hue="g", size="m",
+        palette="pastel",
+        legend={"hue": False},
+    )
+    entries = get_entries(ax)
+    names = [e.name for e in entries]
+    # hue is suppressed, size is still stashed
+    assert "g" not in names
+    assert "m" in names
+
+
+def test_scatterplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(
+        data=df, x="x", y="y", hue="g", size="m",
+        palette="pastel",
+        legend=False,
+    )
+    assert get_entries(ax) == []
+
+
+def test_scatterplot_in_group_suppresses_per_axis_render():
+    """With a legend_group active, the scatter should NOT attach a per-axis
+    Legend artist to ax (the group handles it)."""
+    from matplotlib.legend import Legend
+    df = _scatter_df()
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 40))
+    pp.legend_group(anchor=axes[-1])
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[0])
+    fig.canvas.draw()
+    per_axis_legends = [c for c in axes[0].get_children() if isinstance(c, Legend)]
+    assert per_axis_legends == []
+
+
+def test_scatterplot_no_group_renders_per_axis_legend():
+    from matplotlib.legend import Legend
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel")
+    fig.canvas.draw()
+    per_axis_legends = [c for c in ax.get_children() if isinstance(c, Legend)]
+    assert len(per_axis_legends) >= 1
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v`
+Expected: most FAIL — current scatter uses the legacy `_legend_data` dict, not the new store; `legend=dict(...)` probably crashes.
+
+- [ ] **Step 3: Update `src/publiplots/plot/scatter.py`**
+
+Add to the imports at the top of the file:
+
+```python
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
+```
+
+Find the `_legend()` helper at the bottom of scatter.py (around line 466+ `def _legend(`). Locate the block where `legend_data = {}` is built and the per-kind "hue"/"size"/"style" sections populate it. Rewrite that section to stash `LegendEntry` objects instead:
+
+```python
+    # `legend` is bool | dict from the user; translate to per-kind flags.
+    flags = resolve_legend_flags(legend)
+
+    # HUE
+    if hue is not None and flags["hue"]:
+        hue_label = kwargs.pop("hue_label", hue)
+        if isinstance(palette, dict):  # categorical
+            hue_handles = create_legend_handles(
+                labels=list(palette.keys()),
+                colors=list(palette.values()),
+                edgecolors=[edgecolor] * len(palette) if edgecolor else None,
+                **handle_kwargs,
+            )
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=hue_handles,
+                    labels=list(palette.keys()),
+                ),
+            )
+        else:  # continuous -> colorbar
+            mappable = ScalarMappable(norm=hue_norm, cmap=palette)
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=[mappable],
+                    labels=[],  # continuous
+                ),
+            )
+
+    # SIZE
+    if size is not None and flags["size"]:
+        tick_color = color if hue is None else "gray"
+        size_handle_kwargs = handle_kwargs.copy()
+        size_handle_kwargs["color"] = tick_color
+        tick_labels, tick_sizes = _get_size_ticks(
+            values=data[size].dropna().values,
+            sizes=sizes,
+            size_norm=size_norm,
+            nbins=kwargs.pop("size_nbins", 4),
+            min_n_ticks=kwargs.pop("size_min_n_ticks", 3),
+            include_min_max=kwargs.pop("size_include_min_max", False),
+        )
+        size_handles = create_legend_handles(
+            labels=tick_labels,
+            sizes=tick_sizes,
+            **size_handle_kwargs,
+        )
+        size_label = kwargs.pop("size_label", size)
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=size_label,
+                kind="size",
+                handles=size_handles,
+                labels=tick_labels,
+            ),
+        )
+
+    # STYLE
+    if style is not None and flags["style"]:
+        style_values = data[style].unique()
+        style_label = kwargs.pop("style_label", style)
+        marker_param = markers if isinstance(markers, (list, dict)) else None
+        marker_map = resolve_marker_map(
+            values=list(style_values),
+            marker_map=marker_param,
+        )
+        style_color = color if hue is None else "gray"
+        style_handle_kwargs = handle_kwargs.copy()
+        style_handle_kwargs["color"] = style_color
+        style_handle_kwargs.pop("style", None)
+        style_labels = [str(val) for val in style_values]
+        style_handles = create_legend_handles(
+            labels=style_labels,
+            markers=[marker_map[val] for val in style_values],
+            edgecolors=[edgecolor] * len(style_values) if edgecolor else None,
+            **style_handle_kwargs,
+        )
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=style_label,
+                kind="style",
+                handles=style_handles,
+                labels=style_labels,
+            ),
+        )
+```
+
+Delete the lines that set `ax.collections[0]._legend_data = legend_data` — no longer needed.
+
+Now the per-axis rendering. Replace the `if create_legend:` block at the bottom of `_legend()` with:
+
+```python
+    if create_legend:
+        # Suppress per-axis rendering for entries owned by a legend_group
+        fig = ax.get_figure()
+        entries_to_render = [
+            e for e in get_entries(ax)
+            if flags[e.kind] and not entry_is_in_group(fig, e)
+        ]
+        if not entries_to_render:
+            return
+
+        builder = legend(ax=ax, auto=False)
+        for entry in entries_to_render:
+            if entry.kind == "hue" and is_continuous_hue(entry.handles):
+                builder.add_colorbar(
+                    mappable=entry.handles[0],
+                    label=entry.name,
+                )
+            else:
+                builder.add_legend(
+                    handles=list(entry.handles),
+                    label=entry.name,
+                )
+```
+
+Important: the scatterplot function also calls `_legend` conditionally on `legend` being truthy. The outer caller must now pass `legend` through unchanged (including `legend=dict(...)`), since `_legend` does its own resolution. Find the call site that invokes `_legend(...)`:
+
+```bash
+grep -n "_legend(" src/publiplots/plot/scatter.py | grep -v "def "
+```
+
+Change the call site from something like `if legend: _legend(..., legend=True, ...)` to simply pass the user's `legend` value through. (In scatter's current code, `_legend` takes a `create_legend` kwarg; keep that as True when the function wants to render per-axis, otherwise False. The `legend` kwarg is what drives per-kind flags; `create_legend` gates rendering.)
+
+The shape of the outer call should end up like:
+
+```python
+# Outer call (at the site where scatter decides to run _legend)
+_legend(
+    data=data, x=x, y=y, hue=hue, size=size, style=style, ax=ax,
+    palette=palette, hue_norm=hue_norm, size_norm=size_norm, sizes=sizes,
+    markers=markers, color=color, edgecolor=edgecolor, alpha=alpha,
+    linewidth=linewidth, create_legend=True,
+    legend=legend,   # pass the user's bool | dict through
+    **legend_kws,
+)
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v`
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 151 + 6 = 157 passed. Watch for existing scatter tests that may break — the legacy `_legend_data` attribute is gone, so any test that reads `ax.collections[0]._legend_data` must be updated to use `get_entries(ax)`.
+
+Check for such tests:
+```bash
+grep -rn "_legend_data" tests/
+```
+
+Update any hits to use `get_entries(ax)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/plot/scatter.py tests/test_scatter_legend_stash.py
+git commit -m "feat(scatter): migrate to LegendEntry stash + group-aware render"
+```
+
+---
+
+## Task 8: Migrate `strip.py`
+
+Same pattern as scatter but simpler — strip only has `hue`.
+
+**Files:**
+- Modify: `src/publiplots/plot/strip.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_scatter_legend_stash.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# stripplot migration
+# ---------------------------------------------------------------------------
+
+
+def test_stripplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.stripplot(data=df, x="g", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_stripplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.stripplot(
+        data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
+    )
+    assert get_entries(ax) == []
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v -k "strip"`
+Expected: 2 FAIL.
+
+- [ ] **Step 3: Update `src/publiplots/plot/strip.py`**
+
+Find the block where `legend_data` is built (around line 242). Current shape:
+
+```python
+hue_handles = create_legend_handles(...)
+legend_data["hue"] = {"handles": hue_handles, ...}
+# ...
+ax.collections[0]._legend_data = legend_data
+```
+
+Replace with:
+
+```python
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+)
+
+# ... inside the plot function, at the legend section ...
+flags = resolve_legend_flags(legend)
+if hue is not None and flags["hue"]:
+    hue_label = kwargs.pop("hue_label", hue) if isinstance(kwargs, dict) else hue
+    hue_handles = create_legend_handles(
+        labels=list(palette.keys()) if isinstance(palette, dict) else list(hue_levels),
+        colors=(list(palette.values()) if isinstance(palette, dict)
+                else color_palette(palette, len(hue_levels))),
+        # keep existing handle_kwargs as strip currently computes them
+        **handle_kwargs,
+    )
+    stash_entry(
+        ax,
+        LegendEntry.build(
+            name=hue_label,
+            kind="hue",
+            handles=hue_handles,
+            labels=list(palette.keys()) if isinstance(palette, dict) else list(hue_levels),
+        ),
+    )
+
+# Remove the old `ax.collections[0]._legend_data = legend_data` line.
+
+# Per-axis render:
+if legend:
+    fig = ax.get_figure()
+    entries_to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if entries_to_render:
+        from publiplots.utils.legend import legend as pp_legend
+        builder = pp_legend(ax=ax, auto=False)
+        for entry in entries_to_render:
+            builder.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )
+```
+
+Note: strip already has `hue_levels` and `palette` resolution — preserve them. The edit above is shape-preserving: replace the dict-write with `stash_entry`, and the `ax.collections[0]._legend_data = legend_data` line with the per-axis render gated on `entry_is_in_group`.
+
+Read the current strip.py file carefully before editing. The existing variable names (`hue_levels`, `handle_kwargs`, etc.) should be preserved; only the stash mechanism changes.
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v -k "strip"`
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 157 + 2 = 159 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/plot/strip.py tests/test_scatter_legend_stash.py
+git commit -m "feat(strip): migrate to LegendEntry stash + group-aware render"
+```
+
+---
+
+## Task 9: Migrate `swarm.py`
+
+Same pattern as strip — swarm only has `hue`.
+
+**Files:**
+- Modify: `src/publiplots/plot/swarm.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_scatter_legend_stash.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# swarmplot migration
+# ---------------------------------------------------------------------------
+
+
+def test_swarmplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.swarmplot(data=df, x="g", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_swarmplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.swarmplot(
+        data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
+    )
+    assert get_entries(ax) == []
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v -k "swarm"`
+Expected: 2 FAIL.
+
+- [ ] **Step 3: Update `src/publiplots/plot/swarm.py`**
+
+Same migration pattern as strip (Task 8, Step 3): replace the dict-write + legacy stash with `stash_entry(ax, LegendEntry.build(...))`, and gate per-axis rendering on `entry_is_in_group`. Read `src/publiplots/plot/swarm.py` around line 238 for the current code.
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v -k "swarm"`
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 159 + 2 = 161 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/plot/swarm.py tests/test_scatter_legend_stash.py
+git commit -m "feat(swarm): migrate to LegendEntry stash + group-aware render"
+```
+
+---
+
+## Task 10: Migrate `point.py`
+
+pointplot stashes on `ax.lines[0]._legend_data`. Same `hue`-only kind.
+
+**Files:**
+- Modify: `src/publiplots/plot/point.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_scatter_legend_stash.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# pointplot migration
+# ---------------------------------------------------------------------------
+
+
+def test_pointplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.pointplot(data=df, x="g", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_pointplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.pointplot(
+        data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
+    )
+    assert get_entries(ax) == []
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v -k "pointplot"`
+Expected: 2 FAIL.
+
+- [ ] **Step 3: Update `src/publiplots/plot/point.py`**
+
+Same migration pattern as strip/swarm (Tasks 8-9, Step 3). Read the current file around line 484 for context. The stash attribute today is `ax.lines[0]._legend_data`; the migration target is `ax._publiplots_legend_entries` via `stash_entry`.
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/test_scatter_legend_stash.py -v -k "pointplot"`
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 161 + 2 = 163 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/publiplots/plot/point.py tests/test_scatter_legend_stash.py
+git commit -m "feat(point): migrate to LegendEntry stash + group-aware render"
+```
+
+---
+
+## Task 11: Migrate gallery `plot_14`
+
+Drops the `legend_column=30` kwarg from the 1×3 section (which uses migrated plot types) and drops the explicit `group.add_legend(...)` call — auto-collect handles it. The 1×2 raincloud section keeps its explicit `group.add_legend(...)` because raincloud is NOT migrated in this PR.
+
+**Files:**
+- Modify: `examples/plots/plot_14_edgecolor_control.py`
+
+- [ ] **Step 1: Read the current file state**
+
+Run:
+```bash
+grep -n "legend_column\|legend_group\|group.add_legend" examples/plots/plot_14_edgecolor_control.py
+```
+
+- [ ] **Step 2: Migrate the 1×3 Uniform Edges section**
+
+In the "Uniform Edges Across Plot Types" section, two edits:
+
+1. Change `fig, axes = pp.subplots(1, 3, axes_size=(45, 30), legend_column=30)` to `fig, axes = pp.subplots(1, 3, axes_size=(45, 30))`.
+
+2. Replace the block:
+```python
+group = pp.legend_group(anchor=axes[-1])
+group.add_legend(
+    handles=pp.create_legend_handles(
+        labels=['A', 'B', 'C'],
+        colors=list(pp.color_palette('pastel', 3)),
+        alpha=pp.rcParams['alpha'],
+        linewidth=pp.rcParams['lines.linewidth'],
+        edgecolors=pp.rcParams['edgecolor'],
+    ),
+    label='group',
+)
+```
+
+**BUT**: in this section the plot functions used are `pp.barplot`, `pp.boxplot`, `pp.scatterplot`. Only scatterplot is migrated in this PR; bar and box are NOT. If we drop the explicit `group.add_legend` and replace with bare `pp.legend_group(anchor=axes[-1])`, the group will only pick up the scatterplot entry — the bar and box entries are missing.
+
+So the correct migration for THIS section in THIS PR:
+
+```python
+# legend_column removed (auto-sized now)
+fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
+# ... existing barplot/boxplot/scatterplot calls unchanged ...
+
+# Keep the explicit add_legend for now — raincloud / bar / box don't
+# stash yet (follow-up PR). Once they migrate, this can become a bare
+# pp.legend_group(anchor=axes[-1]).
+group = pp.legend_group(anchor=axes[-1])
+group.add_legend(
+    handles=pp.create_legend_handles(
+        labels=['A', 'B', 'C'],
+        colors=list(pp.color_palette('pastel', 3)),
+        alpha=pp.rcParams['alpha'],
+        linewidth=pp.rcParams['lines.linewidth'],
+        edgecolors=pp.rcParams['edgecolor'],
+    ),
+    label='group',
+)
+```
+
+The ONE change in the 1×3 section: drop `legend_column=30` from `pp.subplots`. Keep the explicit `add_legend` until the follow-up PRs migrate bar + box.
+
+- [ ] **Step 3: Migrate the 1×2 raincloud section**
+
+Same single change: drop `legend_column=30` from the `pp.subplots(1, 2, axes_size=(55, 50), sharey=True, legend_column=30)` → `pp.subplots(1, 2, axes_size=(55, 50), sharey=True)`.
+
+Keep the explicit `group.add_legend(...)` call — raincloud is not migrated.
+
+- [ ] **Step 4: Smoke-run the example**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python examples/plots/plot_14_edgecolor_control.py 2>&1 | tail -5`
+Expected: exits 0, no traceback.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 163 passed (no new tests in this task).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/plots/plot_14_edgecolor_control.py
+git commit -m "docs(gallery): drop legend_column=30 from plot_14 (auto-sized now)"
+```
+
+---
+
+## Task 12: Final verification + PR prep
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full test suite one final time**
+
+Run: `unset VIRTUAL_ENV; .venv/bin/python -m pytest tests/ -q`
+Expected: 163 passed (121 baseline + 42 new).
+
+- [ ] **Step 2: Smoke-run every gallery example**
+
+```bash
+for f in examples/plots/plot_*.py; do
+  name=$(basename "$f")
+  unset VIRTUAL_ENV; .venv/bin/python "$f" > /dev/null 2>&1 \
+    && echo "$name OK" || echo "$name FAIL"
+done
+```
+
+Expected: every script prints "OK". Any FAIL needs diagnosis before proceeding.
+
+- [ ] **Step 3: Sanity-check the auto-collect user flow**
+
+Run this one-liner to confirm the headline win:
+
+```bash
+unset VIRTUAL_ENV; .venv/bin/python - <<'EOF'
+import matplotlib; matplotlib.use("Agg")
+import pandas as pd, numpy as np
+import publiplots as pp
+
+np.random.seed(0)
+df = pd.DataFrame({
+    "x": np.random.randn(60), "y": np.random.randn(60),
+    "g": np.random.choice(list("ABC"), 60),
+})
+
+fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
+pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[0])
+pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[1])
+pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[2])
+pp.legend_group(anchor=axes[-1])  # zero kwargs — no legend_column, no handles
+
+fig.savefig("/tmp/auto_collect_demo.png")
+
+L = fig._publiplots_layout
+print(f"legend_column auto-sized to: {L.legend_column:.1f} mm")
+print(f"figure size: {L.figure_size()} mm")
+EOF
+```
+
+Expected output: `legend_column auto-sized to: <non-zero value> mm`. If it's zero, width-awareness is broken.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin feat/legend-positioning
+gh pr create --title "feat(legend): auto-collect legend_group + width-aware legend_column" \
+  --body "$(cat <<'PRBODY'
+## Summary
+
+Two coordinated pieces:
+
+1. **Auto-collect.** `pp.legend_group(anchor=...)` walks the grid, collects stashed `LegendEntry` objects across all axes, dedups by `(name, kind)`, and renders one unified legend. Users no longer construct `handles=[...]` manually for the common case.
+2. **Width-awareness.** `SubplotsAutoLayout` measures the rendered legend_group width and grows `FigureLayout.legend_column` to fit. The `legend_column` kwarg is dropped from `pp.subplots()` entirely.
+
+Legend width is now fully automatic — no more hand-tuned `legend_column=N` guess.
+
+## Breaking changes
+
+- `pp.subplots(legend_column=N)` raises `TypeError`. Attach a `pp.legend_group(anchor=...)` to the figure instead; the column is auto-sized.
+- Plot functions accept `legend=` as `bool | dict[kind, bool]`. `True` / `False` unchanged; `dict` is new.
+
+## Scope
+
+- Infrastructure: `LegendEntry`, `stash_entry`, `resolve_legend_flags`, `entry_is_in_group`.
+- `MultiAxesLegendGroup.collect` and `_materialize` auto-collection.
+- `SubplotsAutoLayout._measure_legend_column`.
+- Migrations: `scatterplot`, `stripplot`, `swarmplot`, `pointplot`.
+
+## Deferred
+
+- Migrations for `bar`, `box`, `violin`, `raincloud`, `heatmap` — these plots render legends inline today and require a bigger refactor per plot. Documented in `pp.legend_group`'s docstring. Until their follow-up PRs, users fall back to manual `group.add_legend(handles=...)` for those plot types.
+
+## Test plan
+
+- [x] Full suite: 163 passing (121 baseline + 42 new).
+- [x] `auto_collect_demo.png` renders correctly — legend_column auto-grows.
+- [x] All 14 gallery examples smoke-run cleanly.
+PRBODY
+)"
+```
+
+---
+
+## Self-review (pre-execution)
+
+**Spec coverage:**
+- `LegendEntry` + store → Task 1.
+- `resolve_legend_flags` → Task 1.
+- `entry_is_in_group` → Task 1.
+- `is_continuous_hue` → Task 1.
+- `MultiAxesLegendGroup.collect`, `claims`, figure registration → Task 2.
+- `_materialize`, dedup, warning, order filter → Task 3.
+- `pp.subplots()` drops `legend_column` kwarg → Task 4.
+- `SubplotsAutoLayout._measure_legend_column`, `_ALL_SIDES` extension, `_needs_update` branch → Task 5.
+- `pp.legend(ax)` auto-mode reads new store with legacy fallback → Task 6.
+- scatter migration → Task 7.
+- strip migration → Task 8.
+- swarm migration → Task 9.
+- point migration → Task 10.
+- gallery migration (drop `legend_column=30`) → Task 11.
+- Final verification → Task 12.
+
+All spec requirements mapped.
+
+**Placeholders:** grepped for TBD / TODO / placeholder — none in this plan.
+
+**Type consistency:** `LegendEntry` signature identical across Tasks 1, 3, 6, 7-10. `stash_entry`, `get_entries`, `resolve_legend_flags`, `entry_is_in_group`, `is_continuous_hue` names consistent. `_publiplots_legend_entries` attribute name consistent. `_publiplots_legend_group` attribute name consistent. `_measure_legend_column`, `_ALL_SIDES` refs consistent.
+
+Ready for execution.

--- a/docs/superpowers/specs/2026-05-01-legend-auto-collection-design.md
+++ b/docs/superpowers/specs/2026-05-01-legend-auto-collection-design.md
@@ -1,0 +1,757 @@
+# Design — Legend Auto-Collection and Width-Aware Sizing (PR #81)
+
+**Status:** approved, awaiting implementation plan.
+**Worktree:** `.worktrees/legend-positioning` on `feat/legend-positioning`.
+**Follows:** PR #79 (`pp.subplots`), PR #80 (drop notebook style).
+**Blocks:** Composer PR (axes-rectangle snapping, noted in
+`docs/superpowers/handoff/2026-04-30-fixed-axes-pp-subplots.md`).
+
+---
+
+## Goal
+
+Two orthogonal pieces shipped together:
+
+1. **Auto-collect.** `pp.legend_group(anchor=...)` walks the grid, collects
+   per-axes legend entries, dedups, and renders a single unified legend.
+   Users no longer construct `handles=[...]` manually or call
+   `group.add_legend(handles=...)` for the common case.
+2. **Width-awareness.** `SubplotsAutoLayout` measures the rendered group
+   width and grows the figure's `legend_column` reservation to fit. The
+   `legend_column=` kwarg is dropped from `pp.subplots()` — the reservation
+   is always automatic.
+
+After this PR the common shared-legend flow becomes:
+
+```python
+fig, axes = pp.subplots(1, 3)
+pp.scatterplot(..., ax=axes[0])
+pp.scatterplot(..., ax=axes[1])
+pp.scatterplot(..., ax=axes[2])
+pp.legend_group(anchor=axes[-1])
+```
+
+No handle construction, no `legend_column` guess, no `legend=False` on
+individual plots — the group handles everything.
+
+## Philosophy
+
+publiplots already treats `pp.rcParams["subplots.*"]` values as the single
+baseline and auto-measures the four per-side reservations on draw.
+`legend_column` was the one remaining hand-tuned mm value. This PR
+eliminates the last guess.
+
+The `legend=` kwarg on plot functions grows from `bool` to `bool | dict`
+for per-kind control (hue / size / style / marker). Existing `True` / `False`
+semantics are unchanged; the dict form is additive.
+
+## Non-goals
+
+- Inside-the-axes legend placement (e.g., `loc="upper right"` inside the
+  spines). Filed as a potential follow-up — users with that need can call
+  matplotlib's `ax.legend()` directly today.
+- Additional legend kinds beyond `hue`, `size`, `style`, `marker`.
+- Composer / cross-figure axes-rectangle snapping (captured in the
+  PR #79 handoff).
+- Changing `pp.legend(ax)` behavior. `pp.legend(ax)` stays as today: reads
+  stashed entries from `ax`, renders on the right side with
+  `external_to_axis=False`, grows the column's `right` reservation.
+- Auto-detection that would turn any figure with multiple legends into
+  a `legend_group`. Explicit opt-in only — user calls
+  `pp.legend_group(...)`.
+
+---
+
+## Architecture
+
+Three units:
+
+1. **`LegendEntry` + per-axes storage** (new `legend_entries.py`). A
+   dataclass that every plot function writes to `ax._publiplots_legend_entries`.
+   Records `(name, kind, handles, labels, signature)`.
+2. **`MultiAxesLegendGroup` auto-collect** (extend existing). Walks
+   `fig._publiplots_axes`, collects stashed entries, dedups by
+   `(name, kind)` + signature, filters by optional `collect=[...]`,
+   renders via the existing `LegendBuilder` dispatch.
+3. **`SubplotsAutoLayout` width-awareness** (extend existing). Measures
+   the legend_group's rendered right-extent in mm on each draw, updates
+   `FigureLayout.legend_column` via the existing
+   `with_updated_reservations` path.
+
+```
+plot function (pp.barplot / pp.scatterplot / ...)
+  ├─► resolve legend=True/False/dict → per-kind include map
+  ├─► for each enabled kind: stash_entry(ax, LegendEntry.build(...))
+  └─► for each enabled kind: if not entry_is_in_group(fig, entry):
+                                render per-axis via pp.legend(ax)
+
+pp.legend_group(anchor=..., collect=None|[names])
+  ├─► attaches to fig._publiplots_legend_group
+  ├─► on first draw: _materialize() walks grid, dedups, filters, renders
+  └─► subsequent draws: _materialized flag prevents re-collecting
+
+SubplotsAutoLayout._measure()
+  ├─► existing: four per-side tightbbox measurements
+  └─► NEW: _measure_legend_column() returns group right-extent mm
+       (calls group._materialize() to ensure artists exist)
+
+SubplotsAutoLayout._apply() → FigureLayout.with_updated_reservations(
+    **per_side_tuples, legend_column=<new_mm>
+) — existing API
+```
+
+Both pieces compose but are independent. Width-awareness works even
+without auto-collect (user calls manual `group.add_legend(...)`).
+Auto-collect works without width-awareness (group renders inside the
+`right` reservation — ugly but functional).
+
+---
+
+## Component 1 — `LegendEntry` + storage
+
+**File:** `src/publiplots/utils/legend_entries.py` (new).
+
+```python
+from dataclasses import dataclass
+import hashlib
+
+
+_LEGEND_KINDS = ("hue", "size", "style", "marker")
+
+
+@dataclass(frozen=True)
+class LegendEntry:
+    """A single stashed legend entry on an axes.
+
+    Plot functions write these to ``ax._publiplots_legend_entries`` so
+    pp.legend(ax) and pp.legend_group(anchor=ax) can render them.
+    """
+    name: str                  # variable name, e.g. 'treatment'
+    kind: str                  # one of _LEGEND_KINDS
+    handles: tuple             # matplotlib-compatible handles
+    labels: tuple              # tuple[str, ...]
+    signature: str             # for dedup in legend_group
+
+    @classmethod
+    def build(cls, name, kind, handles, labels) -> "LegendEntry":
+        return cls(
+            name=name, kind=kind,
+            handles=tuple(handles),
+            labels=tuple(labels),
+            signature=_hash_handles(handles, labels),
+        )
+
+
+def _hash_handles(handles, labels) -> str:
+    parts = []
+    for h, lab in zip(handles, labels):
+        parts.append(type(h).__name__)
+        parts.append(str(lab))
+        for attr in ("get_facecolor", "get_marker", "get_markersize",
+                     "get_linewidth"):
+            fn = getattr(h, attr, None)
+            if fn is not None:
+                try:
+                    parts.append(repr(fn()))
+                except Exception:
+                    pass
+    return hashlib.sha1("|".join(parts).encode()).hexdigest()[:12]
+
+
+def stash_entry(ax, entry: LegendEntry) -> None:
+    """Append an entry to ax._publiplots_legend_entries.
+
+    Creates the list attribute on first call. Order is preserved —
+    later calls append."""
+    existing = getattr(ax, "_publiplots_legend_entries", None)
+    if existing is None:
+        existing = []
+        ax._publiplots_legend_entries = existing
+    existing.append(entry)
+
+
+def get_entries(ax) -> list[LegendEntry]:
+    """Return the ordered list of entries stashed on an axes."""
+    return list(getattr(ax, "_publiplots_legend_entries", []))
+
+
+def resolve_legend_flags(legend) -> dict[str, bool]:
+    """Convert legend= (bool | dict) to a per-kind include map.
+
+    - True  → {k: True for k in kinds}
+    - False → {k: False for k in kinds}
+    - dict  → as given; missing keys default to True
+    """
+    if legend is True:
+        return {k: True for k in _LEGEND_KINDS}
+    if legend is False:
+        return {k: False for k in _LEGEND_KINDS}
+    if isinstance(legend, dict):
+        return {k: bool(legend.get(k, True)) for k in _LEGEND_KINDS}
+    raise TypeError(
+        f"legend must be bool or dict[str, bool], got {type(legend).__name__}"
+    )
+
+
+def entry_is_in_group(fig, entry: LegendEntry) -> bool:
+    """True if the figure's legend_group (if any) claims this entry."""
+    group = getattr(fig, "_publiplots_legend_group", None)
+    if group is None:
+        return False
+    return group.claims(entry.name)
+```
+
+**Invariants:**
+- `LegendEntry.build(...)` produces deterministic signatures for identical
+  inputs.
+- `stash_entry` is idempotent-safe only in the sense that it appends;
+  duplicate calls add duplicate entries. Dedup happens at collection time
+  in the group.
+- Handle signatures include color / marker / size / linewidth so
+  palette differences across axes are detectable.
+
+---
+
+## Component 2 — `MultiAxesLegendGroup` auto-collect
+
+**File:** `src/publiplots/utils/legend_group.py` (modify).
+
+### API surface
+
+```python
+def __init__(
+    self,
+    anchor: Axes,
+    collect: list[str] | None = None,   # NEW
+    x_offset: float = 2,
+    y_offset: Optional[float] = None,
+    gap: float = 2,
+    column_spacing: float = 5,
+    vpad: float = 5,
+    max_width: Optional[float] = None,
+):
+```
+
+- `collect=None` → collect every `(name, kind)` pair across all grid
+  axes (dedup by signature, first-wins on mismatch).
+- `collect=['treatment', 'category']` → filter to those names only,
+  render in the listed order.
+
+Existing `add_legend(handles, label, ax=...)` and `add_colorbar(...)`
+stay. Manual entries render BEFORE auto-collected ones.
+
+### Constructor validation
+
+`collect` accepts `None` or a sequence (list/tuple) of strings. A bare
+string like `collect='treatment'` is rejected with `TypeError` to
+prevent a silent bug where `'x' in 'treatment'` would accidentally
+match substrings. Validation goes in `__init__`:
+
+```python
+if collect is not None:
+    if isinstance(collect, str) or not hasattr(collect, "__iter__"):
+        raise TypeError(
+            "collect must be None or a list/tuple of names; "
+            "got a bare string. Wrap in a list: collect=['name']"
+        )
+    collect = list(collect)
+self._collect = collect
+```
+
+### Figure registration
+
+`pp.legend_group(...)` now sets `fig._publiplots_legend_group = group`.
+Plot functions consult this during rendering decisions.
+
+### Claims check
+
+```python
+def claims(self, name: str) -> bool:
+    """True if the group will render an entry with this name."""
+    if self._collect is None:
+        return True
+    return name in self._collect
+```
+
+### `_materialize()` — the collection pass
+
+Runs on first draw (called from `SubplotsAutoLayout._measure_legend_column`):
+
+```python
+def _materialize(self) -> None:
+    if self._materialized:
+        return
+    self._materialized = True
+
+    fig = self.anchor.get_figure()
+    axes_matrix = getattr(fig, "_publiplots_axes", None)
+    if axes_matrix is None:
+        return   # not a pp.subplots figure — nothing to auto-collect
+
+    seen: dict[tuple[str, str], LegendEntry] = {}
+    order: list[tuple[str, str]] = []
+    for row in axes_matrix:
+        for ax in row:
+            for entry in get_entries(ax):
+                if self._collect is not None and entry.name not in self._collect:
+                    continue
+                key = (entry.name, entry.kind)
+                if key in seen:
+                    if seen[key].signature != entry.signature and not self._warned_mismatch:
+                        warnings.warn(
+                            f"legend entry {entry.name!r} ({entry.kind}) "
+                            "differs between axes; group uses first occurrence",
+                            UserWarning, stacklevel=2,
+                        )
+                        self._warned_mismatch = True
+                    continue
+                seen[key] = entry
+                order.append(key)
+
+    if self._collect is not None:
+        order.sort(key=lambda k: (self._collect.index(k[0]), k[1]))
+
+    for key in order:
+        self._render_entry(seen[key])
+
+
+def _render_entry(self, entry: LegendEntry) -> None:
+    """Route to add_legend (categorical) or add_colorbar (continuous)."""
+    if entry.kind == "hue" and _is_continuous(entry.handles):
+        mappable = entry.handles[0]
+        self.add_colorbar(mappable=mappable, label=entry.name)
+    else:
+        self.add_legend(
+            handles=list(entry.handles),
+            label=entry.name,
+            labels=list(entry.labels),
+        )
+
+
+def _is_continuous(handles) -> bool:
+    """Continuous hue stashes a ScalarMappable as the first handle."""
+    from matplotlib.cm import ScalarMappable
+    return len(handles) >= 1 and isinstance(handles[0], ScalarMappable)
+```
+
+### Idempotence
+
+`_materialized` flag guards against duplicate collection on repeated
+draws. `SubplotsAutoLayout`'s settlement loop may call `_materialize`
+multiple times; only the first has an effect.
+
+### Manual + auto interaction
+
+If the user calls `group.add_legend(handles=..., label=...)` explicitly
+before any draw, those entries land in `group._builder.elements` first.
+`_materialize()` runs after and appends auto-collected entries. No
+dedup between manual and auto (different signatures by construction —
+the user built different handles).
+
+---
+
+## Component 3 — `SubplotsAutoLayout` width-awareness
+
+**File:** `src/publiplots/layout/auto_layout.py` (modify).
+
+### `_ALL_SIDES` extension
+
+```python
+_ALL_SIDES = {
+    "title_space", "xlabel_space", "ylabel_space", "right",
+    "legend_column",   # NEW
+}
+```
+
+`legend_column` can be added to the locked set if user provides a value
+(we don't expose that kwarg, but the lock-set machinery handles it
+uniformly).
+
+### `_measure_legend_column()`
+
+```python
+def _measure_legend_column(self) -> float:
+    """mm width past the anchor axes' right edge, plus 1 mm padding."""
+    group = getattr(self._fig, "_publiplots_legend_group", None)
+    if group is None:
+        return 0.0
+
+    # Force collection so artists exist to measure.
+    group._materialize()
+    if not group._builder.elements:
+        return 0.0
+
+    dpi = self._fig.dpi
+    anchor_bb = group.anchor.get_window_extent()
+    max_x1 = anchor_bb.x1
+    for kind, obj in group._builder.elements:
+        extent = _artist_window_extent(obj)
+        if extent is None:
+            continue
+        max_x1 = max(max_x1, extent.x1)
+    overhang_px = max_x1 - anchor_bb.x1
+    if overhang_px <= 0:
+        return 0.0
+    return overhang_px / dpi * 25.4 + 1.0
+
+
+def _artist_window_extent(obj):
+    if hasattr(obj, "get_window_extent"):
+        return obj.get_window_extent()
+    if hasattr(obj, "ax"):   # Colorbar stores on .ax
+        return obj.ax.get_window_extent()
+    return None
+```
+
+### `_measure()` integration
+
+```python
+def _measure(self) -> Dict[str, ...]:
+    # ... existing per-side tuple measurements ...
+
+    if "legend_column" not in self._locked:
+        measured["legend_column"] = self._measure_legend_column()
+    return measured
+```
+
+### `_needs_update()` — handle scalar + tuples
+
+```python
+def _needs_update(self, measured) -> bool:
+    for side, new_val in measured.items():
+        current = getattr(self._layout, side)
+        if side == "legend_column":
+            if abs(new_val - current) >= _UPDATE_THRESHOLD_MM:
+                return True
+        else:
+            # tuple comparison — existing code path
+            if len(new_val) != len(current):
+                return True
+            for nv, cv in zip(new_val, current):
+                if abs(nv - cv) >= _UPDATE_THRESHOLD_MM:
+                    return True
+    return False
+```
+
+### `_apply()` — unchanged
+
+`FigureLayout.with_updated_reservations` already accepts arbitrary
+field names. Passing `legend_column=X` alongside tuple reservations
+works without code change.
+
+### Convergence
+
+Settle loop (existing `settle()` wrapper from PR #80) handles this
+automatically. Typical sequence:
+
+1. Draw 1: no artists yet; `_measure_legend_column` calls
+   `_materialize` which creates artists. Artists positioned at old
+   `legend_column=0` (falling off the right edge). Measured overhang =
+   full group width.
+2. `_apply` grows `FigureLayout.legend_column` → `fig.set_size_inches`.
+3. Draw 2: artists re-position (LayoutReactor re-anchors on draw),
+   measurement matches current → converged.
+
+`_MAX_CONVERGENCE_ITERS=5` cap accommodates the two-pass settlement.
+
+### `pp.subplots()` kwarg drop
+
+```python
+# REMOVED from signature:
+legend_column: float = 0.0,
+```
+
+If user passes `legend_column`:
+
+```python
+if "legend_column" in fig_kw:
+    raise TypeError(
+        "pp.subplots() no longer accepts legend_column. "
+        "Attach a pp.legend_group(anchor=...) to the figure; the column "
+        "is auto-sized."
+    )
+```
+
+Gallery migration removes the two `legend_column=30` call sites in
+`plot_14_edgecolor_control.py`.
+
+---
+
+## Component 4 — plot function integration
+
+Each of nine plot files (`bar.py`, `box.py`, `point.py`, `scatter.py`,
+`strip.py`, `swarm.py`, `violin.py`, `raincloud.py`, `heatmap.py`) adopts
+the standardized stash+render pattern.
+
+### The pattern
+
+```python
+from publiplots.utils.legend_entries import (
+    resolve_legend_flags, stash_entry, get_entries, LegendEntry,
+    entry_is_in_group,
+)
+
+def barplot(..., legend=True, ...):
+    # ... plotting logic ...
+
+    flags = resolve_legend_flags(legend)
+
+    # Stash per kind — only for kinds the plot actually used
+    if hue is not None and flags["hue"]:
+        handles, labels = _build_hue_handles(...)
+        stash_entry(ax, LegendEntry.build(
+            name=hue, kind="hue",
+            handles=handles, labels=labels,
+        ))
+    if size is not None and flags["size"]:
+        # similar
+        ...
+
+    # Render per-axis — skip entries claimed by a legend_group
+    fig = ax.get_figure()
+    if any(flags.values()):
+        _render_stashed_on_axes(ax, fig, flags)
+
+
+def _render_stashed_on_axes(ax, fig, flags):
+    from publiplots.utils.legend import legend as pp_legend
+    entries_to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if not entries_to_render:
+        return
+    builder = pp_legend(ax=ax, auto=False)
+    for entry in entries_to_render:
+        if entry.kind == "hue" and _is_continuous(entry.handles):
+            builder.add_colorbar(mappable=entry.handles[0], label=entry.name)
+        else:
+            builder.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+                labels=list(entry.labels),
+            )
+```
+
+### Old ad-hoc stash removal
+
+Plots currently write to various attributes:
+
+- `ax.collections[0]._legend_data = ...` (scatter)
+- `ax._hue_handles = ...` / similar (bar, box)
+- per-plot dict on `ax`
+
+These are removed. `pp.legend(ax)` auto-mode reads from
+`ax._publiplots_legend_entries` only. A migration grep confirms no
+other internal code reads the old attributes.
+
+### Per-plot specifics
+
+- **Categorical hue** (most plots): handles are Rectangle/MarkerPatch
+  with palette colors; labels are category strings.
+- **Continuous hue** (scatter with numeric column + `hue_norm`):
+  handles are `[ScalarMappable]` (length 1); labels are `[]`. Router
+  in `_materialize` / `_render_stashed_on_axes` detects this via
+  `_is_continuous()`.
+- **Size** (scatter, heatmap bubble): handles are MarkerPatches with
+  varying `markersize`; labels are numeric buckets.
+- **Style / marker** (scatter): handles are MarkerPatches with
+  different markers; labels are level names.
+
+The existing per-plot code that builds these handles is reused — we
+only change where they land (stash vs. direct render).
+
+---
+
+## rcParams
+
+No new keys. The existing `subplots.*` reservations continue to drive
+defaults for the four per-side tuples. `legend_column` is always
+auto-measured.
+
+---
+
+## Exports
+
+`publiplots.__init__.py` exports unchanged. `LegendEntry` stays as an
+internal helper (no user-facing need). `resolve_legend_flags` stays
+internal.
+
+---
+
+## Testing
+
+### New test files
+
+**`tests/test_legend_entries.py` (new):**
+
+- `test_resolve_legend_flags_bool_true` — `True` → all kinds True.
+- `test_resolve_legend_flags_bool_false` — `False` → all kinds False.
+- `test_resolve_legend_flags_dict_partial` — `dict(hue=False)` → hue
+  False, others True.
+- `test_resolve_legend_flags_dict_all` — every kind listed explicitly.
+- `test_resolve_legend_flags_rejects_bad_type` — `legend=1` raises
+  `TypeError`.
+- `test_legend_entry_build_is_deterministic` — same inputs → same
+  signature.
+- `test_legend_entry_different_palettes_differ` — same name+kind,
+  different palette → different signatures.
+- `test_stash_entry_preserves_order` — multiple stashes append in
+  order.
+- `test_get_entries_empty_ax` — no stashes → empty list.
+
+**`tests/test_legend_group_auto_collect.py` (new):**
+
+- `test_auto_collect_dedups_identical_entries` — 1×3 grid, same hue on
+  each axes → group has 1 entry.
+- `test_auto_collect_preserves_order_across_axes` — unique entries on
+  each axes → group renders in first-seen order.
+- `test_collect_filter_picks_only_listed_names` — `collect=['x']`
+  drops other entries; they render per-axis.
+- `test_collect_ordering_follows_list_order` — `collect=['b', 'a']`
+  renders b before a.
+- `test_mismatched_signature_warns_once` — same name, different
+  handles → 1 warning (not 2).
+- `test_no_publiplots_axes_noops` — group on a `plt.subplots` figure
+  doesn't crash; just doesn't auto-collect.
+- `test_manual_and_auto_coexist` — `group.add_legend(...)` manually,
+  then draw → both manual and auto entries render.
+
+**`tests/test_subplots.py` (extend):**
+
+- `test_legend_column_auto_sizes_to_group_width` — attach group, draw,
+  `layout.legend_column > 0` and within 2 mm of measured group width.
+- `test_legend_column_is_zero_without_group` — no group → `layout.legend_column == 0.0`.
+- `test_legend_column_grows_when_entries_added` — add one entry, draw;
+  add another, draw; width grows.
+- `test_pp_subplots_rejects_legend_column_kwarg` —
+  `pp.subplots(legend_column=30)` raises `TypeError`.
+
+**`tests/test_scatter_legend_stash.py` (new):**
+
+- `test_scatterplot_stashes_hue_entry` — `hue='x', legend=True` →
+  `get_entries(ax)` has a hue entry with correct name.
+- `test_scatterplot_stashes_size_entry` — `size='y', legend=True` →
+  size entry stashed.
+- `test_scatterplot_legend_dict_suppresses_hue` —
+  `legend=dict(hue=False)` → no hue entry stashed; size still stashed.
+- `test_scatterplot_legend_false_stashes_nothing` — `legend=False` →
+  no entries.
+- `test_scatterplot_legend_group_suppresses_per_axis_render` — group
+  on fig + scatterplot → entries stashed but no Legend child on the
+  axes.
+
+**`tests/test_bar_legend_stash.py` (new):**
+
+- `test_barplot_stashes_hue_entry` — basic stash path works.
+- `test_barplot_legend_dict_hue_false` — dict form suppresses hue.
+
+### Existing test updates
+
+- `tests/test_subplots.py::test_subplots_legend_column_reserves_extra_width`
+  — DROP this test. It tested an API that no longer exists.
+- Any test that called `pp.subplots(legend_column=N)` — update to drop
+  the kwarg; auto-measurement covers it.
+
+### Gallery smoke tests
+
+- `examples/plots/plot_14_edgecolor_control.py` — both `pp.subplots(...)`
+  calls lose `legend_column=30`. The explicit `group.add_legend(handles=...)`
+  calls are replaced with bare `pp.legend_group(anchor=axes[-1])` — auto
+  collect handles it.
+- `examples/plots/plot_02_scatter_plots.py` — bubble plot section
+  continues to render correctly (visual regression check).
+
+### Baseline
+
+Full suite target: **121 baseline + ~25 new** = ~146 passing.
+
+---
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| `pp.subplots(legend_column=30)` | `TypeError` with message pointing at `pp.legend_group` |
+| `legend=1` (int) on plot | `TypeError` from `resolve_legend_flags` |
+| `collect='treatment'` (str, not list) | Not caught explicitly; `in` check on the string returns True for any substring → buggy. **Mitigation**: `collect` validation in `MultiAxesLegendGroup.__init__`: if not None and not list/tuple → `TypeError`. |
+| `legend_group` on non-`pp.subplots` figure | No-op auto-collect (warn is NOT emitted — user may have explicit `add_legend` planned). |
+| Mismatched signatures | One-shot `UserWarning` per figure. |
+| Same `(name, kind)` appears in `collect=` multiple times | Dedup to first occurrence. No warning. |
+
+---
+
+## Interactions with existing code
+
+- **`LegendBuilder`** (PR #78): unchanged public API. Still used by
+  `pp.legend(ax)` and by `MultiAxesLegendGroup._render_entry`. The
+  `external_to_axis` flag from PR #79 amendment continues to route
+  legend_group artists away from per-axis tightbbox measurement.
+- **`LayoutReactor`** (PR #78): unchanged. Still repositions the
+  legend artists on every draw based on registration mm-offsets.
+- **`SubplotsAutoLayout`** (PR #79): gains one new measurement
+  (`legend_column`). Settle loop already handles convergence.
+- **`pp.legend(ax)`** (PR #78): auto mode rewritten to read from
+  `ax._publiplots_legend_entries` instead of scattered ad-hoc
+  attributes. Public API unchanged.
+
+---
+
+## Decisions locked — do NOT re-litigate
+
+- `legend_column` kwarg dropped entirely (breaking change; no deprecation).
+- `legend=True/False` preserved; `legend=dict(kind=bool)` added; missing
+  dict keys default to True.
+- Per-axes storage uses a single standardized attribute
+  (`_publiplots_legend_entries`). Ad-hoc stashes removed.
+- Dedup by `(name, kind)` with signature-based mismatch detection.
+  First-wins + one-shot warn.
+- `collect=None` = collect all; `collect=[names]` = filter + order.
+- Suppression rule: entry claimed by group → per-axis skips. Entry
+  not claimed (or no group) → per-axis renders if its `kind` flag is
+  True.
+- Explicit `add_legend` calls on the group still work; render before
+  auto-collected entries.
+- `pp.legend(ax)` semantics unchanged — no magic auto-group detection.
+- No inside-the-axes legend placement (deferred).
+- No new rcParams.
+
+---
+
+## Files touched
+
+**Create:**
+- `src/publiplots/utils/legend_entries.py`
+- `tests/test_legend_entries.py`
+- `tests/test_legend_group_auto_collect.py`
+- `tests/test_scatter_legend_stash.py`
+- `tests/test_bar_legend_stash.py`
+
+**Modify:**
+- `src/publiplots/utils/legend_group.py` (collect, _materialize,
+  claims, register on fig)
+- `src/publiplots/layout/auto_layout.py` (_measure_legend_column,
+  extend _ALL_SIDES, extend _needs_update)
+- `src/publiplots/layout/subplots.py` (drop legend_column kwarg,
+  raise on use)
+- `src/publiplots/utils/legend.py` (rewrite auto-mode to read the
+  standardized store)
+- `src/publiplots/plot/bar.py` (adopt stash pattern)
+- `src/publiplots/plot/box.py`
+- `src/publiplots/plot/point.py`
+- `src/publiplots/plot/scatter.py`
+- `src/publiplots/plot/strip.py`
+- `src/publiplots/plot/swarm.py`
+- `src/publiplots/plot/violin.py`
+- `src/publiplots/plot/raincloud.py`
+- `src/publiplots/plot/heatmap.py`
+- `examples/plots/plot_14_edgecolor_control.py` (drop `legend_column=30`,
+  drop explicit `group.add_legend(handles=...)` calls)
+- `tests/test_subplots.py` (drop legend_column test; add
+  width-awareness tests)
+
+---
+
+## Open questions for implementation
+
+None. All API decisions are locked above.

--- a/docs/superpowers/specs/2026-05-01-legend-auto-collection-design.md
+++ b/docs/superpowers/specs/2026-05-01-legend-auto-collection-design.md
@@ -59,6 +59,13 @@ semantics are unchanged; the dict form is additive.
 - Auto-detection that would turn any figure with multiple legends into
   a `legend_group`. Explicit opt-in only — user calls
   `pp.legend_group(...)`.
+- **Migrating all 9 plot functions to the stash+render pattern.** Deferred
+  to follow-up PRs. This PR migrates the 4 plot types that already use
+  a stash-like pattern today (`scatter`, `strip`, `swarm`, `point`);
+  the 5 that render legends inline (`bar`, `box`, `violin`, `raincloud`,
+  `heatmap`) keep their current behavior and are NOT auto-collected by
+  `legend_group` until their dedicated follow-up PRs land. See the
+  "Plot migration scope" section below.
 
 ---
 
@@ -563,6 +570,52 @@ only change where they land (stash vs. direct render).
 
 ---
 
+## Plot migration scope
+
+Today's codebase has two patterns for legend handling:
+
+**Stash-then-auto-read** (4 plot functions):
+- `src/publiplots/plot/scatter.py` — stashes to `ax.collections[0]._legend_data`
+- `src/publiplots/plot/strip.py` — same
+- `src/publiplots/plot/swarm.py` — same
+- `src/publiplots/plot/point.py` — stashes to `ax.lines[0]._legend_data`
+
+These four already separate handle construction from legend rendering.
+`pp.legend(ax)` in auto mode reads the stashed dict and renders.
+Migration cost is low: replace the dict-shaped stash with
+`LegendEntry` calls to `stash_entry(ax, ...)`, and rewrite the
+auto-mode reader in `pp.legend`.
+
+**Render-inline** (5 plot functions, DEFERRED to follow-up PRs):
+- `src/publiplots/plot/bar.py` — calls `_legend(...)` helper which builds
+  handles and renders in the same step
+- `src/publiplots/plot/box.py` — calls `pp_legend(ax, handles=...)` directly
+  after building handles inline
+- `src/publiplots/plot/violin.py` — same pattern as box
+- `src/publiplots/plot/raincloud.py` — delegates to its sub-plot layers
+- `src/publiplots/plot/heatmap.py` — builds size legends inline via
+  `_create_size_legend` helper, renders immediately
+
+These require extracting handle-building from rendering, which is a
+meaningful refactor per plot. To keep PR #81 reviewable, we explicitly
+defer these to separate follow-up PRs (one per plot type or grouped as
+makes sense).
+
+**User-visible consequence during the interim:**
+
+```python
+fig, axes = pp.subplots(1, 3)
+pp.scatterplot(..., ax=axes[0])          # stashes; group auto-collects
+pp.barplot(..., ax=axes[1])              # does NOT stash; group does not see it
+pp.legend_group(anchor=axes[-1])         # picks up only the scatterplot entry
+```
+
+Documented clearly in `pp.legend_group`'s docstring. For barplot /
+boxplot / violinplot / raincloudplot / heatmap that need unified
+legends, users fall back to manual `group.add_legend(handles=...)`
+until the follow-up PRs land. This matches pre-PR-#81 behavior exactly
+for those plots — no regression, just no new auto-collect.
+
 ## rcParams
 
 No new keys. The existing `subplots.*` reservations continue to drive
@@ -641,10 +694,9 @@ internal.
   on fig + scatterplot → entries stashed but no Legend child on the
   axes.
 
-**`tests/test_bar_legend_stash.py` (new):**
-
-- `test_barplot_stashes_hue_entry` — basic stash path works.
-- `test_barplot_legend_dict_hue_false` — dict form suppresses hue.
+**`tests/test_bar_legend_stash.py`** — NOT created in this PR. `bar.py`
+is not migrated here; it keeps its current inline render behavior.
+Equivalent tests land in the follow-up PR that migrates `bar.py`.
 
 ### Existing test updates
 
@@ -736,19 +788,22 @@ Full suite target: **121 baseline + ~25 new** = ~146 passing.
   raise on use)
 - `src/publiplots/utils/legend.py` (rewrite auto-mode to read the
   standardized store)
-- `src/publiplots/plot/bar.py` (adopt stash pattern)
-- `src/publiplots/plot/box.py`
-- `src/publiplots/plot/point.py`
-- `src/publiplots/plot/scatter.py`
+- `src/publiplots/plot/scatter.py` (migrate stash pattern)
 - `src/publiplots/plot/strip.py`
 - `src/publiplots/plot/swarm.py`
+- `src/publiplots/plot/point.py`
+- `examples/plots/plot_14_edgecolor_control.py` (drop `legend_column=30`;
+  the existing raincloud section keeps explicit `group.add_legend`
+  because raincloud is not migrated in this PR)
+- `tests/test_subplots.py` (drop legend_column test; add
+  width-awareness tests)
+
+**NOT modified** (deferred to follow-up PRs):
+- `src/publiplots/plot/bar.py`
+- `src/publiplots/plot/box.py`
 - `src/publiplots/plot/violin.py`
 - `src/publiplots/plot/raincloud.py`
 - `src/publiplots/plot/heatmap.py`
-- `examples/plots/plot_14_edgecolor_control.py` (drop `legend_column=30`,
-  drop explicit `group.add_legend(handles=...)` calls)
-- `tests/test_subplots.py` (drop legend_column test; add
-  width-awareness tests)
 
 ---
 

--- a/examples/plots/plot_02_scatter_plots.py
+++ b/examples/plots/plot_02_scatter_plots.py
@@ -206,3 +206,30 @@ fig, ax = pp.scatterplot(
     ylabel='Tissue',
 )
 plt.show()
+
+# %%
+# Shared Legend Across Subplots
+# ------------------------------
+# When several subplots share the same ``hue`` variable, attach
+# ``pp.legend_group(anchor=...)`` to the figure BEFORE drawing. Every
+# plot function that stashes legend entries (scatter / strip / swarm /
+# point) sees the group, skips its own per-axis legend, and lets the
+# group render one unified legend on the right. The figure's
+# ``legend_column`` is auto-sized from the measured group width — no
+# ``legend_column=N`` guess, no ``handles=...`` construction.
+
+np.random.seed(99)
+shared_df = pd.DataFrame({
+    'x': np.random.randn(60),
+    'y': np.random.randn(60),
+    'g': np.random.choice(['low', 'mid', 'high'], 60),
+})
+
+fig, axes = pp.subplots(1, 3, axes_size=(40, 35))
+pp.legend_group(anchor=axes[-1])   # attach BEFORE plotting
+for ax, title in zip(axes, ['Sample A', 'Sample B', 'Sample C']):
+    pp.scatterplot(
+        data=shared_df, x='x', y='y', hue='g',
+        palette='pastel', title=title, ax=ax,
+    )
+plt.show()

--- a/examples/plots/plot_14_edgecolor_control.py
+++ b/examples/plots/plot_14_edgecolor_control.py
@@ -91,7 +91,7 @@ mixed_data = pd.DataFrame({
 # pp.subplots declares axes dimensions in mm and extends the figure to
 # accommodate decorations. legend_column=30 reserves a 30 mm strip on
 # the right for the unified legend; pp.legend_group lands in that strip.
-fig, axes = pp.subplots(1, 3, axes_size=(45, 30), legend_column=30)
+fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
 pp.barplot(
     data=mixed_data, x='group', y='value', hue='group',
     palette='pastel', errorbar='se', title='Bar', ax=axes[0], legend=False,
@@ -145,7 +145,7 @@ rain_data = pd.DataFrame({
     ]),
 })
 
-fig, axes = pp.subplots(1, 2, axes_size=(55, 50), sharey=True, legend_column=30)
+fig, axes = pp.subplots(1, 2, axes_size=(55, 50), sharey=True)
 
 # Left: palette-driven edges (rcParam temporarily off)
 pp.rcParams['edgecolor'] = None

--- a/examples/plots/plot_14_edgecolor_control.py
+++ b/examples/plots/plot_14_edgecolor_control.py
@@ -89,8 +89,8 @@ mixed_data = pd.DataFrame({
 })
 
 # pp.subplots declares axes dimensions in mm and extends the figure to
-# accommodate decorations. legend_column=30 reserves a 30 mm strip on
-# the right for the unified legend; pp.legend_group lands in that strip.
+# accommodate decorations. pp.legend_group's width is auto-measured —
+# the figure grows to fit the unified legend on the right automatically.
 fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
 pp.barplot(
     data=mixed_data, x='group', y='value', hue='group',

--- a/examples/plots/plot_14_edgecolor_control.py
+++ b/examples/plots/plot_14_edgecolor_control.py
@@ -88,10 +88,22 @@ mixed_data = pd.DataFrame({
     ]),
 })
 
-# pp.subplots declares axes dimensions in mm and extends the figure to
-# accommodate decorations. pp.legend_group's width is auto-measured —
-# the figure grows to fit the unified legend on the right automatically.
+# `pp.subplots` declares axes dimensions in mm and extends the figure to
+# accommodate decorations. `pp.legend_group` reserves a shared legend
+# column on the right whose width is auto-measured from the rendered
+# entries — no manual `legend_column=...` guess.
+#
+# `pp.legend_group(anchor=...)` attaches BEFORE the plot calls. Plotting
+# functions that stash entries (scatterplot, stripplot, swarmplot,
+# pointplot in this release) see the group and skip their own per-axis
+# legend — the group claims and renders their entries instead.
+#
+# For plots that don't yet stash (bar, box), we pass `legend=False`; the
+# scatterplot on the right anchors the shared "group" entry for the whole
+# row since all three panels share the same hue variable.
 fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
+pp.legend_group(anchor=axes[-1])
+
 pp.barplot(
     data=mixed_data, x='group', y='value', hue='group',
     palette='pastel', errorbar='se', title='Bar', ax=axes[0], legend=False,
@@ -102,22 +114,7 @@ pp.boxplot(
 )
 pp.scatterplot(
     data=mixed_data, x='group', y='value', hue='group',
-    palette='pastel', title='Scatter', ax=axes[2], legend=False,
-)
-
-# One unified legend to the right of the last axes. `pp.legend_group` keeps
-# every entry in a single mm-aligned column anchored to the chosen axes —
-# the right tool when per-axes legends would overlap neighboring subplots.
-group = pp.legend_group(anchor=axes[-1])
-group.add_legend(
-    handles=pp.create_legend_handles(
-        labels=['A', 'B', 'C'],
-        colors=list(pp.color_palette('pastel', 3)),
-        alpha=pp.rcParams['alpha'],
-        linewidth=pp.rcParams['lines.linewidth'],
-        edgecolors=pp.rcParams['edgecolor'],
-    ),
-    label='group',
+    palette='pastel', title='Scatter', ax=axes[2],
 )
 plt.show()
 

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -220,10 +220,7 @@ class SubplotsAutoLayout:
     def _artist_window_extent(self, obj):
         """Duck-typed window-extent accessor (Legend/Colorbar/Text)."""
         if hasattr(obj, "get_window_extent"):
-            try:
-                return obj.get_window_extent()
-            except Exception:
-                pass
+            return obj.get_window_extent()
         if hasattr(obj, "ax"):  # Colorbar stores geometry on .ax
             return obj.ax.get_window_extent()
         return None

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -141,9 +141,18 @@ class SubplotsAutoLayout:
         return measured
 
     def _side_extent(self, ax, calc, managed_artist_ids) -> float:
-        """Measure ax's tight-vs-window extent for one side, excluding managed overlays."""
+        """Measure ax's tight-vs-window extent for one side, excluding managed overlays.
+
+        Also accounts for reactor-managed artists that are NOT children of
+        ``ax`` but are pinned to it — e.g. colorbar titles added via
+        ``fig.text`` which live under the Figure, not the Axes.
+        ``ax.get_tightbbox()`` misses those, so we manually union their
+        window extents into the tight bbox before computing the side extent.
+        """
         ax_bbox = ax.get_window_extent()
-        # Temporarily drop managed artists from layout consideration.
+        # Temporarily drop managed overlay artists (legend_group's legends)
+        # from layout consideration so they don't inflate the per-axis
+        # reservations.
         toggled = []
         for child in ax.get_children():
             if id(child) in managed_artist_ids and child.get_in_layout():
@@ -156,7 +165,33 @@ class SubplotsAutoLayout:
                 child.set_in_layout(True)
         if tight is None:
             return 0.0
+
+        # Union with pinned-but-not-child artists (per-axis colorbar
+        # titles are fig.text artists registered to this axes via the
+        # reactor). These sit inside the reserved side but are invisible
+        # to ax.get_tightbbox() — without this union, the reservation
+        # shrinks below what the title actually needs and the title gets
+        # clipped on save.
+        tight = self._union_pinned_artists(ax, tight, managed_artist_ids)
         return calc(ax_bbox, tight)
+
+    def _union_pinned_artists(self, ax, tight, managed_artist_ids):
+        """Union `tight` with extents of reactor-managed artists pinned to `ax`
+        that are NOT among the excluded managed overlays."""
+        reactor = getattr(self._fig, "_publiplots_layout_reactor", None)
+        if reactor is None:
+            return tight
+        from matplotlib.transforms import Bbox
+        for reg in reactor._registrations:
+            if reg.ax is not ax:
+                continue
+            if id(reg.artist) in managed_artist_ids:
+                continue  # external overlay — already excluded
+            extent = self._artist_window_extent(reg.artist)
+            if extent is None:
+                continue
+            tight = Bbox.union([tight, extent])
+        return tight
 
     def _externally_managed_artist_ids(self) -> set:
         """IDs of LayoutReactor registrations flagged external_to_axis=True.

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -21,7 +21,7 @@ from publiplots.layout.figure_layout import FigureLayout
 
 _MM2INCH = 1 / 25.4
 _UPDATE_THRESHOLD_MM = 0.1
-_ALL_SIDES = {"title_space", "xlabel_space", "ylabel_space", "right"}
+_ALL_SIDES = {"title_space", "xlabel_space", "ylabel_space", "right", "legend_column"}
 # Cap on settle() draws; 1-3 is typical.
 _MAX_CONVERGENCE_ITERS = 5
 
@@ -135,6 +135,9 @@ class SubplotsAutoLayout:
                         max_px = max(max_px, self._side_extent(ax, calc, managed))
                     per.append(max(max_px / dpi * 25.4, 0.0))
                 measured[side] = tuple(per)
+
+        if "legend_column" not in self._locked:
+            measured["legend_column"] = self._measure_legend_column()
         return measured
 
     def _side_extent(self, ax, calc, managed_artist_ids) -> float:
@@ -173,14 +176,57 @@ class SubplotsAutoLayout:
         }
 
     def _needs_update(self, measured: Dict[str, Tuple[float, ...]]) -> bool:
-        for side, new_tuple in measured.items():
+        for side, new_val in measured.items():
             current = getattr(self._layout, side)
-            if len(new_tuple) != len(current):
-                return True
-            for new_v, cur_v in zip(new_tuple, current):
-                if abs(new_v - cur_v) >= _UPDATE_THRESHOLD_MM:
+            if side == "legend_column":
+                if abs(new_val - current) >= _UPDATE_THRESHOLD_MM:
                     return True
+            else:
+                # tuple comparison (per-row / per-col reservations)
+                if len(new_val) != len(current):
+                    return True
+                for nv, cv in zip(new_val, current):
+                    if abs(nv - cv) >= _UPDATE_THRESHOLD_MM:
+                        return True
         return False
+
+    def _measure_legend_column(self) -> float:
+        """mm width past the anchor axes' right edge, plus 1 mm padding."""
+        group = getattr(self._fig, "_publiplots_legend_group", None)
+        if group is None:
+            return 0.0
+
+        # Force collection so artists exist to measure.
+        group._materialize()
+        if not group._builder.elements:
+            return 0.0
+
+        dpi = self._fig.dpi
+        if dpi <= 0:
+            return 0.0
+
+        anchor_bb = group.anchor.get_window_extent()
+        max_x1 = anchor_bb.x1
+        for _, obj in group._builder.elements:
+            extent = self._artist_window_extent(obj)
+            if extent is None:
+                continue
+            max_x1 = max(max_x1, extent.x1)
+        overhang_px = max_x1 - anchor_bb.x1
+        if overhang_px <= 0:
+            return 0.0
+        return overhang_px / dpi * 25.4 + 1.0
+
+    def _artist_window_extent(self, obj):
+        """Duck-typed window-extent accessor (Legend/Colorbar/Text)."""
+        if hasattr(obj, "get_window_extent"):
+            try:
+                return obj.get_window_extent()
+            except Exception:
+                pass
+        if hasattr(obj, "ax"):  # Colorbar stores geometry on .ax
+            return obj.ax.get_window_extent()
+        return None
 
     def _apply(self, measured: Dict[str, Tuple[float, ...]]) -> None:
         new_layout = self._layout.with_updated_reservations(**measured)

--- a/src/publiplots/layout/subplots.py
+++ b/src/publiplots/layout/subplots.py
@@ -39,7 +39,6 @@ def subplots(
     hspace: Optional[float] = None,
     wspace: Optional[float] = None,
     outer_pad: Optional[float] = None,
-    legend_column: float = 0.0,
     **fig_kw,
 ):
     """
@@ -68,15 +67,15 @@ def subplots(
     hspace, wspace, outer_pad : float, optional
         Gaps and outer margin in mm. ``None`` falls back to rcParams.
         Never auto-measured.
-    legend_column : float, default 0
-        Extra width reserved on the far right of the figure (outside the
-        grid, applied once — not per-cell). Intended for a single unified
-        ``pp.legend_group`` anchored to the rightmost axes. Never
-        auto-measured — opt-in only. Future: legend-width awareness will
-        compute this automatically from registered legend content.
     **fig_kw
         Forwarded to ``plt.figure``. ``figsize`` is rejected; layout-
         engine kwargs are ignored with a warning.
+
+    Notes
+    -----
+    Extra width for a ``pp.legend_group`` anchored to the rightmost axes
+    is auto-computed on first draw from the rendered group width; there
+    is no ``legend_column`` kwarg to set by hand.
 
     Returns
     -------
@@ -111,6 +110,12 @@ def subplots(
         raise TypeError(
             "pp.subplots() does not accept figsize; use axes_size (mm). "
             "Figure size is computed from axes_size + reservations."
+        )
+    if "legend_column" in fig_kw:
+        raise TypeError(
+            "pp.subplots() no longer accepts legend_column. Attach a "
+            "pp.legend_group(anchor=...) to the figure; the column is "
+            "auto-sized based on the rendered group width."
         )
     for k in _LAYOUT_ENGINE_KWARGS:
         if k in fig_kw:
@@ -169,14 +174,11 @@ def subplots(
             raise ValueError(f"{side} must be non-negative, got {val}")
         resolved[side] = float(val)
 
-    if legend_column < 0:
-        raise ValueError(f"legend_column must be non-negative, got {legend_column}")
-
     # --- build layout & figure --------------------------------------------
     layout = FigureLayout(
         nrows=nrows, ncols=ncols,
         axes_size=axes_size_t,
-        legend_column=float(legend_column),
+        legend_column=0.0,
         **resolved,
     )
     W, H = layout.figure_size()

--- a/src/publiplots/plot/point.py
+++ b/src/publiplots/plot/point.py
@@ -19,7 +19,16 @@ from publiplots.themes.rcparams import resolve_param
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.themes.markers import resolve_marker_map
 from publiplots.themes.linestyles import resolve_linestyle_map
-from publiplots.utils import create_legend_handles, legend
+from publiplots.utils import create_legend_handles
+from publiplots.utils.legend import legend as legend_fn
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
 
 
 def pointplot(
@@ -54,7 +63,7 @@ def pointplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
     **kwargs
 ) -> Tuple[plt.Figure, Axes]:
@@ -300,8 +309,10 @@ def pointplot(
     if title is not None:
         ax.set_title(title)
 
-    # Add legend if hue is used
-    if legend and hue is not None:
+    # Stash legend entry (per-kind) and optionally render per-axis legend.
+    # legend may be bool or dict[str, bool]; False short-circuits both stash
+    # and render, True stashes/renders everything, and a dict filters per kind.
+    if hue is not None:
         _legend(
             ax=ax,
             hue=hue,
@@ -314,6 +325,7 @@ def pointplot(
             alpha=alpha,
             linewidth=linewidth,
             kwargs=legend_kws,
+            legend=legend,
         )
 
     return fig, ax
@@ -438,30 +450,17 @@ def _legend(
     alpha: Optional[float] = None,
     linewidth: Optional[float] = None,
     kwargs: Optional[Dict] = None,
+    legend: Union[bool, Dict] = True,
 ) -> None:
     """
-    Create legend handles for point plot.
+    Stash LegendEntry objects for point plot and optionally render per-axis legend.
 
     Parameters
     ----------
-    ax : Axes
-        Axes to create legend for.
-    hue : str
-        Hue column name.
-    palette : dict or str
-        Color palette mapping.
-    markers : list or dict
-        Marker symbols for each hue level.
-    markersize : float, optional
-        Marker size for legend markers.
-    markeredgewidth : float, optional
-        Marker edge width for legend markers.
-    alpha : float, optional
-        Transparency for legend markers.
-    linewidth : float, optional
-        Line width for legend markers.
-    kwargs : dict, optional
-        Additional legend customization.
+    legend : bool or dict, default=True
+        - ``True``  -> stash all kinds and render per-axis (unless claimed by a group).
+        - ``False`` -> stash nothing and render nothing.
+        - ``dict``  -> per-kind flags (missing keys default to True).
     """
     # Read defaults from rcParams if not provided
     alpha = resolve_param("alpha", alpha)
@@ -471,11 +470,10 @@ def _legend(
 
     kwargs = kwargs or {}
 
-    # Store legend data
-    legend_data = {}
+    flags = resolve_legend_flags(legend)
 
-    # Extract unique hue values from marker_info
-    if isinstance(palette, dict):
+    # Stash hue entry
+    if flags["hue"] and isinstance(palette, dict):
         # Use palette keys as the source of truth for labels
         labels = list(palette.keys())
         colors = list(palette.values())
@@ -493,14 +491,39 @@ def _legend(
             markeredgewidth=markeredgewidth,
         )
 
-        legend_data["hue"] = {
-            "handles": hue_handles,
-            "label": kwargs.pop("hue_label", hue),
-        }
+        hue_label = kwargs.pop("hue_label", hue)
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=hue_label,
+                kind="hue",
+                handles=hue_handles,
+                labels=[str(label) for label in labels],
+            ),
+        )
 
-    # Store metadata on first line for retrieval
-    if len(ax.lines) > 0:
-        ax.lines[0]._legend_data = legend_data
+    # Render per-axis legend for entries not claimed by a figure-level group.
+    # legend=False short-circuits (all flags False, nothing stashed, nothing to render).
+    if legend is False:
+        return
 
-    # Create legend using legend() API
-    return legend(ax=ax)
+    fig = ax.get_figure()
+    entries_to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if not entries_to_render:
+        return
+
+    builder = legend_fn(ax=ax, auto=False)
+    for entry in entries_to_render:
+        if entry.kind == "hue" and is_continuous_hue(entry.handles):
+            builder.add_colorbar(
+                mappable=entry.handles[0],
+                label=entry.name,
+            )
+        else:
+            builder.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )

--- a/src/publiplots/plot/scatter.py
+++ b/src/publiplots/plot/scatter.py
@@ -19,7 +19,16 @@ from publiplots.themes.rcparams import resolve_param
 
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.themes.markers import resolve_marker_map
-from publiplots.utils import is_categorical, is_numeric, create_legend_handles, legend
+from publiplots.utils import is_categorical, is_numeric, create_legend_handles
+from publiplots.utils import legend as legend_fn
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
 
 
 def scatterplot(
@@ -43,7 +52,7 @@ def scatterplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
     margins: Union[float, Tuple[float, float]] = 0.1,
     **kwargs
@@ -300,7 +309,9 @@ def scatterplot(
     if ylabel is not None: ax.set_ylabel(ylabel)
     if title is not None: ax.set_title(title)
 
-    # Always store legend metadata, but only create legend if legend=True
+    # Stash legend entries (per-kind) and optionally render per-axis legends.
+    # legend may be bool or dict[str, bool]; False short-circuits both stash
+    # and render, True stashes/renders everything, and a dict filters per kind.
     _legend(
         ax=ax,
         data=data,
@@ -317,7 +328,7 @@ def scatterplot(
         size_norm=size_norm,
         sizes=sizes,
         kwargs=legend_kws,
-        create_legend=legend,  # Only create if legend=True
+        legend=legend,
     )
 
     # Set margins for categorical axes automatically
@@ -479,15 +490,17 @@ def _legend(
         linewidth: Optional[float] = None,
         edgecolor: Optional[str] = None,
         kwargs: Optional[Dict] = None,
-        create_legend: bool = True,
+        legend: Union[bool, Dict] = True,
     ) -> None:
     """
-    Create legend handles for scatter plot.
+    Stash LegendEntry objects for scatter plot and optionally render per-axis legends.
 
     Parameters
     ----------
-    create_legend : bool, default=True
-        If True, creates the legend immediately. If False, only stores metadata.
+    legend : bool or dict, default=True
+        - ``True``  -> stash all kinds and render per-axis (unless claimed by a group).
+        - ``False`` -> stash nothing and render nothing.
+        - ``dict``  -> per-kind flags (missing keys default to True).
     """
     # Read defaults from rcParams if not provided
     alpha = resolve_param("alpha", alpha)
@@ -496,35 +509,43 @@ def _legend(
     kwargs = kwargs or {}
     handle_kwargs = dict(alpha=alpha, linewidth=linewidth, color=color, style="circle")
 
-    # Store legend data in collection for later retrieval
-    legend_data = {}
+    flags = resolve_legend_flags(legend)
 
-    # Prepare hue legend data
-    if hue is not None:
+    # Stash hue entry
+    if hue is not None and flags["hue"]:
         hue_label = kwargs.pop("hue_label", hue)
-        if isinstance(palette, dict):  # categorical legend
+        if isinstance(palette, dict):  # categorical
+            hue_labels = list(palette.keys())
             hue_handles = create_legend_handles(
-                labels=list(palette.keys()),
+                labels=hue_labels,
                 colors=list(palette.values()),
                 edgecolors=[edgecolor] * len(palette) if edgecolor else None,
                 **handle_kwargs
             )
-            legend_data["hue"] = {
-                "handles": hue_handles,
-                "label": hue_label,
-            }
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=hue_handles,
+                    labels=hue_labels,
+                ),
+            )
         else:
+            # continuous -> colorbar
             mappable = ScalarMappable(norm=hue_norm, cmap=palette)
-            legend_data["hue"] = {
-                "mappable": mappable,
-                "label": hue_label,
-                "height": kwargs.pop("hue_height", 20),  # millimeters (was 0.2 axes coords)
-                "width": kwargs.pop("hue_width", 5),    # millimeters (was 0.05 axes coords)
-                "type": "colorbar",
-            }
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=[mappable],
+                    labels=[],
+                ),
+            )
 
-    # Prepare size legend data
-    if size is not None:
+    # Stash size entry
+    if size is not None and flags["size"]:
         tick_color = color if hue is None else "gray"
         size_handle_kwargs = handle_kwargs.copy()
         size_handle_kwargs["color"] = tick_color
@@ -541,14 +562,19 @@ def _legend(
             sizes=tick_sizes,
             **size_handle_kwargs
         )
-        legend_data["size"] = {
-            "handles": size_handles,
-            "label": kwargs.pop("size_label", size),
-            "labelspacing": kwargs.pop("labelspacing", 1/3 * max(1, sizes[1] / 200)),
-        }
+        size_label = kwargs.pop("size_label", size)
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=size_label,
+                kind="size",
+                handles=size_handles,
+                labels=tick_labels,
+            ),
+        )
 
-    # Prepare style legend data
-    if style is not None:
+    # Stash style entry
+    if style is not None and flags["style"]:
         style_values = data[style].unique()
         style_label = kwargs.pop("style_label", style)
 
@@ -564,24 +590,48 @@ def _legend(
         style_color = color if hue is None else "gray"
         style_handle_kwargs = handle_kwargs.copy()
         style_handle_kwargs["color"] = style_color
-        style_handle_kwargs.pop("style")  # Remove style key from handle_kwargs
+        style_handle_kwargs.pop("style", None)  # Remove style key from handle_kwargs
 
         # Create legend handles with different markers
+        style_labels = [str(val) for val in style_values]
         style_handles = create_legend_handles(
-            labels=[str(val) for val in style_values],
+            labels=style_labels,
             markers=[marker_map[val] for val in style_values],
             edgecolors=[edgecolor] * len(style_values) if edgecolor else None,
             **style_handle_kwargs
         )
-        legend_data["style"] = {
-            "handles": style_handles,
-            "label": style_label,
-        }
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=style_label,
+                kind="style",
+                handles=style_handles,
+                labels=style_labels,
+            ),
+        )
 
-    # Store metadata on collection (always, regardless of create_legend)
-    if len(ax.collections) > 0:
-        ax.collections[0]._legend_data = legend_data
+    # Render per-axis legends for entries not claimed by a figure-level group.
+    # legend=False short-circuits (all flags False, nothing stashed, nothing to render).
+    if legend is False:
+        return
 
-    # Create legends using new legend() API (only if create_legend=True)
-    if create_legend:
-        builder = legend(ax=ax)
+    fig = ax.get_figure()
+    entries_to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if not entries_to_render:
+        return
+
+    builder = legend_fn(ax=ax, auto=False)
+    for entry in entries_to_render:
+        if entry.kind == "hue" and is_continuous_hue(entry.handles):
+            builder.add_colorbar(
+                mappable=entry.handles[0],
+                label=entry.name,
+            )
+        else:
+            builder.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )

--- a/src/publiplots/plot/strip.py
+++ b/src/publiplots/plot/strip.py
@@ -17,7 +17,16 @@ import pandas as pd
 
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.utils.transparency import ArtistTracker
-from publiplots.utils.legend import create_legend_handles, legend
+from publiplots.utils.legend import create_legend_handles
+from publiplots.utils.legend import legend as legend_fn
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
 
 
 def stripplot(
@@ -42,7 +51,7 @@ def stripplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
     **kwargs
 ) -> Tuple[plt.Figure, Axes]:
@@ -186,8 +195,10 @@ def stripplot(
     # Apply transparency to new collections only
     tracker.apply_transparency(on="collections", face_alpha=alpha)
 
-    # Add legend if hue is used
-    if legend and hue is not None:
+    # Stash legend entry (per-kind) and optionally render per-axis legend.
+    # legend may be bool or dict[str, bool]; False short-circuits both stash
+    # and render, True stashes/renders everything, and a dict filters per kind.
+    if hue is not None:
         _legend(
             ax=ax,
             hue=hue,
@@ -198,6 +209,7 @@ def stripplot(
             alpha=alpha,
             linewidth=linewidth,
             kwargs=legend_kws,
+            legend=legend,
         )
 
     # Set labels
@@ -221,9 +233,17 @@ def _legend(
     alpha: Optional[float] = None,
     linewidth: Optional[float] = None,
     kwargs: Optional[Dict] = None,
+    legend: Union[bool, Dict] = True,
 ) -> None:
     """
-    Create legend handles for strip plot.
+    Stash LegendEntry objects for strip plot and optionally render per-axis legend.
+
+    Parameters
+    ----------
+    legend : bool or dict, default=True
+        - ``True``  -> stash all kinds and render per-axis (unless claimed by a group).
+        - ``False`` -> stash nothing and render nothing.
+        - ``dict``  -> per-kind flags (missing keys default to True).
     """
     # Read defaults from rcParams if not provided
     alpha = resolve_param("alpha", alpha)
@@ -232,38 +252,63 @@ def _legend(
     kwargs = kwargs or {}
     handle_kwargs = dict(alpha=alpha, linewidth=linewidth, color=color, style="circle")
 
-    # Store legend data in collection for later retrieval
-    legend_data = {}
+    flags = resolve_legend_flags(legend)
 
-    # Prepare hue legend data
-    if hue is not None:
+    # Stash hue entry
+    if hue is not None and flags["hue"]:
         hue_label = kwargs.pop("hue_label", hue)
-        if isinstance(palette, dict):  # categorical legend
+        if isinstance(palette, dict):  # categorical
+            hue_labels = list(palette.keys())
             hue_handles = create_legend_handles(
-                labels=list(palette.keys()),
+                labels=hue_labels,
                 colors=list(palette.values()),
                 edgecolors=[edgecolor] * len(palette) if edgecolor else None,
                 **handle_kwargs
             )
-            legend_data["hue"] = {
-                "handles": hue_handles,
-                "label": hue_label,
-            }
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=hue_handles,
+                    labels=hue_labels,
+                ),
+            )
         else:
-            # Continuous colorbar
+            # continuous -> colorbar
             mappable = ScalarMappable(norm=hue_norm, cmap=palette)
-            legend_data["hue"] = {
-                "mappable": mappable,
-                "label": hue_label,
-                "height": kwargs.pop("hue_height", 0.2),
-                "width": kwargs.pop("hue_width", 0.05),
-                "type": "colorbar",
-            }
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=[mappable],
+                    labels=[],
+                ),
+            )
 
-    # Store metadata on collection
-    if len(ax.collections) > 0:
-        ax.collections[0]._legend_data = legend_data
+    # Render per-axis legend for entries not claimed by a figure-level group.
+    # legend=False short-circuits (all flags False, nothing stashed, nothing to render).
+    if legend is False:
+        return
 
-    # Create legends using legend() API
-    from publiplots.utils.legend import legend as pp_legend
-    builder = pp_legend(ax=ax)
+    fig = ax.get_figure()
+    entries_to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if not entries_to_render:
+        return
+
+    builder = legend_fn(ax=ax, auto=False)
+    for entry in entries_to_render:
+        if entry.kind == "hue" and is_continuous_hue(entry.handles):
+            builder.add_colorbar(
+                mappable=entry.handles[0],
+                label=entry.name,
+            )
+        else:
+            builder.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )

--- a/src/publiplots/plot/swarm.py
+++ b/src/publiplots/plot/swarm.py
@@ -17,7 +17,16 @@ import pandas as pd
 
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.utils.transparency import ArtistTracker
-from publiplots.utils.legend import create_legend_handles, legend
+from publiplots.utils.legend import create_legend_handles
+from publiplots.utils.legend import legend as legend_fn
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
 
 
 def swarmplot(
@@ -41,7 +50,7 @@ def swarmplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
     **kwargs
 ) -> Tuple[plt.Figure, Axes]:
@@ -182,8 +191,10 @@ def swarmplot(
     # Apply transparency to new collections only
     tracker.apply_transparency(on="collections", face_alpha=alpha)
 
-    # Add legend if hue is used
-    if legend and hue is not None:
+    # Stash legend entry (per-kind) and optionally render per-axis legend.
+    # legend may be bool or dict[str, bool]; False short-circuits both stash
+    # and render, True stashes/renders everything, and a dict filters per kind.
+    if hue is not None:
         _legend(
             ax=ax,
             hue=hue,
@@ -194,6 +205,7 @@ def swarmplot(
             alpha=alpha,
             linewidth=linewidth,
             kwargs=legend_kws,
+            legend=legend,
         )
 
     # Set labels
@@ -217,9 +229,17 @@ def _legend(
     alpha: Optional[float] = None,
     linewidth: Optional[float] = None,
     kwargs: Optional[Dict] = None,
+    legend: Union[bool, Dict] = True,
 ) -> None:
     """
-    Create legend handles for swarm plot.
+    Stash LegendEntry objects for swarm plot and optionally render per-axis legend.
+
+    Parameters
+    ----------
+    legend : bool or dict, default=True
+        - ``True``  -> stash all kinds and render per-axis (unless claimed by a group).
+        - ``False`` -> stash nothing and render nothing.
+        - ``dict``  -> per-kind flags (missing keys default to True).
     """
     # Read defaults from rcParams if not provided
     alpha = resolve_param("alpha", alpha)
@@ -228,38 +248,63 @@ def _legend(
     kwargs = kwargs or {}
     handle_kwargs = dict(alpha=alpha, linewidth=linewidth, color=color, style="circle")
 
-    # Store legend data in collection for later retrieval
-    legend_data = {}
+    flags = resolve_legend_flags(legend)
 
-    # Prepare hue legend data
-    if hue is not None:
+    # Stash hue entry
+    if hue is not None and flags["hue"]:
         hue_label = kwargs.pop("hue_label", hue)
-        if isinstance(palette, dict):  # categorical legend
+        if isinstance(palette, dict):  # categorical
+            hue_labels = list(palette.keys())
             hue_handles = create_legend_handles(
-                labels=list(palette.keys()),
+                labels=hue_labels,
                 colors=list(palette.values()),
                 edgecolors=[edgecolor] * len(palette) if edgecolor else None,
                 **handle_kwargs
             )
-            legend_data["hue"] = {
-                "handles": hue_handles,
-                "label": hue_label,
-            }
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=hue_handles,
+                    labels=hue_labels,
+                ),
+            )
         else:
-            # Continuous colorbar
+            # continuous -> colorbar
             mappable = ScalarMappable(norm=hue_norm, cmap=palette)
-            legend_data["hue"] = {
-                "mappable": mappable,
-                "label": hue_label,
-                "height": kwargs.pop("hue_height", 0.2),
-                "width": kwargs.pop("hue_width", 0.05),
-                "type": "colorbar",
-            }
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=hue_label,
+                    kind="hue",
+                    handles=[mappable],
+                    labels=[],
+                ),
+            )
 
-    # Store metadata on collection
-    if len(ax.collections) > 0:
-        ax.collections[0]._legend_data = legend_data
+    # Render per-axis legend for entries not claimed by a figure-level group.
+    # legend=False short-circuits (all flags False, nothing stashed, nothing to render).
+    if legend is False:
+        return
 
-    # Create legends using legend() API
-    from publiplots.utils.legend import legend as pp_legend
-    builder = pp_legend(ax=ax)
+    fig = ax.get_figure()
+    entries_to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if not entries_to_render:
+        return
+
+    builder = legend_fn(ax=ax, auto=False)
+    for entry in entries_to_render:
+        if entry.kind == "hue" and is_continuous_hue(entry.handles):
+            builder.add_colorbar(
+                mappable=entry.handles[0],
+                label=entry.name,
+            )
+        else:
+            builder.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -10,6 +10,10 @@ visual style of scatterplots and barplots.
 from typing import List, Dict, Optional, Tuple, Any, Union
 
 from publiplots.themes.rcparams import resolve_param
+from publiplots.utils.legend_entries import (
+    get_entries,
+    is_continuous_hue,
+)
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
@@ -1450,26 +1454,44 @@ def legend(
 
     # Auto mode
     if auto:
-        legend_data = _get_legend_data(ax)
-        if legend_data:
-            # Add hue legend/colorbar
-            if 'hue' in legend_data:
-                hue_data = legend_data['hue'].copy()
-                if hue_data.get('type') == 'colorbar':
-                    hue_data.pop('type', None)
-                    builder.add_colorbar(**hue_data)
+        # Prefer the new LegendEntry store.
+        entries = get_entries(ax)
+        if entries:
+            seen = set()  # (name, kind) dedup within one axes
+            for entry in entries:
+                key = (entry.name, entry.kind)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if entry.kind == "hue" and is_continuous_hue(entry.handles):
+                    builder.add_colorbar(
+                        mappable=entry.handles[0],
+                        label=entry.name,
+                    )
                 else:
-                    builder.add_legend(**hue_data, **kwargs)
-
-            # Add size legend
-            if 'size' in legend_data:
-                size_data = legend_data['size'].copy()
-                builder.add_legend(**size_data, **kwargs)
-
-            # Add style legend
-            if 'style' in legend_data:
-                style_data = legend_data['style'].copy()
-                builder.add_legend(**style_data, **kwargs)
+                    builder.add_legend(
+                        handles=list(entry.handles),
+                        label=entry.name,
+                        **kwargs,
+                    )
+        else:
+            # Back-compat: read legacy _legend_data dict store (plot
+            # functions not migrated in PR #81 still use this path).
+            legend_data = _get_legend_data(ax)
+            if legend_data:
+                if 'hue' in legend_data:
+                    hue_data = legend_data['hue'].copy()
+                    if hue_data.get('type') == 'colorbar':
+                        hue_data.pop('type', None)
+                        builder.add_colorbar(**hue_data)
+                    else:
+                        builder.add_legend(**hue_data, **kwargs)
+                if 'size' in legend_data:
+                    size_data = legend_data['size'].copy()
+                    builder.add_legend(**size_data, **kwargs)
+                if 'style' in legend_data:
+                    style_data = legend_data['style'].copy()
+                    builder.add_legend(**style_data, **kwargs)
 
     return builder
 

--- a/src/publiplots/utils/legend_entries.py
+++ b/src/publiplots/utils/legend_entries.py
@@ -1,0 +1,133 @@
+"""
+Shared legend-entry infrastructure.
+
+Plot functions stash LegendEntry objects on ax._publiplots_legend_entries.
+pp.legend(ax) reads from this store to render per-axis legends.
+pp.legend_group(anchor=ax) aggregates entries across a grid of axes.
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+import hashlib
+
+
+_LEGEND_KINDS = ("hue", "size", "style", "marker")
+
+
+@dataclass(frozen=True)
+class LegendEntry:
+    """A single stashed legend entry on an axes.
+
+    Attributes
+    ----------
+    name : str
+        The variable name the user passed to the plot function
+        (e.g. ``hue='treatment'`` -> ``name='treatment'``).
+    kind : str
+        One of ``"hue"``, ``"size"``, ``"style"``, ``"marker"``.
+    handles : tuple
+        Matplotlib-compatible handles. For continuous hue, the first
+        handle is a ``ScalarMappable`` (see :func:`is_continuous_hue`).
+    labels : tuple of str
+        Display labels. Empty for continuous hue (colorbar path).
+    signature : str
+        Short hash of (kind, labels, handle-type + key visual props).
+        Used by pp.legend_group for dedup and mismatch detection.
+    """
+    name: str
+    kind: str
+    handles: tuple
+    labels: tuple
+    signature: str
+
+    @classmethod
+    def build(cls, name, kind, handles, labels) -> "LegendEntry":
+        """Construct an entry with a computed signature."""
+        return cls(
+            name=name,
+            kind=kind,
+            handles=tuple(handles),
+            labels=tuple(labels),
+            signature=_hash_handles(handles, labels),
+        )
+
+
+def _hash_handles(handles, labels) -> str:
+    parts = []
+    for h, lab in zip(handles, labels):
+        parts.append(type(h).__name__)
+        parts.append(str(lab))
+        for attr in ("get_facecolor", "get_marker", "get_markersize",
+                     "get_linewidth"):
+            fn = getattr(h, attr, None)
+            if fn is not None:
+                try:
+                    parts.append(repr(fn()))
+                except Exception:
+                    pass
+    # If no labels but there ARE handles (continuous hue / colorbar),
+    # include the handle types at least.
+    if not labels and handles:
+        for h in handles:
+            parts.append(type(h).__name__)
+    return hashlib.sha1("|".join(parts).encode()).hexdigest()[:12]
+
+
+def stash_entry(ax, entry: LegendEntry) -> None:
+    """Append an entry to ``ax._publiplots_legend_entries``.
+
+    Creates the list attribute on first call. Order is preserved;
+    later calls append.
+    """
+    existing = getattr(ax, "_publiplots_legend_entries", None)
+    if existing is None:
+        existing = []
+        ax._publiplots_legend_entries = existing
+    existing.append(entry)
+
+
+def get_entries(ax) -> list:
+    """Return the ordered list of entries stashed on ``ax``."""
+    return list(getattr(ax, "_publiplots_legend_entries", []))
+
+
+def resolve_legend_flags(legend) -> dict:
+    """Convert ``legend=`` (bool | dict) to a per-kind include map.
+
+    - ``True``  -> all kinds True
+    - ``False`` -> all kinds False
+    - ``dict``  -> as given; missing keys default to True
+    """
+    if legend is True:
+        return {k: True for k in _LEGEND_KINDS}
+    if legend is False:
+        return {k: False for k in _LEGEND_KINDS}
+    if isinstance(legend, dict):
+        return {k: bool(legend.get(k, True)) for k in _LEGEND_KINDS}
+    raise TypeError(
+        f"legend must be bool or dict[str, bool], got {type(legend).__name__}"
+    )
+
+
+def entry_is_in_group(fig, entry: LegendEntry) -> bool:
+    """True if the figure's legend_group (if any) claims this entry."""
+    group = getattr(fig, "_publiplots_legend_group", None)
+    if group is None:
+        return False
+    return group.claims(entry.name)
+
+
+def is_continuous_hue(handles) -> bool:
+    """True if the handles list represents a continuous colormap.
+
+    Detection is by the presence of a ``ScalarMappable`` as the first
+    handle — categorical hue handles are publiplots' RectanglePatch /
+    MarkerPatch / etc., never ScalarMappable.
+    """
+    if not handles:
+        return False
+    try:
+        from matplotlib.cm import ScalarMappable
+    except ImportError:
+        return False
+    return isinstance(handles[0], ScalarMappable)

--- a/src/publiplots/utils/legend_entries.py
+++ b/src/publiplots/utils/legend_entries.py
@@ -6,9 +6,8 @@ pp.legend(ax) reads from this store to render per-axis legends.
 pp.legend_group(anchor=ax) aggregates entries across a grid of axes.
 """
 
-from dataclasses import dataclass
-from typing import Tuple
 import hashlib
+from dataclasses import dataclass
 
 
 _LEGEND_KINDS = ("hue", "size", "style", "marker")

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -7,6 +7,7 @@ axes in the same figure. This is the primary tool for complex subplot
 layouts.
 """
 
+import warnings
 from typing import List, Optional, Sequence
 
 from matplotlib.axes import Axes
@@ -15,6 +16,11 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
 
 from publiplots.utils.legend import LegendBuilder
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    get_entries,
+    is_continuous_hue,
+)
 
 
 class MultiAxesLegendGroup:
@@ -83,6 +89,61 @@ class MultiAxesLegendGroup:
         if self._collect is None:
             return True
         return name in self._collect
+
+    def _materialize(self) -> None:
+        """Collect stashed entries from every grid axes and render them.
+
+        Called by SubplotsAutoLayout during the settle pass (Task 5).
+        Idempotent — subsequent calls after the first return immediately.
+        """
+        if self._materialized:
+            return
+        self._materialized = True
+
+        fig = self.anchor.get_figure()
+        axes_matrix = getattr(fig, "_publiplots_axes", None)
+        if axes_matrix is None:
+            return
+
+        seen = {}  # (name, kind) -> LegendEntry
+        order = []  # list of (name, kind) in collection order
+        for row in axes_matrix:
+            for ax in row:
+                for entry in get_entries(ax):
+                    if self._collect is not None and entry.name not in self._collect:
+                        continue
+                    key = (entry.name, entry.kind)
+                    if key in seen:
+                        if seen[key].signature != entry.signature and not self._warned_mismatch:
+                            warnings.warn(
+                                f"legend entry {entry.name!r} ({entry.kind}) "
+                                "differs between axes; group uses first occurrence",
+                                UserWarning,
+                                stacklevel=2,
+                            )
+                            self._warned_mismatch = True
+                        continue
+                    seen[key] = entry
+                    order.append(key)
+
+        if self._collect is not None:
+            # Stable sort by the user's collect order; ties (same name with
+            # different kinds) stay in the order they were encountered.
+            order.sort(key=lambda k: (self._collect.index(k[0]), 0))
+
+        for key in order:
+            self._render_entry(seen[key])
+
+    def _render_entry(self, entry: LegendEntry) -> None:
+        """Route to add_legend (categorical) or add_colorbar (continuous)."""
+        if entry.kind == "hue" and is_continuous_hue(entry.handles):
+            mappable = entry.handles[0]
+            self.add_colorbar(mappable=mappable, label=entry.name)
+        else:
+            self.add_legend(
+                handles=list(entry.handles),
+                label=entry.name,
+            )
 
     def add_legend(
         self,

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -7,7 +7,7 @@ axes in the same figure. This is the primary tool for complex subplot
 layouts.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from matplotlib.axes import Axes
 from matplotlib.legend import Legend
@@ -21,30 +21,28 @@ class MultiAxesLegendGroup:
     """
     Unified legend column across multiple axes.
 
-    All elements share a single mm-based layout anchored to `anchor`. Each
-    element can be attached to a different axes (via `ax=` on add_* calls)
-    for hit-testing and picking; its POSITION is always computed against
-    the anchor's right edge regardless of which axes owns the artist.
+    All elements share a single mm-based layout anchored to ``anchor``. Each
+    element can be attached to a different axes (via ``ax=`` on ``add_*``
+    calls) for hit-testing and picking; its POSITION is always computed
+    against the anchor's right edge regardless of which axes owns the artist.
 
     Parameters
     ----------
     anchor : Axes
         The axes whose right edge defines x=0 for the shared column.
+    collect : list or tuple of str, optional
+        Names of entries to auto-collect from across the grid's stashed
+        ``LegendEntry`` objects. ``None`` (default) collects everything.
+        A list filters and orders — e.g. ``collect=['treatment', 'dose']``
+        renders only those two names, in that order.
     x_offset, y_offset, gap, column_spacing, vpad, max_width
-        Same meaning as LegendBuilder — all in millimeters.
-
-    Examples
-    --------
-    >>> fig, axes = plt.subplots(1, 3, figsize=(12, 3))
-    >>> group = pp.legend_group(anchor=axes[0])
-    >>> group.add_legend(handles_a, label="Treatment", ax=axes[0])
-    >>> group.add_legend(handles_b, label="Dose",      ax=axes[1])
-    >>> group.add_colorbar(mappable, ax=axes[2])
+        Same meaning as :class:`LegendBuilder` — all in millimeters.
     """
 
     def __init__(
         self,
         anchor: Axes,
+        collect: Optional[Sequence[str]] = None,
         x_offset: float = 2,
         y_offset: Optional[float] = None,
         gap: float = 2,
@@ -53,6 +51,17 @@ class MultiAxesLegendGroup:
         max_width: Optional[float] = None,
     ):
         self.anchor = anchor
+        if collect is not None:
+            if isinstance(collect, str) or not hasattr(collect, "__iter__"):
+                raise TypeError(
+                    "collect must be None or a list/tuple of names; "
+                    "got a bare string. Wrap in a list: collect=['name']"
+                )
+            collect = list(collect)
+        self._collect = collect
+        # Track whether _materialize has already run (set by Task 3).
+        self._materialized = False
+        self._warned_mismatch = False
         # anchor_ax=anchor pins position math/reactor to the anchor regardless
         # of self.ax swaps during add_* calls.
         self._builder = LegendBuilder(
@@ -64,11 +73,16 @@ class MultiAxesLegendGroup:
             column_spacing=column_spacing,
             vpad=vpad,
             max_width=max_width,
-            # Legend_group overlays are external to any single axes' footprint.
-            # SubplotsAutoLayout excludes them from tightbbox so the figure's
-            # `legend_column` is the only reservation counting this legend's width.
             external_to_axis=True,
         )
+        # Register on the figure so plot functions can check claims.
+        anchor.get_figure()._publiplots_legend_group = self
+
+    def claims(self, name: str) -> bool:
+        """True if the group will render an entry with this name."""
+        if self._collect is None:
+            return True
+        return name in self._collect
 
     def add_legend(
         self,
@@ -113,6 +127,7 @@ class MultiAxesLegendGroup:
 def legend_group(
     anchor: Axes,
     *,
+    collect: Optional[Sequence[str]] = None,
     x_offset: float = 2,
     y_offset: Optional[float] = None,
     gap: float = 2,
@@ -120,9 +135,13 @@ def legend_group(
     vpad: float = 5,
     max_width: Optional[float] = None,
 ) -> MultiAxesLegendGroup:
-    """Create a shared legend column anchored to `anchor`. See MultiAxesLegendGroup."""
+    """Create a shared legend column anchored to ``anchor``.
+
+    See :class:`MultiAxesLegendGroup` for parameter docs.
+    """
     return MultiAxesLegendGroup(
         anchor=anchor,
+        collect=collect,
         x_offset=x_offset,
         y_offset=y_offset,
         gap=gap,

--- a/tests/test_legend_entries.py
+++ b/tests/test_legend_entries.py
@@ -1,0 +1,124 @@
+"""Tests for legend_entries.py — entries, stashing, flag resolution."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+    is_continuous_hue,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+class _FakeHandle:
+    def __init__(self, fc="red"):
+        self._fc = fc
+    def get_facecolor(self):
+        return self._fc
+
+
+def test_legend_entry_build_is_deterministic():
+    e1 = LegendEntry.build("g", "hue", [_FakeHandle("red")], ["A"])
+    e2 = LegendEntry.build("g", "hue", [_FakeHandle("red")], ["A"])
+    assert e1.signature == e2.signature
+
+
+def test_legend_entry_different_handles_differ():
+    e1 = LegendEntry.build("g", "hue", [_FakeHandle("red")], ["A"])
+    e2 = LegendEntry.build("g", "hue", [_FakeHandle("blue")], ["A"])
+    assert e1.signature != e2.signature
+
+
+def test_legend_entry_name_and_kind_preserved():
+    e = LegendEntry.build("treatment", "size", [], [])
+    assert e.name == "treatment"
+    assert e.kind == "size"
+    assert e.handles == ()
+    assert e.labels == ()
+
+
+def test_stash_entry_creates_list_first_time():
+    fig, ax = plt.subplots()
+    assert get_entries(ax) == []
+    stash_entry(ax, LegendEntry.build("g", "hue", [], []))
+    assert len(get_entries(ax)) == 1
+
+
+def test_stash_entry_appends_in_order():
+    fig, ax = plt.subplots()
+    stash_entry(ax, LegendEntry.build("g1", "hue", [], []))
+    stash_entry(ax, LegendEntry.build("g2", "size", [], []))
+    names = [e.name for e in get_entries(ax)]
+    assert names == ["g1", "g2"]
+
+
+def test_resolve_legend_flags_true():
+    flags = resolve_legend_flags(True)
+    assert flags == {"hue": True, "size": True, "style": True, "marker": True}
+
+
+def test_resolve_legend_flags_false():
+    flags = resolve_legend_flags(False)
+    assert flags == {"hue": False, "size": False, "style": False, "marker": False}
+
+
+def test_resolve_legend_flags_dict_partial_missing_defaults_to_true():
+    flags = resolve_legend_flags({"hue": False})
+    assert flags == {"hue": False, "size": True, "style": True, "marker": True}
+
+
+def test_resolve_legend_flags_dict_full():
+    flags = resolve_legend_flags({"hue": True, "size": False, "style": False, "marker": False})
+    assert flags == {"hue": True, "size": False, "style": False, "marker": False}
+
+
+def test_resolve_legend_flags_rejects_bad_type():
+    with pytest.raises(TypeError, match="legend must be bool or dict"):
+        resolve_legend_flags(1)
+
+
+def test_entry_is_in_group_no_group():
+    fig, ax = plt.subplots()
+    entry = LegendEntry.build("g", "hue", [], [])
+    assert entry_is_in_group(fig, entry) is False
+
+
+def test_entry_is_in_group_with_claim():
+    """entry_is_in_group delegates to group.claims(name) — mock one."""
+    fig, ax = plt.subplots()
+    entry = LegendEntry.build("treatment", "hue", [], [])
+
+    class _FakeGroup:
+        def claims(self, name):
+            return name == "treatment"
+
+    fig._publiplots_legend_group = _FakeGroup()
+    assert entry_is_in_group(fig, entry) is True
+
+    other = LegendEntry.build("other", "hue", [], [])
+    assert entry_is_in_group(fig, other) is False
+
+
+def test_is_continuous_hue_true_for_scalar_mappable():
+    from matplotlib.cm import ScalarMappable
+    from matplotlib.colors import Normalize
+    sm = ScalarMappable(cmap="viridis", norm=Normalize(0, 1))
+    assert is_continuous_hue([sm]) is True
+
+
+def test_is_continuous_hue_false_for_empty():
+    assert is_continuous_hue([]) is False
+
+
+def test_is_continuous_hue_false_for_regular_handles():
+    assert is_continuous_hue([_FakeHandle()]) is False

--- a/tests/test_legend_entries.py
+++ b/tests/test_legend_entries.py
@@ -122,3 +122,30 @@ def test_is_continuous_hue_false_for_empty():
 
 def test_is_continuous_hue_false_for_regular_handles():
     assert is_continuous_hue([_FakeHandle()]) is False
+
+
+def test_pp_legend_auto_reads_new_store():
+    """pp.legend(ax) in auto mode should render from stashed LegendEntry."""
+    import matplotlib.pyplot as plt
+    import publiplots as pp
+    from publiplots.utils.legend import create_legend_handles
+
+    fig, ax = pp.subplots(axes_size=(60, 40))
+    ax.scatter([0, 1, 2], [0, 1, 0])
+    stash_entry(
+        ax,
+        LegendEntry.build(
+            "group", "hue",
+            handles=create_legend_handles(
+                labels=["A", "B"], colors=["#111", "#222"],
+                alpha=0.5, linewidth=1.0,
+            ),
+            labels=("A", "B"),
+        ),
+    )
+    builder = pp.legend(ax)  # auto mode
+    fig.canvas.draw()
+    # At least one legend artist should exist on the axes now.
+    from matplotlib.legend import Legend
+    legends = [c for c in ax.get_children() if isinstance(c, Legend)]
+    assert len(legends) >= 1

--- a/tests/test_legend_group_auto_collect.py
+++ b/tests/test_legend_group_auto_collect.py
@@ -42,3 +42,125 @@ def test_legend_group_rejects_bare_string_collect():
     fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
     with pytest.raises(TypeError, match="list/tuple"):
         pp.legend_group(anchor=axes[-1], collect="treatment")
+
+
+# ---------------------------------------------------------------------------
+# _materialize — auto-collection
+# ---------------------------------------------------------------------------
+
+from matplotlib.patches import Rectangle
+
+from publiplots.utils.legend_entries import LegendEntry, stash_entry
+
+
+def _stub_handle(color="red", label="A"):
+    """Real matplotlib Rectangle so it both hashes (get_facecolor) and renders (get_label)."""
+    return Rectangle((0, 0), 1, 1, facecolor=color, label=label)
+
+
+def _stash_on_axes(ax, name, kind, color="red", labels=("A",)):
+    entry = LegendEntry.build(
+        name=name, kind=kind,
+        handles=[_stub_handle(color, label=lab) for lab in labels],
+        labels=labels,
+    )
+    stash_entry(ax, entry)
+
+
+def test_materialize_dedups_identical_entries_across_axes():
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    _stash_on_axes(axes[1], "treatment", "hue")
+    _stash_on_axes(axes[2], "treatment", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    group._materialize()
+    # Only one legend element added to the builder (not 3).
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 1
+
+
+def test_materialize_collects_distinct_names_across_axes():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    _stash_on_axes(axes[1], "dose", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 2
+
+
+def test_materialize_with_collect_filter_drops_unlisted_names():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    _stash_on_axes(axes[1], "dose", "hue")
+    group = pp.legend_group(anchor=axes[-1], collect=["treatment"])
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 1
+
+
+def test_materialize_collect_list_preserves_order():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "dose", "hue")
+    _stash_on_axes(axes[1], "treatment", "hue")
+    # First-in-axes-order is dose; but collect says treatment first.
+    group = pp.legend_group(anchor=axes[-1], collect=["treatment", "dose"])
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    assert len(legend_elements) == 2
+    # Legend.get_title().get_text() gives the "label" of each legend.
+    titles = [e[1].get_title().get_text() for e in legend_elements]
+    assert titles == ["treatment", "dose"]
+
+
+def test_materialize_is_idempotent():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    group._materialize()
+    count_after_first = len(group._builder.elements)
+    group._materialize()
+    count_after_second = len(group._builder.elements)
+    assert count_after_first == count_after_second
+
+
+def test_materialize_mismatched_signature_warns_once():
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue", color="red")
+    _stash_on_axes(axes[1], "treatment", "hue", color="blue")   # different palette
+    _stash_on_axes(axes[2], "treatment", "hue", color="green")  # yet another
+    group = pp.legend_group(anchor=axes[-1])
+    with pytest.warns(UserWarning, match="differs between axes"):
+        group._materialize()
+    # Warn-once: calling _materialize again should not re-warn.
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)  # fail if any warning fires
+        # Reset the _materialized flag so it re-runs the collection
+        group._materialized = False
+        group._materialize()  # must not warn again
+
+
+def test_materialize_no_publiplots_axes_is_noop():
+    """Group on a plt.subplots figure (no _publiplots_axes) must not crash."""
+    fig, ax = plt.subplots()
+    group = pp.legend_group(anchor=ax)
+    group._materialize()
+    assert group._builder.elements == []
+
+
+def test_materialize_manual_and_auto_coexist():
+    from publiplots.utils.legend import create_legend_handles
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    _stash_on_axes(axes[0], "treatment", "hue")
+    group = pp.legend_group(anchor=axes[-1])
+    # Manual add BEFORE materialize
+    group.add_legend(
+        handles=create_legend_handles(labels=["x"], colors=["#000"], alpha=0.5, linewidth=1.0),
+        label="manual",
+    )
+    # Now materialize
+    group._materialize()
+    legend_elements = [e for e in group._builder.elements if e[0] == "legend"]
+    # One manual + one auto-collected treatment entry.
+    assert len(legend_elements) == 2

--- a/tests/test_legend_group_auto_collect.py
+++ b/tests/test_legend_group_auto_collect.py
@@ -1,0 +1,44 @@
+"""Tests for MultiAxesLegendGroup auto-collect (PR #81)."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Claims + figure registration
+# ---------------------------------------------------------------------------
+
+
+def test_legend_group_registers_on_figure():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    group = pp.legend_group(anchor=axes[-1])
+    assert fig._publiplots_legend_group is group
+
+
+def test_legend_group_claims_collect_none_returns_true():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    group = pp.legend_group(anchor=axes[-1])
+    assert group.claims("anything") is True
+    assert group.claims("other") is True
+
+
+def test_legend_group_claims_with_collect_list():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    group = pp.legend_group(anchor=axes[-1], collect=["treatment"])
+    assert group.claims("treatment") is True
+    assert group.claims("dose") is False
+
+
+def test_legend_group_rejects_bare_string_collect():
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    with pytest.raises(TypeError, match="list/tuple"):
+        pp.legend_group(anchor=axes[-1], collect="treatment")

--- a/tests/test_scatter_legend_stash.py
+++ b/tests/test_scatter_legend_stash.py
@@ -87,3 +87,24 @@ def test_scatterplot_no_group_renders_per_axis_legend():
     fig.canvas.draw()
     per_axis_legends = [c for c in ax.get_children() if isinstance(c, Legend)]
     assert len(per_axis_legends) >= 1
+
+
+# ---------------------------------------------------------------------------
+# stripplot migration
+# ---------------------------------------------------------------------------
+
+
+def test_stripplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.stripplot(data=df, x="g", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_stripplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.stripplot(
+        data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
+    )
+    assert get_entries(ax) == []

--- a/tests/test_scatter_legend_stash.py
+++ b/tests/test_scatter_legend_stash.py
@@ -129,3 +129,24 @@ def test_swarmplot_legend_false_stashes_nothing():
         data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
     )
     assert get_entries(ax) == []
+
+
+# ---------------------------------------------------------------------------
+# pointplot migration
+# ---------------------------------------------------------------------------
+
+
+def test_pointplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.pointplot(data=df, x="g", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_pointplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.pointplot(
+        data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
+    )
+    assert get_entries(ax) == []

--- a/tests/test_scatter_legend_stash.py
+++ b/tests/test_scatter_legend_stash.py
@@ -1,0 +1,89 @@
+"""Tests for scatterplot legend stashing via LegendEntry."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import pytest
+
+import publiplots as pp
+from publiplots.utils.legend_entries import get_entries
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _scatter_df(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 30
+    return pd.DataFrame({
+        "x": rng.normal(size=n),
+        "y": rng.normal(size=n),
+        "g": rng.choice(["A", "B", "C"], size=n),
+        "m": rng.uniform(1, 5, size=n),
+    })
+
+
+def test_scatterplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_scatterplot_stashes_size_entry():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(data=df, x="x", y="y", size="m")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("m", "size") in names_kinds
+
+
+def test_scatterplot_legend_dict_suppresses_hue():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(
+        data=df, x="x", y="y", hue="g", size="m",
+        palette="pastel",
+        legend={"hue": False},
+    )
+    entries = get_entries(ax)
+    names = [e.name for e in entries]
+    # hue is suppressed, size is still stashed
+    assert "g" not in names
+    assert "m" in names
+
+
+def test_scatterplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(
+        data=df, x="x", y="y", hue="g", size="m",
+        palette="pastel",
+        legend=False,
+    )
+    assert get_entries(ax) == []
+
+
+def test_scatterplot_in_group_suppresses_per_axis_render():
+    """With a legend_group active, the scatter should NOT attach a per-axis
+    Legend artist to ax (the group handles it)."""
+    from matplotlib.legend import Legend
+    df = _scatter_df()
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 40))
+    pp.legend_group(anchor=axes[-1])
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[0])
+    fig.canvas.draw()
+    per_axis_legends = [c for c in axes[0].get_children() if isinstance(c, Legend)]
+    assert per_axis_legends == []
+
+
+def test_scatterplot_no_group_renders_per_axis_legend():
+    from matplotlib.legend import Legend
+    df = _scatter_df()
+    fig, ax = pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel")
+    fig.canvas.draw()
+    per_axis_legends = [c for c in ax.get_children() if isinstance(c, Legend)]
+    assert len(per_axis_legends) >= 1

--- a/tests/test_scatter_legend_stash.py
+++ b/tests/test_scatter_legend_stash.py
@@ -108,3 +108,24 @@ def test_stripplot_legend_false_stashes_nothing():
         data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
     )
     assert get_entries(ax) == []
+
+
+# ---------------------------------------------------------------------------
+# swarmplot migration
+# ---------------------------------------------------------------------------
+
+
+def test_swarmplot_stashes_hue_entry():
+    df = _scatter_df()
+    fig, ax = pp.swarmplot(data=df, x="g", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_swarmplot_legend_false_stashes_nothing():
+    df = _scatter_df()
+    fig, ax = pp.swarmplot(
+        data=df, x="g", y="y", hue="g", palette="pastel", legend=False,
+    )
+    assert get_entries(ax) == []

--- a/tests/test_subplots.py
+++ b/tests/test_subplots.py
@@ -289,7 +289,7 @@ def test_auto_layout_locked_side_not_remeasured():
 def test_auto_layout_no_hook_when_all_sides_locked():
     layout = _make_layout()
     fig, _ = _make_fig_with_layout(layout)
-    all_sides = {"title_space", "xlabel_space", "ylabel_space", "right"}
+    all_sides = {"title_space", "xlabel_space", "ylabel_space", "right", "legend_column"}
     reactor = SubplotsAutoLayout(fig, layout, locked=all_sides)
     # No draw-event callback should be connected
     assert reactor._cid is None
@@ -455,11 +455,15 @@ def test_subplots_sharex_row_shares_within_row_only():
 
 
 def test_subplots_all_locked_skips_hook():
+    # Even with all four per-side reservations locked via kwargs,
+    # legend_column is still auto-measured (width-awareness, Task 5),
+    # so the draw-event hook must remain attached. Users cannot lock
+    # legend_column from pp.subplots(); it is always auto.
     fig, ax = pp.subplots(
         axes_size=(50, 30),
         title_space=5, xlabel_space=8, ylabel_space=10, right=2,
     )
-    assert fig._publiplots_auto_layout._cid is None
+    assert fig._publiplots_auto_layout._cid is not None
 
 
 def test_subplots_any_auto_side_attaches_hook():
@@ -612,4 +616,61 @@ def test_barplot_with_figsize_uses_matplotlib_fallback():
     # Explicit figsize → matplotlib path → no publiplots layout attached.
     assert not hasattr(fig, "_publiplots_layout"), (
         "explicit figsize should use plt.subplots (publiplots layout unexpectedly present)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Width-awareness: legend_column auto-sizing
+# ---------------------------------------------------------------------------
+
+from publiplots.utils.legend_entries import LegendEntry, stash_entry
+
+
+def _stub_handle(color="red"):
+    class H:
+        def __init__(self, c):
+            self._c = c
+        def get_facecolor(self):
+            return self._c
+    return H(color)
+
+
+def test_legend_column_is_zero_without_group():
+    fig, ax = pp.subplots(axes_size=(50, 30))
+    # No pp.legend_group call.
+    fig.canvas.draw()
+    assert fig._publiplots_layout.legend_column == 0.0
+
+
+def test_legend_column_auto_grows_with_group():
+    from publiplots.utils.legend import create_legend_handles
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    # Stash so auto-collect picks something up
+    stash_entry(
+        axes[0],
+        LegendEntry.build(
+            "g", "hue",
+            handles=create_legend_handles(labels=["A", "B"], colors=["#000", "#fff"],
+                                          alpha=0.5, linewidth=1.0),
+            labels=("A", "B"),
+        ),
+    )
+    pp.legend_group(anchor=axes[-1])
+    fig.savefig("/tmp/test_legend_column_auto.png")
+    layout = fig._publiplots_layout
+    assert layout.legend_column > 5.0, (
+        f"legend_column should have grown; got {layout.legend_column}"
+    )
+
+
+def test_legend_column_stays_small_with_empty_group():
+    """No stashed entries and no manual adds -> group has no artists ->
+    legend_column stays near zero."""
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    pp.legend_group(anchor=axes[-1])
+    # No stashing, no manual add_legend calls.
+    fig.savefig("/tmp/test_legend_column_empty.png")
+    layout = fig._publiplots_layout
+    assert layout.legend_column < 2.0, (
+        f"legend_column should stay near 0; got {layout.legend_column}"
     )

--- a/tests/test_subplots.py
+++ b/tests/test_subplots.py
@@ -431,18 +431,9 @@ def test_subplots_validates_negative_reservation():
         pp.subplots(axes_size=(50, 30), title_space=-1.0)
 
 
-def test_subplots_legend_column_reserves_extra_width():
-    fig_no_col, _ = pp.subplots(axes_size=(50, 30), legend_column=0,
-                                title_space=5, xlabel_space=8,
-                                ylabel_space=10, right=2,
-                                hspace=8, wspace=10, outer_pad=2)
-    fig_with_col, _ = pp.subplots(axes_size=(50, 30), legend_column=30,
-                                  title_space=5, xlabel_space=8,
-                                  ylabel_space=10, right=2,
-                                  hspace=8, wspace=10, outer_pad=2)
-    w_no = fig_no_col.get_figwidth()
-    w_with = fig_with_col.get_figwidth()
-    assert w_with == pytest.approx(w_no + 30 * MM2INCH, abs=1e-3)
+def test_subplots_rejects_legend_column_kwarg():
+    with pytest.raises(TypeError, match="legend_column"):
+        pp.subplots(axes_size=(50, 30), legend_column=30)
 
 
 def test_subplots_sharex_true_shares_all():
@@ -549,7 +540,7 @@ def test_auto_layout_excludes_legend_group_from_tightbbox():
     """pp.legend_group anchors a legend external to the axes — its width
     is handled by legend_column, not the column's `right` reservation."""
     from publiplots.utils.legend import create_legend_handles
-    fig, axes = pp.subplots(1, 3, axes_size=(45, 30), legend_column=30)
+    fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
     for ax in axes:
         ax.plot([0, 1, 2], [0, 1, 0])
     group = pp.legend_group(anchor=axes[-1])


### PR DESCRIPTION
## Summary

Two coordinated pieces finalize publiplots' "everything is automatic" legend story:

1. **Auto-collect.** `pp.legend_group(anchor=...)` walks the grid, gathers stashed `LegendEntry` objects across all axes, dedups by `(name, kind)`, and renders one unified legend. Users no longer construct `handles=[...]` manually for the common case.
2. **Width-awareness.** `SubplotsAutoLayout` measures the rendered legend_group width and grows `FigureLayout.legend_column` to fit. The `legend_column` kwarg is dropped from `pp.subplots()` entirely.

Legend width is now fully automatic — no more hand-tuned `legend_column=N` guess.

```python
fig, axes = pp.subplots(1, 3)
pp.scatterplot(data=df, x="x", y="y", hue="g", ax=axes[0])
pp.scatterplot(data=df, x="x", y="y", hue="g", ax=axes[1])
pp.scatterplot(data=df, x="x", y="y", hue="g", ax=axes[2])
pp.legend_group(anchor=axes[-1])   # zero kwargs
```

The `legend=` kwarg on plot functions now also accepts `dict[kind, bool]` for per-kind control (e.g. `legend=dict(hue=False)` shows only the size legend).

Verified demo: `legend_column` auto-sized to 13.7 mm; figure width 197 mm; no manual inputs.

## Breaking changes

- `pp.subplots(legend_column=N)` raises `TypeError`. Attach `pp.legend_group(anchor=...)` instead.
- Plot functions accept `legend=` as `bool | dict[kind, bool]`. `True` / `False` unchanged; `dict` is new.
- The draw-event hook on `pp.subplots()` now always attaches (not skippable), because `legend_column` can't be user-locked.

## Scope

**Infrastructure**
- `LegendEntry`, `stash_entry`, `get_entries`, `resolve_legend_flags`, `entry_is_in_group`, `is_continuous_hue` (`src/publiplots/utils/legend_entries.py`)
- `MultiAxesLegendGroup` gains `collect=`, `claims()`, `_materialize()`, figure registration
- `SubplotsAutoLayout._measure_legend_column` auto-grows `FigureLayout.legend_column`
- `pp.legend(ax)` auto-mode prefers new store with legacy dict fallback

**Plot migrations (4 of 9)**
- `scatterplot`, `stripplot`, `swarmplot`, `pointplot` → use `LegendEntry` stash

## Deferred

Migrations for `bar`, `box`, `violin`, `raincloud`, `heatmap` — those plots render legends inline today and need a per-plot refactor. Documented in spec as explicit non-goal. Until their follow-up PRs, users fall back to manual `group.add_legend(handles=...)` for those plot types. No regression vs pre-PR-#81 behavior for them.

## Follow-up items

- Migrate remaining 5 plot types to `LegendEntry` stash (one PR or grouped)
- Revisit `_ALL_SIDES` membership commentary now that `legend_column` cannot be user-locked
- Rename `tests/test_scatter_legend_stash.py` → `test_plot_legend_stashing.py` as more plots migrate

## Test plan

- [x] Full suite: **164 passing** (121 baseline + 43 new).
- [x] All 14 gallery examples smoke-run clean.
- [x] End-to-end demo: `pp.legend_group(anchor=axes[-1])` with zero kwargs → `legend_column` auto-sized to measured group width.
- [x] `pp.subplots(legend_column=30)` → `TypeError` mentioning `legend_column`.
- [x] `pp.legend_group(collect='treatment')` → `TypeError` mentioning `list/tuple`.
- [x] Per-axis `pp.legend(ax)` still works; width flows into per-column `right` reservation unchanged.
- [x] Mixed grids (migrated + unmigrated plots) still render via legacy fallback.