### PR TITLE
fix(bar): IndexError when hatch==categorical_axis and len(hue) < n_axis

### DIFF
--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -450,10 +450,15 @@ def _apply_hatches_and_override_colors(
         # set_hatch_linewidth
         patch.set_hatch_linewidth(linewidth)
 
-        # Repaint the bars when needed (override colors if not using double split)
-        bar_color = palette[hue_order[hue_idx]] if hue is not None else color
+        # Repaint the bars when needed (override colors if not using double
+        # split AND hatch isn't the categorical axis). `hue_idx` is only a
+        # valid `hue_order` index on this branch — on the `hatch == categorical_axis`
+        # branch it was computed from `axis_idx`, which ranges over `[0, n_axis)`
+        # and can exceed `len(hue_order)` when n_hue < n_axis. Gating the
+        # `bar_color` computation behind the same condition as the recolor
+        # avoids an IndexError on paths where the value was never used anyway.
         if not (double_split or hatch == categorical_axis):
-            # Use the same color for all bars
+            bar_color = palette[hue_order[hue_idx]] if hue is not None else color
             patch.set_edgecolor(edgecolor if edgecolor is not None else bar_color)
             patch.set_facecolor(bar_color)
 

--- a/tests/test_bar_hatch_eq_categorical.py
+++ b/tests/test_bar_hatch_eq_categorical.py
@@ -1,0 +1,63 @@
+"""Regression tests for the `hatch == categorical_axis` path in barplot.
+
+When hatch is the same column as the categorical axis AND hue is a separate
+column with fewer levels than the categorical axis, the old code computed
+`bar_color = palette[hue_order[hue_idx]]` with `hue_idx = axis_idx`, which
+indexes past `hue_order` when `n_hue < n_axis`. The fix moves the bar_color
+computation inside the recolor gate (it's dead work on this path).
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _mismatched_df(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 60
+    return pd.DataFrame({
+        "cond": rng.choice(["A", "B", "C"], size=n),     # 3 levels (categorical axis)
+        "treat": rng.choice(["ctrl", "trt"], size=n),    # 2 levels (hue, < n_axis)
+        "value": rng.normal(size=n),
+    })
+
+
+def test_bar_hatch_equals_categorical_with_fewer_hue_levels_does_not_raise():
+    """Regression: hue=treat (2), hatch=cond=x (3) must not raise IndexError."""
+    df = _mismatched_df()
+    fig, ax = pp.barplot(
+        data=df, x="cond", y="value",
+        hue="treat", hatch="cond",
+        palette={"ctrl": "#ff0000", "trt": "#00ff00"},
+    )
+    # If we get here without IndexError, the fix holds. Also assert the
+    # expected 6 bars were drawn (n_axis × n_hue).
+    bars = [p for p in ax.patches if hasattr(p, "get_height")]
+    assert len(bars) == 6
+
+
+def test_bar_hatch_equals_categorical_applies_distinct_hatch_per_column():
+    """The hatch patterns must still match the categorical axis column."""
+    df = _mismatched_df()
+    fig, ax = pp.barplot(
+        data=df, x="cond", y="value",
+        hue="treat", hatch="cond",
+        palette={"ctrl": "#ff0000", "trt": "#00ff00"},
+        hatch_map={"A": "", "B": "///", "C": "xxx"},
+    )
+    bars = [p for p in ax.patches if hasattr(p, "get_height")]
+    # Each bar's hatch pattern should be one of the three from hatch_map.
+    patterns = {p.get_hatch() for p in bars}
+    assert patterns <= {"", "///", "xxx"}
+    # All three patterns should appear (every category represented).
+    assert patterns == {"", "///", "xxx"}


### PR DESCRIPTION
## Summary

Fixes a pre-existing ``IndexError`` in ``_apply_hatches_and_override_colors`` that fires when ``hatch == categorical_axis`` AND ``len(hue_order) < n_axis``.

## Root cause

On the ``hatch == categorical_axis`` branch, ``hue_idx`` is computed as ``axis_idx`` (ranges over ``[0, n_axis)``), but ``hue_order`` has length ``n_hue`` which can be smaller.

The crashing line was:
```python
bar_color = palette[hue_order[hue_idx]] if hue is not None else color
if not (double_split or hatch == categorical_axis):
    patch.set_edgecolor(...)
    patch.set_facecolor(bar_color)
```

The computed ``bar_color`` is only consumed inside the ``if not (...)`` gate — which is False on exactly the path that crashes. So the computation is dead work that blows up on valid input.

## Fix

Move ``bar_color = palette[hue_order[hue_idx]]`` inside the same ``if not (...)`` gate. Zero behavior change for working paths; the previously-crashing path now runs cleanly.

## Reproducer (was crashing pre-fix)

```python
df = pd.DataFrame({
    'cond': rng.choice(['A','B','C'], size=60),
    'treat': rng.choice(['ctrl','trt'], size=60),
    'value': rng.normal(size=60),
})
pp.barplot(data=df, x='cond', y='value', hue='treat', hatch='cond',
           palette={'ctrl':'#ff0000','trt':'#00ff00'})
# → IndexError: list index out of range  (pre-fix)
```

## Test plan
- [x] New ``tests/test_bar_hatch_eq_categorical.py`` with 2 regression tests (no raise + distinct hatch per x category)
- [x] Full suite: 200 passed (198 + 2 new)
- [x] Gallery smoke: all 14 ``examples/plots/*.py`` render clean

This unblocks the PR B test fixture workaround (PR #84 used 2-level ``cond`` to avoid the bug); follow-up PR can widen fixtures to 3-level now that the crash is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)