### PR TITLE
fix(upset): measurement-driven figure growth to prevent decoration crop

### DIFF
--- a/src/publiplots/plot/upset/diagram.py
+++ b/src/publiplots/plot/upset/diagram.py
@@ -328,8 +328,58 @@ def upsetplot(
         set_label=set_label,
     )
 
+    # Reserve vertical space for decorations (bar-top annotations, xlabel,
+    # title, ticklabels) that would otherwise clip because the gridspec spans
+    # the full figure (top=1/bottom=0). Draw once, measure overflow, grow the
+    # figure by the measured amount, and shift the gridspec inward so panel
+    # dimensions stay unchanged.
+    _reserve_upset_decoration_space(fig, ax_intersections, ax_sets, ax_matrix)
+
     return {
         "intersections": ax_intersections,
         "matrix": ax_matrix,
         "sets": ax_sets,
     }
+
+
+def _reserve_upset_decoration_space(fig, ax_intersections, ax_sets, ax_matrix):
+    """Grow the figure and shift the gridspec so decorations don't clip.
+
+    UpSet's gridspec uses ``top=1, bottom=0`` (zero margin). Bar-top
+    annotations, xlabels, titles, and ticklabels therefore extend outside
+    the figure canvas and clip on ``plt.show()`` or non-tight ``savefig``.
+
+    Measurement-driven fix: draw once, compute overflow in inches at the
+    top and bottom of the figure, grow ``figheight`` by that amount, then
+    shift the gridspec ``top``/``bottom`` inward by the same fractional
+    amount so the plotted panels keep their original dimensions.
+    """
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    tight = fig.get_tightbbox(renderer)
+    fig_bb = fig.bbox_inches
+
+    # Overflow in inches; negative means safely inside the canvas.
+    top_overflow = max(0.0, tight.y1 - fig_bb.y1)
+    bottom_overflow = max(0.0, -tight.y0)
+
+    if top_overflow == 0.0 and bottom_overflow == 0.0:
+        return  # Nothing to reserve.
+
+    # Small padding beyond the measured overflow so borders don't kiss the
+    # canvas edge.
+    pad_in = 4.0 / 72.0  # ~4 pt
+    top_pad_in = top_overflow + pad_in if top_overflow > 0 else 0.0
+    bottom_pad_in = bottom_overflow + pad_in if bottom_overflow > 0 else 0.0
+
+    current_h_in = fig.get_figheight()
+    new_h_in = current_h_in + top_pad_in + bottom_pad_in
+    fig.set_figheight(new_h_in)
+
+    # Recover the gridspec from any of its subplots and shift top/bottom
+    # inward by the padding we just added.
+    gs = ax_intersections.get_gridspec()
+    gs.update(
+        top=1.0 - top_pad_in / new_h_in,
+        bottom=bottom_pad_in / new_h_in,
+    )

--- a/tests/test_upset_layout.py
+++ b/tests/test_upset_layout.py
@@ -1,0 +1,82 @@
+"""Regression tests for UpSet layout fix (Path A).
+
+UpSet's gridspec spans top=1/bottom=0 (zero margin), so bar-top
+annotations, xlabels, titles, and ticklabels clip on plt.show / non-tight
+savefig. The fix measures post-draw overflow and grows the figure +
+shifts the gridspec inward to reserve space.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture(scope="module")
+def simple_sets():
+    rng = np.random.default_rng(42)
+    return {
+        "A": set(rng.integers(1, 100, 50)),
+        "B": set(rng.integers(20, 120, 50)),
+        "C": set(rng.integers(40, 140, 50)),
+        "D": set(rng.integers(60, 160, 50)),
+    }
+
+
+def _overflow(fig):
+    """Return (top_overflow_in, bottom_overflow_in) after drawing."""
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    tight = fig.get_tightbbox(renderer)
+    fig_bb = fig.bbox_inches
+    return (tight.y1 - fig_bb.y1, -tight.y0)
+
+
+def test_upsetplot_bare_fits_inside_canvas(simple_sets):
+    """Bare UpSet (no title, no labels) must not clip bar annotations or ticklabels."""
+    axes = pp.upsetplot(simple_sets)
+    fig = axes["intersections"].get_figure()
+    top, bottom = _overflow(fig)
+    assert top <= 0, f"top overflow {top:+.3f} in — bar annotations clipped"
+    assert bottom <= 0, f"bottom overflow {bottom:+.3f} in — xticklabels clipped"
+
+
+def test_upsetplot_with_decorations_fits_inside_canvas(simple_sets):
+    """UpSet with title + ylabel + xlabel must reserve space for all decorations."""
+    axes = pp.upsetplot(
+        simple_sets,
+        title="Set Overlap Analysis",
+        intersection_label="Intersection size",
+        set_label="Set size",
+    )
+    fig = axes["intersections"].get_figure()
+    top, bottom = _overflow(fig)
+    assert top <= 0, f"top overflow {top:+.3f} in — title/annotations clipped"
+    assert bottom <= 0, f"bottom overflow {bottom:+.3f} in — xlabel clipped"
+
+
+def test_upsetplot_decorations_grow_figure_vs_bare(simple_sets):
+    """Adding a title + labels should grow the figure beyond the bare version."""
+    axes_bare = pp.upsetplot(simple_sets)
+    h_bare = axes_bare["intersections"].get_figure().get_figheight()
+
+    axes_decorated = pp.upsetplot(
+        simple_sets,
+        title="Overlap",
+        intersection_label="Size",
+        set_label="Size",
+    )
+    h_decorated = axes_decorated["intersections"].get_figure().get_figheight()
+
+    assert h_decorated > h_bare, (
+        f"decorated figure ({h_decorated:.3f} in) should be taller than "
+        f"bare ({h_bare:.3f} in) — more decorations = more reserved space"
+    )


### PR DESCRIPTION
## Summary

Pre-existing bug: UpSet's `GridSpec` spans `top=1, bottom=0` (zero margin), so bar-top annotations, xlabels, titles, and ticklabels extend outside the figure canvas and clip on `plt.show()` or non-tight `savefig`.

## Fix (Path A per the handoff note)

After all UpSet drawing completes, measure the tight-bbox overflow against the figure bbox, grow `figheight` by the measured amount (plus a small padding), then shift the `GridSpec` `top`/`bottom` inward by the same fractional amount. Panel dimensions stay unchanged.

## Measurements

```
                          figure          overflow (in)
Before (on main)          7.00 × 2.00     top=+0.069  bottom=+0.149  CLIPPED
After, bare               7.00 × 2.33     top=−0.056  bottom=−0.056  SAFE
After, with title+labels  7.00 × 2.62     top=−0.056  bottom=−0.056  SAFE
```

Figure grows only as much as the actual decorations require — a bare UpSet gets less padding than one with `title=...` + `intersection_label=...` + `set_label=...`.

## Why Path A, not Path B

Path B (composer-friendly UpSet where axes are hosted by `pp.subplots` so `SubplotsAutoLayout` owns measurement automatically) is the architectural long-term answer and unlocks new use cases (e.g. heatmap above intersection bars sharing the x-axis). It's tracked as the bigger composer rewrite — planned after this PR + context compaction.

Path A is the narrow bug fix: restores safe decoration rendering today without redesigning the UpSet API.

## Test plan
- [x] New `tests/test_upset_layout.py` — 3 regression tests (bare fits, decorated fits, decorated > bare height)
- [x] Full suite: 292 passed (289 baseline + 3 new)
- [x] Gallery smoke: all 14 `examples/plots/*.py` render clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)