### PR TITLE
feat(legend): migrate box/violin/raincloud to stash pattern

### DIFF
--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -303,8 +303,7 @@ def _stash_legend(
         return
 
     flags = resolve_legend_flags(legend)
-    legend_kws = dict(legend_kws or {})
-    hue_label = legend_kws.pop("label", hue)
+    hue_label = (legend_kws or {}).get("hue_label", hue)
 
     if flags["hue"]:
         labels = list(palette.keys())
@@ -329,7 +328,7 @@ def _stash_legend(
     fig = ax.get_figure()
     to_render = [
         e for e in get_entries(ax)
-        if flags.get(e.kind, True) and not entry_is_in_group(fig, e)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
     ]
     if not to_render:
         return
@@ -338,5 +337,4 @@ def _stash_legend(
         builder.add_legend(
             handles=list(entry.handles),
             label=entry.name,
-            **legend_kws,
         )

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -112,8 +112,9 @@ def boxplot(
         X-axis label.
     ylabel : str, default=""
         Y-axis label.
-    legend : bool, default=True
-        Whether to show the legend.
+    legend : bool or dict, default=True
+        Whether to show the legend. Accepts ``bool`` or ``dict[kind, bool]``
+        for per-kind control (e.g., ``legend={"hue": False}``).
     legend_kws : dict, optional
         Additional keyword arguments for legend.
     **kwargs
@@ -303,7 +304,8 @@ def _stash_legend(
         return
 
     flags = resolve_legend_flags(legend)
-    hue_label = (legend_kws or {}).get("hue_label", hue)
+    legend_kws = dict(legend_kws or {})
+    hue_label = legend_kws.pop("hue_label", hue)
 
     if flags["hue"]:
         labels = list(palette.keys())

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -18,7 +18,15 @@ import numpy as np
 
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.utils.transparency import ArtistTracker
-from publiplots.utils import is_categorical
+from publiplots.utils import is_categorical, create_legend_handles
+from publiplots.utils.legend import legend as legend_fn
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+)
 
 
 def boxplot(
@@ -45,7 +53,7 @@ def boxplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
     **kwargs
 ) -> Tuple[plt.Figure, Axes]:
@@ -256,22 +264,18 @@ def boxplot(
             fc = line.get_markerfacecolor()
             line.set_markerfacecolor(to_rgba(fc, alpha))
 
-    # Add legend if hue is used
-    if legend and hue is not None:
-        from publiplots.utils.legend import legend as pp_legend
-        from publiplots.utils.legend import create_legend_handles
-
-        palette_colors = list(palette.values()) if isinstance(palette, dict) else None
-        handles = create_legend_handles(
-            labels=list(palette.keys()) if isinstance(palette, dict) else None,
-            colors=palette_colors,
-            edgecolors=[resolved_edgecolor] * len(palette) if resolved_edgecolor and isinstance(palette, dict) else None,
-            alpha=alpha,
-            linewidth=linewidth,
-        )
-
-        legend_kwargs = legend_kws or dict(label=hue)
-        pp_legend(ax, handles=handles, **legend_kwargs)
+    # Stash legend entries and optionally render per-axis legend.
+    # legend may be bool or dict[str, bool]; False short-circuits both.
+    _stash_legend(
+        ax=ax,
+        hue=hue,
+        palette=palette,
+        edgecolor=resolved_edgecolor,
+        alpha=alpha,
+        linewidth=linewidth,
+        legend=legend,
+        legend_kws=legend_kws,
+    )
 
     # Set labels
     if xlabel is not None:
@@ -282,3 +286,57 @@ def boxplot(
         ax.set_title(title)
 
     return fig, ax
+
+
+def _stash_legend(
+        ax: Axes,
+        hue: Optional[str],
+        palette: Optional[Union[str, Dict, List]],
+        edgecolor: Optional[str],
+        alpha: Optional[float],
+        linewidth: Optional[float],
+        legend: Union[bool, Dict],
+        legend_kws: Optional[Dict],
+    ) -> None:
+    """Stash one hue LegendEntry and optionally render it per-axis."""
+    if legend is False or hue is None or not isinstance(palette, dict):
+        return
+
+    flags = resolve_legend_flags(legend)
+    legend_kws = dict(legend_kws or {})
+    hue_label = legend_kws.pop("label", hue)
+
+    if flags["hue"]:
+        labels = list(palette.keys())
+        handles = create_legend_handles(
+            labels=labels,
+            colors=list(palette.values()),
+            edgecolors=[edgecolor] * len(palette) if edgecolor else None,
+            alpha=alpha,
+            linewidth=linewidth,
+        )
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=hue_label,
+                kind="hue",
+                handles=handles,
+                labels=labels,
+            ),
+        )
+
+    # Render per-axis only for entries not claimed by a figure-level group.
+    fig = ax.get_figure()
+    to_render = [
+        e for e in get_entries(ax)
+        if flags.get(e.kind, True) and not entry_is_in_group(fig, e)
+    ]
+    if not to_render:
+        return
+    builder = legend_fn(ax=ax, auto=False)
+    for entry in to_render:
+        builder.add_legend(
+            handles=list(entry.handles),
+            label=entry.name,
+            **legend_kws,
+        )

--- a/src/publiplots/plot/raincloud.py
+++ b/src/publiplots/plot/raincloud.py
@@ -161,8 +161,12 @@ def raincloudplot(
     ...     data=df, x="category", y="value", hue="group"
     ... )
     """
-    # Read defaults from rcParams if not provided
-    figsize = resolve_param("figure.figsize", figsize)
+    # Read defaults from rcParams if not provided.
+    # Deliberately do NOT fall back on rcParams["figure.figsize"] for the
+    # figsize argument: when figsize is None, the inner violinplot call takes
+    # the pp.subplots() path and SubplotsAutoLayout grows the figure to fit
+    # the legend. Forcing a default figsize here would route us through
+    # plt.subplots(figsize=...), skipping auto-layout and cropping the legend.
     linewidth = resolve_param("lines.linewidth", linewidth)
     cloud_alpha = resolve_param("alpha", cloud_alpha)
     color = resolve_param("color", color)

--- a/src/publiplots/plot/raincloud.py
+++ b/src/publiplots/plot/raincloud.py
@@ -59,7 +59,7 @@ def raincloudplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
 ) -> Tuple[plt.Figure, Axes]:
     """
@@ -134,8 +134,10 @@ def raincloudplot(
         X-axis label.
     ylabel : str, default=""
         Y-axis label.
-    legend : bool, default=True
-        Whether to show the legend.
+    legend : bool or dict, default=True
+        Whether to show the legend. Accepts the same ``bool | dict[kind, bool]``
+        form as the underlying violin plot; the value is forwarded to the
+        inner ``violinplot`` call, which owns the legend for the raincloud.
     legend_kws : dict, optional
         Additional keyword arguments for legend.
 

--- a/src/publiplots/plot/violin.py
+++ b/src/publiplots/plot/violin.py
@@ -144,8 +144,9 @@ def violinplot(
         X-axis label.
     ylabel : str, default=""
         Y-axis label.
-    legend : bool, default=True
-        Whether to show the legend.
+    legend : bool or dict, default=True
+        Whether to show the legend. Accepts ``bool`` or ``dict[kind, bool]``
+        for per-kind control (e.g., ``legend={"hue": False}``).
     legend_kws : dict, optional
         Additional keyword arguments for legend.
     side : str, default="both"
@@ -446,7 +447,8 @@ def _stash_legend(
         return
 
     flags = resolve_legend_flags(legend)
-    hue_label = (legend_kws or {}).get("hue_label", hue)
+    legend_kws = dict(legend_kws or {})
+    hue_label = legend_kws.pop("hue_label", hue)
 
     if flags["hue"]:
         labels = list(palette.keys())

--- a/src/publiplots/plot/violin.py
+++ b/src/publiplots/plot/violin.py
@@ -20,7 +20,15 @@ import pandas as pd
 import numpy as np
 
 from publiplots.themes.colors import resolve_palette_map
-from publiplots.utils import is_categorical
+from publiplots.utils import is_categorical, create_legend_handles
+from publiplots.utils.legend import legend as legend_fn
+from publiplots.utils.legend_entries import (
+    LegendEntry,
+    stash_entry,
+    get_entries,
+    resolve_legend_flags,
+    entry_is_in_group,
+)
 from publiplots.utils.transparency import ArtistTracker
 
 
@@ -56,7 +64,7 @@ def violinplot(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
-    legend: bool = True,
+    legend: Union[bool, Dict] = True,
     legend_kws: Optional[Dict] = None,
     side: str = "both",
     **kwargs
@@ -278,21 +286,18 @@ def violinplot(
             if isinstance(coll, FillBetweenPolyCollection):
                 coll.set_edgecolors(edgecolor)
 
-    # Add legend if hue is used
-    if legend and hue is not None:
-        from publiplots.utils.legend import legend as pp_legend
-        from publiplots.utils.legend import create_legend_handles
-
-        handles = create_legend_handles(
-            labels=list(palette.keys()) if isinstance(palette, dict) else None,
-            colors=list(palette.values()) if isinstance(palette, dict) else None,
-            edgecolors=[edgecolor] * len(palette) if edgecolor and isinstance(palette, dict) else None,
-            alpha=alpha,
-            linewidth=linewidth,
-        )
-
-        legend_kwargs = legend_kws or dict(label=hue)
-        pp_legend(ax, handles=handles, **legend_kwargs)
+    # Stash legend entries and optionally render per-axis legend.
+    # legend may be bool or dict[str, bool]; False short-circuits both.
+    _stash_legend(
+        ax=ax,
+        hue=hue,
+        palette=palette,
+        edgecolor=edgecolor,
+        alpha=alpha,
+        linewidth=linewidth,
+        legend=legend,
+        legend_kws=legend_kws,
+    )
 
     # Set labels
     if xlabel is not None:
@@ -424,3 +429,55 @@ def _side_clip_violin(
                 new_segments.append(new_segment)
 
             coll.set_segments(new_segments)
+
+
+def _stash_legend(
+        ax: Axes,
+        hue: Optional[str],
+        palette: Optional[Union[str, Dict, List]],
+        edgecolor: Optional[str],
+        alpha: Optional[float],
+        linewidth: Optional[float],
+        legend: Union[bool, Dict],
+        legend_kws: Optional[Dict],
+    ) -> None:
+    """Stash one hue LegendEntry and optionally render it per-axis."""
+    if legend is False or hue is None or not isinstance(palette, dict):
+        return
+
+    flags = resolve_legend_flags(legend)
+    hue_label = (legend_kws or {}).get("hue_label", hue)
+
+    if flags["hue"]:
+        labels = list(palette.keys())
+        handles = create_legend_handles(
+            labels=labels,
+            colors=list(palette.values()),
+            edgecolors=[edgecolor] * len(palette) if edgecolor else None,
+            alpha=alpha,
+            linewidth=linewidth,
+        )
+        stash_entry(
+            ax,
+            LegendEntry.build(
+                name=hue_label,
+                kind="hue",
+                handles=handles,
+                labels=labels,
+            ),
+        )
+
+    # Render per-axis only for entries not claimed by a figure-level group.
+    fig = ax.get_figure()
+    to_render = [
+        e for e in get_entries(ax)
+        if flags[e.kind] and not entry_is_in_group(fig, e)
+    ]
+    if not to_render:
+        return
+    builder = legend_fn(ax=ax, auto=False)
+    for entry in to_render:
+        builder.add_legend(
+            handles=list(entry.handles),
+            label=entry.name,
+        )

--- a/tests/test_box_legend_stash.py
+++ b/tests/test_box_legend_stash.py
@@ -1,0 +1,69 @@
+"""Tests for boxplot legend stashing via LegendEntry."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import pytest
+
+import publiplots as pp
+from publiplots.utils.legend_entries import get_entries
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _box_df(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 60
+    return pd.DataFrame({
+        "x": rng.choice(["A", "B", "C"], size=n),
+        "y": rng.normal(size=n),
+        "g": rng.choice(["ctrl", "trt"], size=n),
+    })
+
+
+def test_boxplot_stashes_hue_entry():
+    df = _box_df()
+    fig, ax = pp.boxplot(data=df, x="x", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_boxplot_no_hue_stashes_nothing():
+    df = _box_df()
+    fig, ax = pp.boxplot(data=df, x="x", y="y")
+    assert get_entries(ax) == []
+
+
+def test_boxplot_legend_false_stashes_nothing():
+    df = _box_df()
+    fig, ax = pp.boxplot(
+        data=df, x="x", y="y", hue="g", palette="pastel",
+        legend=False,
+    )
+    assert get_entries(ax) == []
+
+
+def test_boxplot_in_group_suppresses_per_axis_render():
+    from matplotlib.legend import Legend
+    df = _box_df()
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 40))
+    pp.legend_group(anchor=axes[-1])
+    pp.boxplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[0])
+    fig.canvas.draw()
+    per_axis_legends = [c for c in axes[0].get_children() if isinstance(c, Legend)]
+    assert per_axis_legends == []
+
+
+def test_boxplot_legend_dict_suppresses_hue():
+    df = _box_df()
+    fig, ax = pp.boxplot(
+        data=df, x="x", y="y", hue="g", palette="pastel",
+        legend={"hue": False},
+    )
+    assert get_entries(ax) == []

--- a/tests/test_raincloud_legend_group.py
+++ b/tests/test_raincloud_legend_group.py
@@ -1,0 +1,58 @@
+"""Integration tests for raincloudplot inside a pp.legend_group."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import pytest
+
+import publiplots as pp
+from publiplots.utils.legend_entries import get_entries
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _rain_df(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 90
+    return pd.DataFrame({
+        "condition": rng.choice(["Control", "Low", "High"], size=n),
+        "response": rng.normal(50, 8, size=n),
+    })
+
+
+def test_raincloud_in_group_stashes_via_violin():
+    """Raincloud forwards legend to its inner violin; the hue entry must land
+    on the same ax the user sees."""
+    from matplotlib.legend import Legend
+    df = _rain_df()
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 40))
+    pp.legend_group(anchor=axes[-1])
+    pp.raincloudplot(
+        data=df, x="condition", y="response", hue="condition",
+        palette="pastel", ax=axes[0],
+    )
+    fig.canvas.draw()
+    # Entry stashed on the raincloud axis (by the inner violin call)
+    names_kinds = [(e.name, e.kind) for e in get_entries(axes[0])]
+    assert ("condition", "hue") in names_kinds
+    # No per-axis legend artist (group claimed it)
+    per_axis_legends = [c for c in axes[0].get_children() if isinstance(c, Legend)]
+    assert per_axis_legends == []
+
+
+def test_raincloud_accepts_legend_dict():
+    """Type widening: legend=dict is accepted and forwarded to violin."""
+    df = _rain_df()
+    fig, ax = pp.subplots(axes_size=(50, 40))
+    # Should not raise a TypeError
+    pp.raincloudplot(
+        data=df, x="condition", y="response", hue="condition",
+        palette="pastel", legend={"hue": False}, ax=ax,
+    )
+    # With hue suppressed, nothing is stashed
+    assert get_entries(ax) == []

--- a/tests/test_violin_legend_stash.py
+++ b/tests/test_violin_legend_stash.py
@@ -1,0 +1,69 @@
+"""Tests for violinplot legend stashing via LegendEntry."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import pytest
+
+import publiplots as pp
+from publiplots.utils.legend_entries import get_entries
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _violin_df(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 120
+    return pd.DataFrame({
+        "x": rng.choice(["A", "B", "C"], size=n),
+        "y": rng.normal(size=n),
+        "g": rng.choice(["ctrl", "trt"], size=n),
+    })
+
+
+def test_violinplot_stashes_hue_entry():
+    df = _violin_df()
+    fig, ax = pp.violinplot(data=df, x="x", y="y", hue="g", palette="pastel")
+    entries = get_entries(ax)
+    names_kinds = [(e.name, e.kind) for e in entries]
+    assert ("g", "hue") in names_kinds
+
+
+def test_violinplot_no_hue_stashes_nothing():
+    df = _violin_df()
+    fig, ax = pp.violinplot(data=df, x="x", y="y")
+    assert get_entries(ax) == []
+
+
+def test_violinplot_legend_false_stashes_nothing():
+    df = _violin_df()
+    fig, ax = pp.violinplot(
+        data=df, x="x", y="y", hue="g", palette="pastel",
+        legend=False,
+    )
+    assert get_entries(ax) == []
+
+
+def test_violinplot_in_group_suppresses_per_axis_render():
+    from matplotlib.legend import Legend
+    df = _violin_df()
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 40))
+    pp.legend_group(anchor=axes[-1])
+    pp.violinplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=axes[0])
+    fig.canvas.draw()
+    per_axis_legends = [c for c in axes[0].get_children() if isinstance(c, Legend)]
+    assert per_axis_legends == []
+
+
+def test_violinplot_legend_dict_suppresses_hue():
+    df = _violin_df()
+    fig, ax = pp.violinplot(
+        data=df, x="x", y="y", hue="g", palette="pastel",
+        legend={"hue": False},
+    )
+    assert get_entries(ax) == []


### PR DESCRIPTION
## Summary

Extends the `LegendEntry` stash pattern from PR #81 (scatter/strip/swarm/point) to three more plot types, completing the first half of the phase-2 migration:

- **box, violin**: Inline legend block replaced with a `_stash_legend` helper (byte-identical between the two — will be deduplicated into a shared utility in PR B). Legend entries are now stashed on \`ax._publiplots_legend_entries\` and rendered per-axis only when not claimed by a figure-level \`pp.legend_group\`.
- **raincloud**: Legend parameter type widened to \`bool | dict[kind, bool]\`; no structural change — the inner \`violinplot\` call now does the stashing on behalf of the raincloud.
- All three plots' \`legend\` parameter accepts \`bool\` (old behavior) or a per-kind dict (new), matching the contract established in PR #81.

## Behavior note for downstream users

The migrated box and violin now route legend rendering through the publiplots \`legend_fn\` builder (as scatter/strip/swarm/point already do). User-supplied \`legend_kws\` keys other than \`hue_label\` are no longer forwarded to the underlying builder. Users who previously relied on \`legend_kws={"loc": "upper right"}\` or similar should configure legend layout via \`pp.legend_group\`, rcParams, or leave the defaults.

## Scope

- PR A (this PR): box, violin, raincloud — simple hue-only migrations.
- PR B (upcoming): bar, heatmap — multi-kind migrations (bar needs a new \`"hatch"\` kind; heatmap has both a colorbar and a size legend).

Tracked in \`docs/superpowers/specs/2026-05-01-legend-migration-phase2-design.md\`.

## Test plan

- [x] \`tests/test_box_legend_stash.py\` — 5 tests (stash shape, no-hue short-circuit, \`legend=False\`, group-claim suppression, \`legend={"hue": False}\`)
- [x] \`tests/test_violin_legend_stash.py\` — 5 tests, parallel coverage
- [x] \`tests/test_raincloud_legend_group.py\` — 2 integration tests (group claim via inner violin, \`dict\` accepted)
- [x] Full suite: 176 passed (164 baseline + 12 new)
- [x] Gallery smoke-run: all 14 \`examples/plots/*.py\` render without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)