### PR TITLE
feat(display): add pp.show() and pp.suptitle() wrappers

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -13,7 +13,6 @@ First, import the necessary libraries:
    import publiplots as pp
    import pandas as pd
    import numpy as np
-   import matplotlib.pyplot as plt
 
 Creating Your First Plot
 -------------------------
@@ -42,7 +41,7 @@ Create a simple bar plot from a DataFrame:
        palette='pastel'
    )
 
-   plt.show()
+   pp.show()
 
 Scatter Plot
 ~~~~~~~~~~~~
@@ -71,7 +70,7 @@ Create a scatter plot with color and size encoding:
        title='Scatter Plot Example'
    )
 
-   plt.show()
+   pp.show()
 
 Customizing Your Plots
 -----------------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ To add a new example:
    # Description of this section.
    ```
 
-5. Include `plt.show()` after creating figures
+5. Include `pp.show()` after creating figures
 6. Run the example to ensure it works before building docs
 
 ## Notes

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -143,7 +143,7 @@
     "    ylabel='Value',\n",
     "    palette='pastel',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -183,7 +183,7 @@
     "    capsize=0.1,\n",
     "    palette='pastel',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -232,7 +232,7 @@
     "    errorbar='se',\n",
     "    palette=\"RdGyBu_r\",\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -273,7 +273,7 @@
     "    hatch_map={'Low': '', 'Medium': '//', 'High': 'xx'},\n",
     "    alpha=0.0,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -330,7 +330,7 @@
     "    hatch_map={\"24h\": \"\", \"48h\": \"///\"},\n",
     "    figsize=(8, 5)\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -369,7 +369,7 @@
     "    alpha=0.3,\n",
     "    order=horizontal_data['gene'].tolist()\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -421,7 +421,7 @@
     "    ylabel='Y Variable',\n",
     ")\n",
     "ax.margins(x=0.1, y=0.1)\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -452,7 +452,7 @@
     "    ylabel='Y Variable',\n",
     ")\n",
     "ax.margins(x=0.1, y=0.1)\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -483,7 +483,7 @@
     "    ylabel='Y Variable',\n",
     "    alpha=0.2,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -518,7 +518,7 @@
     "    legend_kws=dict(hue_label=\"Continuous Score\"),\n",
     ")\n",
     "ax.margins(0.1)\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -562,7 +562,7 @@
     "    xlabel='Condition',\n",
     "    ylabel='Cell Type',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -596,7 +596,7 @@
     "    ylabel='Cell Type',\n",
     "    alpha=0.2,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -641,7 +641,7 @@
     "    xlabel='Time Point',\n",
     "    ylabel='Tissue',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -698,7 +698,7 @@
     "    ylabel='Measurement',\n",
     ")\n",
     "ax.grid(axis=\"y\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -739,7 +739,7 @@
     "    palette=\"RdGyBu_r\"\n",
     ")\n",
     "ax.grid(axis=\"y\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -768,7 +768,7 @@
     "    ylabel='Measurement',\n",
     ")\n",
     "ax.grid(axis=\"y\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -797,7 +797,7 @@
     "    ylabel='Measurement',\n",
     ")\n",
     "ax.grid(axis=\"y\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -828,7 +828,7 @@
     "    ylabel='Measurement',\n",
     ")\n",
     "ax.grid(axis=\"y\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -857,7 +857,7 @@
     "    ylabel='Measurement',\n",
     ")\n",
     "ax.grid(axis=\"y\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -886,7 +886,7 @@
     "    ylabel='Measurement',\n",
     ")\n",
     "ax.grid(axis=\"y\", alpha=0.3)\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1022,7 +1022,7 @@
     "ax.grid(axis='x', alpha=0.3)\n",
     "ax.legend(loc='lower right')\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1076,7 +1076,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1106,7 +1106,7 @@
     "    ylabel='Value',\n",
     "    palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1134,7 +1134,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1161,7 +1161,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1187,7 +1187,7 @@
     "    xlabel='Value',\n",
     "    ylabel='Category',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1241,7 +1241,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1268,7 +1268,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1298,7 +1298,7 @@
     "    ylabel='Value',\n",
     "    palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1326,7 +1326,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1352,7 +1352,7 @@
     "    xlabel='Value',\n",
     "    ylabel='Category',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1408,7 +1408,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1439,7 +1439,7 @@
     "    ylabel='Value',\n",
     "    palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1464,7 +1464,7 @@
     "    xlabel='Value',\n",
     "    ylabel='Category',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1503,7 +1503,7 @@
     "ax.set_xlabel('Category')\n",
     "ax.set_ylabel('Value')\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1533,7 +1533,7 @@
     "    ylabel='Value',\n",
     "    alpha=0.3,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1559,7 +1559,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1615,7 +1615,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1646,7 +1646,7 @@
     "    ylabel='Value',\n",
     "    palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1675,7 +1675,7 @@
     "    xlabel='Category',\n",
     "    ylabel='Value',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1700,7 +1700,7 @@
     "    xlabel='Value',\n",
     "    ylabel='Category',\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1740,7 +1740,7 @@
     "ax.set_xlabel('Category')\n",
     "ax.set_ylabel('Value')\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1770,7 +1770,7 @@
     "    ylabel='Value',\n",
     "    alpha=0.3,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1801,7 +1801,7 @@
     "        ylabel='Value',\n",
     "    )\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1848,7 +1848,7 @@
     "    palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},\n",
     ")\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1905,7 +1905,7 @@
     "    ylabel='Measurement',\n",
     "    cloud_alpha=0.6,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1936,7 +1936,7 @@
     "    box_offset=0.1,\n",
     "    rain_offset=0.1,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -1974,7 +1974,7 @@
     "        marker=\"x\"\n",
     "    )\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2003,7 +2003,7 @@
     "    ylabel='Measurement',\n",
     "    cloud_alpha=0.6,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2046,7 +2046,7 @@
     "    cloud_alpha=0.6,\n",
     ")\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2078,7 +2078,7 @@
     "    box_offset=0.1,\n",
     "    rain_offset=0.1,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2122,7 +2122,7 @@
     "    labels=['Set A', 'Set B'],\n",
     "    colors=pp.color_palette('pastel', n_colors=2),\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2152,7 +2152,7 @@
     "    alpha=0.3,\n",
     "    figsize=(6, 6)\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2179,7 +2179,7 @@
     "    labels=['Set A', 'Set B', 'Set C'],\n",
     "    colors=pp.color_palette('pastel', n_colors=3),\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2209,7 +2209,7 @@
     "    colors=pp.color_palette('pastel', n_colors=4),\n",
     "    figsize=(6, 6),\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2240,7 +2240,7 @@
     "    colors=pp.color_palette('pastel', n_colors=5),\n",
     "    figsize=(6, 6),\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2269,8 +2269,8 @@
     "    alpha=0.4,\n",
     "    figsize=(7, 7),\n",
     ")\n",
-    "plt.title('Differentially Expressed Genes', fontsize=14, fontweight='bold')\n",
-    "plt.show()\n"
+    "ax.set_title('Differentially Expressed Genes', fontsize=14, fontweight='bold')\n",
+    "pp.show()\n"
    ]
   },
   {
@@ -2320,7 +2320,7 @@
     "    title='Gene Set Intersection Analysis',\n",
     "    show_counts=15,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2347,7 +2347,7 @@
     "    bar_linewidth=1.5,\n",
     "    show_counts=12,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2383,7 +2383,7 @@
     "    color='#75B375',\n",
     "    show_counts=20,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2420,7 +2420,7 @@
     "    alpha=0.4,\n",
     "    show_counts=15,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2458,14 +2458,14 @@
     ")\n",
     "ax1.set_title('5-Way Venn Diagram', fontsize=12, fontweight='bold')\n",
     "# UpSet plot (right) - need to handle this differently since upsetplot returns multiple axes\n",
-    "plt.subplot(1, 2, 2)\n",
+    "ax2 = plt.subplot(1, 2, 2)\n",
     "# For this comparison, we'll create a separate figure for the UpSet plot\n",
     "plt.text(0.5, 0.5, 'UpSet plot shown separately\\n(see next figure)',\n",
     "         ha='center', va='center', fontsize=12)\n",
     "plt.axis('off')\n",
-    "plt.title('UpSet Plot (Better for 5+ Sets)', fontsize=12, fontweight='bold')\n",
+    "ax2.set_title('UpSet Plot (Better for 5+ Sets)', fontsize=12, fontweight='bold')\n",
     "plt.tight_layout()\n",
-    "plt.show()\n",
+    "pp.show()\n",
     "# Show the UpSet plot\n",
     "axes = pp.upsetplot(\n",
     "    data=five_sets,\n",
@@ -2475,7 +2475,7 @@
     "    alpha=0.3,\n",
     "    show_counts=20,\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2565,7 +2565,7 @@
     "    ax=axes[1, 1]\n",
     ")\n",
     "plt.tight_layout()\n",
-    "plt.show()\n",
+    "pp.show()\n",
     "# Reset to default\n",
     "pp.set_hatch_mode()\n"
    ]
@@ -2637,7 +2637,7 @@
     "    color='#5D83C3',\n",
     "    alpha=0.0,\n",
     ")\n",
-    "plt.show()\n",
+    "pp.show()\n",
     "# Reset mode\n",
     "pp.set_hatch_mode()\n"
    ]
@@ -2691,7 +2691,7 @@
     "    hatch_map={'Group A': '', 'Group B': '..'},\n",
     "    color='#5D83C3',\n",
     ")\n",
-    "plt.show()\n",
+    "pp.show()\n",
     "# Reset mode\n",
     "pp.set_hatch_mode()\n"
    ]
@@ -2745,7 +2745,7 @@
     "    hatch_map={'Control': '', 'Treatment': '//'},\n",
     "    alpha=0.3,\n",
     ")\n",
-    "plt.show()\n",
+    "pp.show()\n",
     "# Reset mode\n",
     "pp.set_hatch_mode()\n"
    ]
@@ -2811,7 +2811,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Create sample data for demonstration\nnp.random.seed(100)\nsample_data = pd.DataFrame({\n    'category': np.repeat(['A', 'B', 'C'], 10),\n    'value': np.concatenate([\n        np.random.normal(50, 8, 10),\n        np.random.normal(70, 10, 10),\n        np.random.normal(85, 12, 10),\n    ])\n})\n\nprint(\"\\nDefault PubliPlots Style (applied on import):\")\nprint(f\"  Figure size: {pp.rcParams['figure.figsize']}\")\nprint(f\"  Font size: {pp.rcParams['font.size']}\")\nprint(f\"  DPI: {pp.rcParams['savefig.dpi']}\")\n\nax = pp.barplot(\n    data=sample_data,\n    x='category',\n    y='value',\n    title='Default Publication-Grade Style',\n    errorbar='se',\n    palette='pastel'\n)\nplt.show()\n"
+   "source": "# Create sample data for demonstration\nnp.random.seed(100)\nsample_data = pd.DataFrame({\n    'category': np.repeat(['A', 'B', 'C'], 10),\n    'value': np.concatenate([\n        np.random.normal(50, 8, 10),\n        np.random.normal(70, 10, 10),\n        np.random.normal(85, 12, 10),\n    ])\n})\n\nprint(\"\\nDefault PubliPlots Style (applied on import):\")\nprint(f\"  Figure size: {pp.rcParams['figure.figsize']}\")\nprint(f\"  Font size: {pp.rcParams['font.size']}\")\nprint(f\"  DPI: {pp.rcParams['savefig.dpi']}\")\n\nax = pp.barplot(\n    data=sample_data,\n    x='category',\n    y='value',\n    title='Default Publication-Grade Style',\n    errorbar='se',\n    palette='pastel'\n)\npp.show()\n"
   },
   {
    "cell_type": "markdown",
@@ -2826,7 +2826,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Set custom defaults\npp.rcParams['color'] = '#E67E7E'  # Change default color to red\npp.rcParams['alpha'] = 0.3        # Increase default transparency\npp.rcParams['capsize'] = 0.15     # Larger error bar caps\npp.rcParams['hatch_mode'] = 2     # Medium density hatch patterns\n\n# Also customize matplotlib parameters\npp.rcParams['figure.figsize'] = (8, 5)  # Wider figures\npp.rcParams['lines.linewidth'] = 2.5    # Thicker lines\npp.rcParams['font.size'] = 11           # Slightly larger font\n\n# Create plot with custom defaults\nax = pp.barplot(\n    data=sample_data,\n    x='category',\n    y='value',\n    title='Plot with Custom rcParams',\n    errorbar='se',\n)\nplt.show()\n\n# Reset to default\npp.reset_style()\n"
+   "source": "# Set custom defaults\npp.rcParams['color'] = '#E67E7E'  # Change default color to red\npp.rcParams['alpha'] = 0.3        # Increase default transparency\npp.rcParams['capsize'] = 0.15     # Larger error bar caps\npp.rcParams['hatch_mode'] = 2     # Medium density hatch patterns\n\n# Also customize matplotlib parameters\npp.rcParams['figure.figsize'] = (8, 5)  # Wider figures\npp.rcParams['lines.linewidth'] = 2.5    # Thicker lines\npp.rcParams['font.size'] = 11           # Slightly larger font\n\n# Create plot with custom defaults\nax = pp.barplot(\n    data=sample_data,\n    x='category',\n    y='value',\n    title='Plot with Custom rcParams',\n    errorbar='se',\n)\npp.show()\n\n# Reset to default\npp.reset_style()\n"
   },
   {
    "cell_type": "markdown",
@@ -2906,7 +2906,7 @@
     "    ax=axes[1, 1]\n",
     ")\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2941,7 +2941,7 @@
     "    palette='pastel',\n",
     "    alpha=0.2,\n",
     ")\n",
-    "plt.show()\n",
+    "pp.show()\n",
     "# Plot 2: Override alpha and color for this plot only\n",
     "ax = pp.scatterplot(\n",
     "    data=scatter_data,\n",
@@ -2952,7 +2952,7 @@
     "    palette='pastel',\n",
     "    alpha=0.5,  # Override default alpha just for this plot\n",
     ")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {
@@ -2988,7 +2988,7 @@
     "print(\"  - PNG at 300 DPI (publications)\")\n",
     "print(\"  - PDF (vector, editable)\")\n",
     "print(\"  - SVG (vector, web-friendly)\")\n",
-    "plt.show()\n"
+    "pp.show()\n"
    ]
   },
   {

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -9,7 +9,6 @@ including simple bars, grouped bars, error bars, and hatch patterns.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Bar Plot
@@ -32,7 +31,7 @@ ax = pp.barplot(
     ylabel='Value',
     palette='pastel',
 )
-plt.show()
+pp.show()
 
 # %%
 # Bar Plot with Error Bars
@@ -63,7 +62,7 @@ ax = pp.barplot(
     capsize=0.1,
     palette='pastel',
 )
-plt.show()
+pp.show()
 
 # %%
 # Grouped Bar Plot with Hue
@@ -103,7 +102,7 @@ ax = pp.barplot(
     errorbar='se',
     palette="RdGyBu_r",
 )
-plt.show()
+pp.show()
 
 # %%
 # Bar Plot with Hatch Patterns Only
@@ -135,7 +134,7 @@ ax = pp.barplot(
     hatch_map={'Low': '', 'Medium': '//', 'High': 'xx'},
     alpha=0.0,
 )
-plt.show()
+pp.show()
 
 # %%
 # Bar Plot with Hue and Hatch (Double Split)
@@ -182,7 +181,7 @@ ax = pp.barplot(
     palette={"Vehicle": "#8E8EC1", "Drug": "#60a8a8"},
     hatch_map={"24h": "", "48h": "///"},
 )
-plt.show()
+pp.show()
 
 # %%
 # Horizontal Bar Plot
@@ -212,7 +211,7 @@ ax = pp.barplot(
     alpha=0.3,
     order=horizontal_data['gene'].tolist()
 )
-plt.show()
+pp.show()
 
 # %%
 # Shared Legend Across Subplots
@@ -243,4 +242,4 @@ for ax, title in zip(axes, ["Sample A", "Sample B", "Sample C"]):
         title=title, ax=ax,
         errorbar="se",
     )
-plt.show()
+pp.show()

--- a/examples/plots/plot_02_scatter_plots.py
+++ b/examples/plots/plot_02_scatter_plots.py
@@ -10,7 +10,6 @@ color scales, and bubble plots (categorical scatter heatmaps).
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Basic Scatter Plot
@@ -35,7 +34,7 @@ ax = pp.scatterplot(
     ylabel='Y Variable',
 )
 ax.margins(x=0.1, y=0.1)
-plt.show()
+pp.show()
 
 # %%
 # Scatter with Size Encoding
@@ -57,7 +56,7 @@ ax = pp.scatterplot(
     ylabel='Y Variable',
 )
 ax.margins(x=0.1, y=0.1)
-plt.show()
+pp.show()
 
 # %%
 # Scatter with Categorical Hue
@@ -79,7 +78,7 @@ ax = pp.scatterplot(
     ylabel='Y Variable',
     alpha=0.2,
 )
-plt.show()
+pp.show()
 
 # %%
 # Scatter with Continuous Color Scale
@@ -105,7 +104,7 @@ ax = pp.scatterplot(
     legend_kws=dict(hue_label="Continuous Score"),
 )
 ax.margins(0.1)
-plt.show()
+pp.show()
 
 # %%
 # Bubble Plot (Categorical Scatter Heatmap)
@@ -142,7 +141,7 @@ ax = pp.scatterplot(
     xlabel='Condition',
     ylabel='Cell Type',
 )
-plt.show()
+pp.show()
 
 # %%
 # Bubble Plot with Continuous Colors
@@ -167,7 +166,7 @@ ax = pp.scatterplot(
     ylabel='Cell Type',
     alpha=0.2,
 )
-plt.show()
+pp.show()
 
 # %%
 # Large Bubble Plot
@@ -205,7 +204,7 @@ ax = pp.scatterplot(
     xlabel='Time Point',
     ylabel='Tissue',
 )
-plt.show()
+pp.show()
 
 # %%
 # Shared Legend Across Subplots
@@ -232,4 +231,4 @@ for ax, title in zip(axes, ['Sample A', 'Sample B', 'Sample C']):
         data=shared_df, x='x', y='y', hue='g',
         palette='pastel', title=title, ax=ax,
     )
-plt.show()
+pp.show()

--- a/examples/plots/plot_03_pointplot.py
+++ b/examples/plots/plot_03_pointplot.py
@@ -11,7 +11,6 @@ comparing groups over time or conditions.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Point Plot
@@ -40,7 +39,7 @@ ax = pp.pointplot(
     ylabel='Measurement',
 )
 ax.grid(axis="y")
-plt.show()
+pp.show()
 
 
 # %%
@@ -73,7 +72,7 @@ ax = pp.pointplot(
     palette="RdGyBu_r"
 )
 ax.grid(axis="y")
-plt.show()
+pp.show()
 
 
 # %%
@@ -93,7 +92,7 @@ ax = pp.pointplot(
     ylabel='Measurement',
 )
 ax.grid(axis="y")
-plt.show()
+pp.show()
 
 # %%
 # Point Plot with Custom Line Styles
@@ -112,7 +111,7 @@ ax = pp.pointplot(
     ylabel='Measurement',
 )
 ax.grid(axis="y")
-plt.show()
+pp.show()
 
 # %%
 # Complete Customization
@@ -133,7 +132,7 @@ ax = pp.pointplot(
     ylabel='Measurement',
 )
 ax.grid(axis="y")
-plt.show()
+pp.show()
 
 # %%
 # Point Plot with Standard Error
@@ -152,7 +151,7 @@ ax = pp.pointplot(
     ylabel='Measurement',
 )
 ax.grid(axis="y")
-plt.show()
+pp.show()
 
 # %%
 # Point Plot with Standard Deviation
@@ -171,7 +170,7 @@ ax = pp.pointplot(
     ylabel='Measurement',
 )
 ax.grid(axis="y", alpha=0.3)
-plt.show()
+pp.show()
 
 # %%
 # Forest Plot: Log2 Odds Ratios with Significance Coloring
@@ -291,4 +290,4 @@ ax.axvline(x=placebo_mean, color='red', linestyle=':', linewidth=1.5,
 ax.grid(axis='x', alpha=0.3)
 ax.legend(loc='lower right')
 
-plt.show()
+pp.show()

--- a/examples/plots/plot_04_swarm_plots.py
+++ b/examples/plots/plot_04_swarm_plots.py
@@ -9,7 +9,6 @@ which shows individual data points with minimal overlap.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Swarm Plot
@@ -37,7 +36,7 @@ ax = pp.swarmplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Swarm Plot with Hue Grouping
@@ -58,7 +57,7 @@ ax = pp.swarmplot(
     ylabel='Value',
     palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},
 )
-plt.show()
+pp.show()
 
 # %%
 # Dodged Swarm Plot
@@ -76,7 +75,7 @@ ax = pp.swarmplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Swarm Plot with Custom Size
@@ -93,7 +92,7 @@ ax = pp.swarmplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Horizontal Swarm Plot
@@ -109,4 +108,4 @@ ax = pp.swarmplot(
     xlabel='Value',
     ylabel='Category',
 )
-plt.show()
+pp.show()

--- a/examples/plots/plot_05_strip_plots.py
+++ b/examples/plots/plot_05_strip_plots.py
@@ -9,7 +9,6 @@ which shows individual data points with optional jitter.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Strip Plot
@@ -37,7 +36,7 @@ ax = pp.stripplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Strip Plot with Jitter
@@ -54,7 +53,7 @@ ax = pp.stripplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Strip Plot with Hue Grouping
@@ -75,7 +74,7 @@ ax = pp.stripplot(
     ylabel='Value',
     palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},
 )
-plt.show()
+pp.show()
 
 # %%
 # Dodged Strip Plot
@@ -93,7 +92,7 @@ ax = pp.stripplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Horizontal Strip Plot
@@ -109,4 +108,4 @@ ax = pp.stripplot(
     xlabel='Value',
     ylabel='Category',
 )
-plt.show()
+pp.show()

--- a/examples/plots/plot_06_box_plots.py
+++ b/examples/plots/plot_06_box_plots.py
@@ -12,7 +12,6 @@ Examples
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Box Plot
@@ -41,7 +40,7 @@ ax = pp.boxplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Box Plot with Hue Grouping
@@ -63,7 +62,7 @@ ax = pp.boxplot(
     ylabel='Value',
     palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},
 )
-plt.show()
+pp.show()
 
 # %%
 # Horizontal Box Plot
@@ -78,7 +77,7 @@ ax = pp.boxplot(
     xlabel='Value',
     ylabel='Category',
 )
-plt.show()
+pp.show()
 
 # %%
 # Combined Box and Swarm Plot
@@ -109,7 +108,7 @@ pp.swarmplot(
 ax.set_title('Combined Box and Swarm Plot')
 ax.set_xlabel('Category')
 ax.set_ylabel('Value')
-plt.show()
+pp.show()
 
 # %%
 # Customization
@@ -130,7 +129,7 @@ ax = pp.boxplot(
     ylabel='Value',
     alpha=0.3,
 )
-plt.show()
+pp.show()
 
 # %%
 # Box Plot Without Outliers
@@ -146,4 +145,4 @@ ax = pp.boxplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()

--- a/examples/plots/plot_07_violin_plots.py
+++ b/examples/plots/plot_07_violin_plots.py
@@ -12,7 +12,6 @@ Examples
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Violin Plot
@@ -41,7 +40,7 @@ ax = pp.violinplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Violin Plot with Hue Grouping
@@ -63,7 +62,7 @@ ax = pp.violinplot(
     ylabel='Value',
     palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},
 )
-plt.show()
+pp.show()
 
 # %%
 # Split Violin Plot
@@ -82,7 +81,7 @@ ax = pp.violinplot(
     xlabel='Category',
     ylabel='Value',
 )
-plt.show()
+pp.show()
 
 # %%
 # Horizontal Violin Plot
@@ -97,7 +96,7 @@ ax = pp.violinplot(
     xlabel='Value',
     ylabel='Category',
 )
-plt.show()
+pp.show()
 
 # %%
 # Combined Violin and Swarm Plot
@@ -129,7 +128,7 @@ pp.swarmplot(
 ax.set_title('Combined Violin and Swarm Plot')
 ax.set_xlabel('Category')
 ax.set_ylabel('Value')
-plt.show()
+pp.show()
 
 # %%
 # Customization
@@ -150,7 +149,7 @@ ax = pp.violinplot(
     ylabel='Value',
     alpha=0.3,
 )
-plt.show()
+pp.show()
 
 # %%
 # Violin Plot with Different Inner Representations
@@ -172,7 +171,7 @@ for ax, inner in zip(axes.flat, inner_types):
         ylabel='Value',
     )
 
-plt.show()
+pp.show()
 
 # %%
 # One-Sided Violin Plots
@@ -211,5 +210,5 @@ pp.violinplot(
     palette={'Group 1': '#8E8EC1', 'Group 2': '#75B375'},
 )
 
-plt.show()
+pp.show()
 

--- a/examples/plots/plot_08_raincloud_plots.py
+++ b/examples/plots/plot_08_raincloud_plots.py
@@ -13,7 +13,6 @@ Examples
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Raincloud Plot
@@ -43,7 +42,7 @@ ax = pp.raincloudplot(
     ylabel='Measurement',
     cloud_alpha=0.6,
 )
-plt.show()
+pp.show()
 
 # %%
 # Raincloud Plot with Hue Grouping (Vertical)
@@ -64,7 +63,7 @@ ax = pp.raincloudplot(
     box_offset=0.1,
     rain_offset=0.1,
 )
-plt.show()
+pp.show()
 
 # %%
 # Horizontal Raincloud Plot with Hue
@@ -95,7 +94,7 @@ pp.raincloudplot(
     ),
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # %%
 # Customization
@@ -115,7 +114,7 @@ ax = pp.raincloudplot(
     ylabel='Measurement',
     cloud_alpha=0.6,
 )
-plt.show()
+pp.show()
 
 # %%
 # Raincloud Plot with Custom Cloud Side
@@ -150,7 +149,7 @@ pp.raincloudplot(
     cloud_alpha=0.6,
 )
 
-plt.show()
+pp.show()
 
 # %%
 # Raincloud Plot with Custom Alpha Values
@@ -172,4 +171,4 @@ ax = pp.raincloudplot(
     box_offset=0.1,
     rain_offset=0.1,
 )
-plt.show()
+pp.show()

--- a/examples/plots/plot_09_venn_diagrams.py
+++ b/examples/plots/plot_09_venn_diagrams.py
@@ -9,7 +9,6 @@ labels, and formatting.
 
 import publiplots as pp
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # 2-Way Venn Diagram
@@ -26,7 +25,7 @@ ax = pp.venn(
     labels=['Set A', 'Set B'],
     colors=pp.color_palette('pastel', n_colors=2),
 )
-plt.show()
+pp.show()
 
 # %%
 # 2-Way Venn with Percentage Format
@@ -50,7 +49,7 @@ pp.venn(
     alpha=0.3,
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # %%
 # 3-Way Venn Diagram
@@ -68,7 +67,7 @@ ax = pp.venn(
     labels=['Set A', 'Set B', 'Set C'],
     colors=pp.color_palette('pastel', n_colors=3),
 )
-plt.show()
+pp.show()
 
 # %%
 # 4-Way Venn Diagram
@@ -90,7 +89,7 @@ pp.venn(
     colors=pp.color_palette('pastel', n_colors=4),
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # %%
 # 5-Way Venn Diagram
@@ -113,7 +112,7 @@ pp.venn(
     colors=pp.color_palette('pastel', n_colors=5),
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # %%
 # Custom Styled Venn Diagram
@@ -134,5 +133,5 @@ pp.venn(
     alpha=0.4,
     ax=ax,
 )
-plt.title('Differentially Expressed Genes', fontsize=14, fontweight='bold')
-plt.show()
+ax.set_title('Differentially Expressed Genes', fontsize=14, fontweight='bold')
+pp.show()

--- a/examples/plots/plot_10_upset_plots.py
+++ b/examples/plots/plot_10_upset_plots.py
@@ -11,7 +11,6 @@ set intersections, especially useful when dealing with many sets
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Basic UpSet Plot
@@ -33,7 +32,7 @@ axes = pp.upsetplot(
     title='Gene Set Intersection Analysis',
     show_counts=15,
 )
-plt.show()
+pp.show()
 
 # %%
 # UpSet Plot with Custom Colors
@@ -50,7 +49,7 @@ axes = pp.upsetplot(
     bar_linewidth=1.5,
     show_counts=12,
 )
-plt.show()
+pp.show()
 
 # %%
 # UpSet Plot with Many Sets
@@ -77,7 +76,7 @@ axes = pp.upsetplot(
     color='#75B375',
     show_counts=20,
 )
-plt.show()
+pp.show()
 
 # %%
 # UpSet Plot from DataFrame
@@ -105,7 +104,7 @@ axes = pp.upsetplot(
     alpha=0.4,
     show_counts=15,
 )
-plt.show()
+pp.show()
 
 # %%
 # Comparing UpSet vs Venn for 4+ Sets
@@ -140,7 +139,7 @@ ax2.text(0.5, 0.5, 'UpSet plot shown separately\n(see next figure)',
 ax2.axis('off')
 ax2.set_title('UpSet Plot (Better for 5+ Sets)', fontsize=12, fontweight='bold')
 
-plt.show()
+pp.show()
 
 # Show the UpSet plot
 axes = pp.upsetplot(
@@ -151,4 +150,4 @@ axes = pp.upsetplot(
     alpha=0.3,
     show_counts=20,
 )
-plt.show()
+pp.show()

--- a/examples/plots/plot_11_heatmap.py
+++ b/examples/plots/plot_11_heatmap.py
@@ -10,7 +10,6 @@ and complex heatmaps with margin plots.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Simple Heatmap (Wide Format)
@@ -37,7 +36,7 @@ ax = pp.heatmap(
     xlabel='Samples',
     ylabel='Genes',
 )
-plt.show()
+pp.show()
 
 # %%
 # Annotated Heatmap
@@ -53,7 +52,7 @@ ax = pp.heatmap(
     linecolor='white',
     title='Annotated Expression Matrix',
 )
-plt.show()
+pp.show()
 
 # %%
 # Heatmap from Long-Format Data
@@ -81,7 +80,7 @@ ax = pp.heatmap(
     title='Heatmap from Long-Format Data',
     legend_kws={'value_label': 'Expression (Z-score)'},
 )
-plt.show()
+pp.show()
 
 # %%
 # Dot Heatmap (Bubble Plot)
@@ -120,7 +119,7 @@ ax = pp.heatmap(
         'size_label': 'P-value',
     },
 )
-plt.show()
+pp.show()
 
 # %%
 # Clustered Heatmap
@@ -154,8 +153,8 @@ axes = (
     )
     .build()
 )
-plt.suptitle('Clustered Heatmap with Dendrograms', y=1.02)
-plt.show()
+pp.suptitle('Clustered Heatmap with Dendrograms', y=1.02)
+pp.show()
 
 # %%
 # Complex Heatmap with Margin Plots
@@ -204,8 +203,8 @@ axes = (
     )
     .build()
 )
-plt.suptitle('Complex Heatmap with Summary Bar Plot', y=1.02)
-plt.show()
+pp.suptitle('Complex Heatmap with Summary Bar Plot', y=1.02)
+pp.show()
 
 # %%
 # Dot Heatmap for GO Enrichment
@@ -247,7 +246,7 @@ ax = pp.heatmap(
         'size_label': '-log10(p-value)',
     },
 )
-plt.show()
+pp.show()
 
 # %%
 # Square Heatmap
@@ -271,7 +270,7 @@ ax = pp.heatmap(
     linewidths=0.5,
     title='Correlation Matrix',
 )
-plt.show()
+pp.show()
 
 # %%
 # Complex Heatmap Without Dendrograms
@@ -290,5 +289,5 @@ axes = (
     )
     .build()
 )
-plt.suptitle('Clustered Heatmap (Dendrograms Hidden)', y=1.02)
-plt.show()
+pp.suptitle('Clustered Heatmap (Dendrograms Hidden)', y=1.02)
+pp.show()

--- a/examples/plots/plot_12_hatch_patterns.py
+++ b/examples/plots/plot_12_hatch_patterns.py
@@ -10,7 +10,6 @@ figures that are distinguishable without relying on color.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Understanding Hatch Modes
@@ -77,7 +76,7 @@ pp.barplot(
     ax=axes[1, 1]
 )
 
-plt.show()
+pp.show()
 
 # Reset to default
 pp.set_hatch_mode()
@@ -133,7 +132,7 @@ ax = pp.barplot(
     color='#5D83C3',
     alpha=0.0,
 )
-plt.show()
+pp.show()
 
 # Reset mode
 pp.set_hatch_mode()
@@ -180,7 +179,7 @@ ax = pp.barplot(
     hatch_map={'Group A': '', 'Group B': '..'},
     color='#5D83C3',
 )
-plt.show()
+pp.show()
 
 # Reset mode
 pp.set_hatch_mode()
@@ -227,7 +226,7 @@ ax = pp.barplot(
     hatch_map={'Control': '', 'Treatment': '//'},
     alpha=0.3,
 )
-plt.show()
+pp.show()
 
 # Reset mode
 pp.set_hatch_mode()

--- a/examples/plots/plot_13_configuration.py
+++ b/examples/plots/plot_13_configuration.py
@@ -9,7 +9,6 @@ set global styles, and customize various plotting parameters.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # %%
 # Understanding rcParams
@@ -62,7 +61,7 @@ ax = pp.barplot(
     errorbar='se',
     palette='pastel'
 )
-plt.show()
+pp.show()
 
 # %%
 # Customizing Individual Parameters
@@ -88,7 +87,7 @@ ax = pp.barplot(
     title='Plot with Custom rcParams',
     errorbar='se',
 )
-plt.show()
+pp.show()
 
 # Reset to default (reverts to matplotlib defaults)
 pp.reset_style()
@@ -167,7 +166,7 @@ pp.barplot(
     ax=axes[1, 1]
 )
 
-plt.show()
+pp.show()
 
 # %%
 # Context-Based Styling
@@ -193,7 +192,7 @@ ax = pp.scatterplot(
     palette='pastel',
     alpha=0.2,
 )
-plt.show()
+pp.show()
 
 # Plot 2: Override alpha and color for this plot only
 ax = pp.scatterplot(
@@ -205,7 +204,7 @@ ax = pp.scatterplot(
     palette='pastel',
     alpha=0.5,  # Override default alpha just for this plot
 )
-plt.show()
+pp.show()
 
 # %%
 # Saving Figures with Custom Settings
@@ -234,7 +233,7 @@ print("  - PNG at 300 DPI (publications)")
 print("  - PDF (vector, editable)")
 print("  - SVG (vector, web-friendly)")
 
-plt.show()
+pp.show()
 
 # %%
 # Best Practices Summary

--- a/examples/plots/plot_14_edgecolor_control.py
+++ b/examples/plots/plot_14_edgecolor_control.py
@@ -14,7 +14,6 @@ it once applies uniform edges across every plot in the figure.
 import publiplots as pp
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 # Use a higher alpha for this example so face colors are vivid — it makes
 # edge colors easier to spot by contrast.
@@ -48,7 +47,7 @@ pp.barplot(
     title='Default: edges match palette',
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # %%
 # Global Override via rcParams
@@ -70,7 +69,7 @@ pp.barplot(
     title="rcParams['edgecolor'] = 'black'",
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # %%
 # Uniform Edges Across Plot Types
@@ -116,7 +115,7 @@ pp.scatterplot(
     data=mixed_data, x='group', y='value', hue='group',
     palette='pastel', title='Scatter', ax=axes[2],
 )
-plt.show()
+pp.show()
 
 # %%
 # Composite Plots: Raincloud
@@ -184,7 +183,7 @@ group.add_legend(
     ),
     label='condition',
 )
-plt.show()
+pp.show()
 
 # %%
 # Per-Call Override
@@ -214,7 +213,7 @@ pp.barplot(
     title="edgecolor='#c0392b' (per-call)",
     ax=axes[1],
 )
-plt.show()
+pp.show()
 
 # %%
 # Restoring the Default
@@ -234,7 +233,7 @@ pp.barplot(
     title="Back to default (None = auto)",
     ax=ax,
 )
-plt.show()
+pp.show()
 
 # Restore the global alpha default.
 pp.rcParams['alpha'] = 0.1

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -37,6 +37,7 @@ from publiplots.plot.heatmap import heatmap, complex_heatmap, dendrogram
 
 # Utilities
 from publiplots.utils.io import savefig, save_multiple, close_all
+from publiplots.utils.display import show, suptitle
 from publiplots.utils.axes import (
     adjust_spines,
     add_grid,
@@ -105,6 +106,9 @@ __all__ = [
     "savefig",
     "save_multiple",
     "close_all",
+    # Display utilities
+    "show",
+    "suptitle",
     # Axes utilities
     "adjust_spines",
     "add_grid",

--- a/src/publiplots/utils/display.py
+++ b/src/publiplots/utils/display.py
@@ -1,0 +1,63 @@
+"""
+Display-side helpers for publiplots.
+
+Thin wrappers around ``matplotlib.pyplot`` so users don't need to import
+``matplotlib.pyplot`` alongside ``publiplots`` for common display tasks.
+"""
+
+from typing import Any, Optional
+
+import matplotlib.pyplot as plt
+from matplotlib.text import Text
+
+
+def show(*args: Any, **kwargs: Any) -> None:
+    """Display figures.
+
+    Thin wrapper around :func:`matplotlib.pyplot.show`. Behavior depends on
+    the active matplotlib backend: interactive backends block until the
+    window closes; inline / Agg backends return immediately.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        Forwarded to ``matplotlib.pyplot.show``. The most common kwarg is
+        ``block`` (``True`` by default in interactive mode).
+
+    Examples
+    --------
+    >>> import publiplots as pp
+    >>> ax = pp.barplot(data=df, x='category', y='value')
+    >>> pp.show()
+    """
+    plt.show(*args, **kwargs)
+
+
+def suptitle(text: str, **kwargs: Any) -> Text:
+    """Add a figure-level title to the current figure.
+
+    Thin wrapper around :func:`matplotlib.pyplot.suptitle`. Returns the
+    created :class:`~matplotlib.text.Text` artist.
+
+    Parameters
+    ----------
+    text : str
+        The title text.
+    **kwargs
+        Forwarded to ``matplotlib.pyplot.suptitle`` (e.g., ``fontsize``,
+        ``y``, ``fontweight``).
+
+    Returns
+    -------
+    matplotlib.text.Text
+        The suptitle artist.
+
+    Examples
+    --------
+    >>> import publiplots as pp
+    >>> fig, axes = pp.subplots(1, 2)
+    >>> pp.barplot(data=df1, x='x', y='y', ax=axes[0])
+    >>> pp.barplot(data=df2, x='x', y='y', ax=axes[1])
+    >>> pp.suptitle('Comparison of two experiments')
+    """
+    return plt.suptitle(text, **kwargs)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,45 @@
+"""Tests for pp.show and pp.suptitle."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.text import Text
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def test_show_is_exported():
+    assert callable(pp.show)
+
+
+def test_suptitle_is_exported():
+    assert callable(pp.suptitle)
+
+
+def test_show_returns_none():
+    """pp.show() is a pass-through; returns None on the Agg backend."""
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    result = pp.show()
+    assert result is None
+
+
+def test_suptitle_attaches_to_current_figure():
+    fig, ax = pp.subplots(axes_size=(50, 30))
+    result = pp.suptitle("Overall Title")
+    assert isinstance(result, Text)
+    assert result.get_text() == "Overall Title"
+    # It sits on the figure, not the axes
+    assert result in fig.texts
+
+
+def test_suptitle_forwards_kwargs():
+    fig, ax = pp.subplots(axes_size=(50, 30))
+    result = pp.suptitle("Title", fontsize=14, fontweight="bold")
+    assert result.get_fontsize() == 14
+    assert result.get_fontweight() == "bold"


### PR DESCRIPTION
## Summary

Users no longer need to `import matplotlib.pyplot as plt` alongside publiplots for common display tasks.

## New public API

| Call | What it does |
|---|---|
| `pp.show(*args, **kwargs)` | Thin wrapper around `plt.show` |
| `pp.suptitle(text, **kwargs)` | Thin wrapper around `plt.suptitle` (figure-level title) |

Both are additive — no breaking changes. They live in the new `src/publiplots/utils/display.py` module.

## Gallery + docs sweep

Replaced across the gallery, notebook, and Sphinx docs:
- `plt.show()` → `pp.show()` (90 sites)
- `plt.suptitle(...)` → `pp.suptitle(...)` (3 sites in `plot_11`)
- `plt.title('foo', ...)` → `ax.set_title('foo', ...)` (1 site in `plot_09` — no wrapper added, since plot functions already take `title=`)

Files where `import matplotlib.pyplot as plt` is no longer needed had the import dropped.

`tests/` are untouched — they still use `plt.close("all")` in fixtures, which is legitimate matplotlib fixture use, not user-facing.

## Audit

```bash
grep -rn "plt\.show\b\|plt\.suptitle\b\|plt\.title\b" . \
  --include="*.py" --include="*.rst" --include="*.md" --include="*.ipynb" \
  | grep -v "tests/" | grep -v ".worktrees" | grep -v "docs/superpowers" \
  | grep -v "src/publiplots/utils/display.py"
```

Returns only a source-code comment in `auto_layout.py:269` (describes downstream behavior; not a call).

## Test plan
- [x] New `tests/test_display.py` — 5 contract tests (export, return types, kwarg forwarding, fig attachment)
- [x] Full suite: 289 passed (284 baseline + 5 new)
- [x] Gallery smoke: all 14 examples OK
- [x] Notebook JSON integrity verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)