### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-01
+
+### Added
+- `pp.subplots(nrows, ncols, axes_size=(w_mm, h_mm), ...)` — fixed-axes-size helper that grows the figure to fit auto-measured decorations (titles, labels, legends).
+- `pp.legend_group(anchor=ax)` auto-collects `LegendEntry` objects stashed by plotting functions; renders one unified legend on the right of the anchor axes with auto-measured column width. Works across scatter, strip, swarm, point, box, violin, raincloud, bar, and heatmap.
+- `"hatch"` as a new `_LEGEND_KINDS` entry — enables `legend={"hatch": False}` for per-kind suppression on bar plots' secondary split dimension.
+- `legend: bool | dict[kind, bool]` accepted on every plot function for per-kind legend control (e.g. `legend={"size": False}` on a dot heatmap keeps the colorbar, hides the size legend).
+- `LayoutReactor` — mm-based draw-event anchoring for colorbars and legend groups; recalibrates on figure resize without per-plot manual positioning.
+- `rcParams["edgecolor"]` as a global default for plot edges (was per-call only).
+- `external_to_axis` flag on reactor registrations so `legend_group` artists don't inflate per-axis tight-bbox measurements.
+- New gallery example `plot_14_edgecolor_control.py` and shared-legend demo panels in `plot_01_bar_plots.py`, `plot_02_scatter_plots.py`.
+
+### Changed
+- Plot functions now use `pp.subplots()` when `figsize` is not provided, installing `SubplotsAutoLayout` for auto-sizing. Users who pass `figsize=` still get the legacy `plt.subplots` path (see [Known issues]).
+- Legend auto-mode reads the new `LegendEntry` store on each axes first, falling back to the legacy per-artist `_legend_data` attribute for backward compatibility.
+- Publication-first defaults unified — dropped the separate "notebook" style; all plots render at paper-ready dimensions by default.
+- Bulletproof legend builder: mm-based positioning with automatic column overflow and a per-axes singleton pattern.
+
+### Fixed
+- Legend auto-layout measurement now unions reactor-pinned figure-level text artists (e.g. colorbar titles) into the side-reservation calculation, so titles no longer crop on `savefig`.
+- `savefig` now settles layout before rendering — legend/title overflow is sized into the saved figure, not cropped post-hoc.
+- `raincloudplot` no longer injects `rcParams["figure.figsize"]` as a default, letting the inner `violinplot` take the `pp.subplots` path and auto-reserve legend space.
+- `violinplot` applies `edgecolor` to cloud `PolyCollection`s (previously seaborn's `linecolor` only touched inner stat lines).
+- Colorbar title now sits above the colorbar, not overlapping.
+- Gallery build preserves publiplots styling across sphinx-gallery runs.
+
+### Known issues
+- Plots called with explicit `figsize=(w_in, h_in)` still route through `plt.subplots(figsize=...)` and bypass `SubplotsAutoLayout`, which can crop legends and titles (e.g. the horizontal raincloud example in `plot_08`). Tracked for a dedicated cleanup PR that replaces `figsize=` with `axes_size=` across all plot functions.
+- `barplot` raises `IndexError` in the `hue-only` legend path (`hatch == categorical_axis`) when `len(hue) < len(categorical_axis)`. Workaround: match cardinalities in that specific layout. Tracked for a dedicated fix PR.
+
+[0.5.0]: https://github.com/jorgebotas/publiplots/releases/tag/v0.5.0
+
 ## [0.4.7] - 2026-04-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.4.7"
+version = "0.5.0"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.5.0"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
## Summary

Bumps version **0.4.7 → 0.5.0** (minor, substantial new public API).

Files:
- ``pyproject.toml`` — ``version = "0.5.0"``
- ``src/publiplots/__init__.py`` — ``__version__ = "0.5.0"``
- ``CHANGELOG.md`` — new 0.5.0 section grouping Added / Changed / Fixed / Known issues

## What shipped since 0.4.7

- **``pp.subplots(nrows, ncols, axes_size=(w_mm, h_mm))``** — fixed-axes helper that grows the figure to fit auto-measured decorations (PR #79).
- **``pp.legend_group(anchor=ax)`` auto-collection** — one call before plotting, the group collects stashed ``LegendEntry`` objects across subplots and renders a single unified legend (PR #81, PR #83, PR #84).
- **``legend: bool | dict[kind, bool]`` contract** — every plot function now accepts per-kind legend suppression (``legend={"size": False}``, ``legend={"hatch": False}``).
- **``"hatch"`` as a new legend kind** for bar's secondary split dimension.
- **Bulletproof legend builder + ``LayoutReactor``** — mm-based draw-event anchoring that recalibrates on figure resize (PR #78).
- **``rcParams["edgecolor"]``** as a global default (PR #77).
- **Unified publication-first defaults** — single style (PR #80).
- Shared ``_stash_legend`` helpers in ``src/publiplots/utils/plot_legend.py``; ~70 LOC of duplication removed across box/violin.

## Known issues (called out in CHANGELOG)
- ``figsize=`` on plot functions bypasses ``SubplotsAutoLayout`` → tracked for a follow-up cleanup PR.
- ``barplot`` ``IndexError`` in the ``hue-only`` legend path when ``len(hue) < len(categorical_axis)`` → tracked for a follow-up fix PR.

## Release plan

After merge, cut a GitHub Release with tag **``v0.5.0``** (switching from the old ``v.0.4.*`` convention — the leading ``v`` is standard, no dot after it). Creating the release triggers ``.github/workflows/publish.yml`` → PyPI.

## Test plan
- [x] Full test suite still 198 passed on this branch
- [x] Gallery smoke-run: all 14 ``examples/plots/*.py`` render clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)