### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-02
+
+### Breaking changes
+- `figsize=` is no longer accepted by `barplot`, `boxplot`, `violinplot`, `raincloudplot`, `scatterplot`, `stripplot`, `swarmplot`, `pointplot`, `heatmap` (both categorical and dot paths), `complex_heatmap`, `venn`, or `upsetplot`. Passing `figsize=` raises `TypeError` with a clear migration message. To customize axes dimensions, compose with `pp.subplots(axes_size=(w_mm, h_mm))` and pass `ax=` into the plot function.
+- `complex_heatmap` replaces `figsize=(w_in, h_in)` with `axes_size=(w_mm, h_mm)` (millimeters, matching the rest of the publiplots API). Internally converts to inches for the existing gridspec math. Default is `(80, 60)` mm.
+- `publiplots` no longer overrides matplotlib's `figure.figsize` rcParam. Figure dimensions come from `subplots.axes_size` via `pp.subplots`. Users reading `pp.rcParams['figure.figsize']` now see matplotlib's own default.
+
+### Migration
+Before:
+```python
+pp.barplot(data=df, x="x", y="y", figsize=(4, 3))
+pp.complex_heatmap(data=df, figsize=(5, 5))
+```
+After:
+```python
+fig, ax = pp.subplots(axes_size=(80, 50))  # mm, not inches
+pp.barplot(data=df, x="x", y="y", ax=ax)
+
+pp.complex_heatmap(data=df, axes_size=(90, 90))  # mm, not inches
+```
+Or omit for auto-layout defaults.
+
+### Why
+When a plot function received `figsize=`, it took a `plt.subplots(figsize=...)` branch that did not install `SubplotsAutoLayout`. Legends, titles, and colorbar overflow were not reserved for — figures cropped on save (see the 0.5.0 horizontal raincloud known issue). `pp.subplots` is now the single source of truth for figure + axes dimensions.
+
+### Fixed
+- `barplot` `IndexError` in the `hue-only` legend path (when `hatch == categorical_axis` and `len(hue) < len(categorical_axis)`). The crashing `bar_color` computation is now gated behind the `if not (double_split or hatch == categorical_axis)` check that already guards its only consumer.
+- `venn` internally used `plt.subplots` when `ax is None`, bypassing `SubplotsAutoLayout`. Now routes through `pp.subplots` consistently.
+
+### Known issues
+- `upsetplot` decorations (bar-top annotations, xlabel, title) can clip against the canvas on `plt.show()` and non-tight `savefig`. The bug is pre-existing (present since 0.5.0 and earlier). Tracked in `docs/superpowers/handoff/2026-05-02-upset-layout-followup.md`; a dedicated layout PR will address it.
+- `complex_heatmap` has minor decoration overflow (~0.08 in bottom) in some configurations; part of the same composite-layout rework.
+
+[0.6.0]: https://github.com/jorgebotas/publiplots/releases/tag/v0.6.0
+
 ## [0.5.0] - 2026-05-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.5.0"
+version = "0.6.0"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
## Summary

Version bump **0.5.0 → 0.6.0**. Major bump signals the breaking change in PR C (figsize removal).

## Files
- \`pyproject.toml\` — \`version = "0.6.0"\`
- \`src/publiplots/__init__.py\` — \`__version__ = "0.6.0"\`
- \`CHANGELOG.md\` — new 0.6.0 section with breaking changes + migration guide

## Breaking changes in 0.6.0
- \`figsize=\` removed from all simple plot functions + venn/upsetplot. Use \`pp.subplots(axes_size=...)\` + \`ax=\`.
- \`complex_heatmap\` switches to \`axes_size=(w_mm, h_mm)\`.
- \`figure.figsize\` rcParam no longer overridden by publiplots.

## Also included in 0.6.0
- \`barplot\` IndexError fix (\`hatch == categorical_axis\` + \`len(hue) < n_axis\`).
- \`venn\` now routes through \`pp.subplots\` consistently.

## Known issues called out in CHANGELOG
- \`upsetplot\` decoration clipping (pre-existing; tracked in \`docs/superpowers/handoff/2026-05-02-upset-layout-followup.md\`).
- \`complex_heatmap\` minor overflow (same composite-layout rework).

## Release plan
After merge, cut GitHub Release with tag \`v0.6.0\` (no dot — standard convention, matching \`v0.5.0\`). Creating the release triggers \`.github/workflows/publish.yml\` → PyPI.

## Test plan
- [x] Full test suite: 235 passed on this branch
- [x] Gallery smoke: all 14 \`examples/plots/*.py\` render clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)