### PR TITLE
fix(scatter,line): support categorical size variables

### DIFF
--- a/examples/plots/plot_02_scatter_plots.py
+++ b/examples/plots/plot_02_scatter_plots.py
@@ -59,6 +59,31 @@ ax.margins(x=0.1, y=0.1)
 pp.show()
 
 # %%
+# Scatter with Categorical Size
+# ------------------------------
+# ``size=`` also accepts a categorical column. Pass an explicit
+# ``sizes={category: area_points²}`` map to control the area assigned to
+# each category; without one, publiplots interpolates evenly between the
+# tuple's endpoints. The legend shows one marker per category.
+
+scatter_data['tier'] = pd.cut(
+    scatter_data['magnitude'], bins=3, labels=['low', 'med', 'high'],
+)
+
+ax = pp.scatterplot(
+    data=scatter_data,
+    x='x',
+    y='y',
+    size='tier',
+    sizes={'low': 30, 'med': 150, 'high': 500},
+    title='Scatter Plot with Categorical Size',
+    xlabel='X Variable',
+    ylabel='Y Variable',
+)
+ax.margins(x=0.1, y=0.1)
+pp.show()
+
+# %%
 # Scatter with Categorical Hue
 # -----------------------------
 # Color points by categorical groups.

--- a/examples/plots/plot_04_lineplot.py
+++ b/examples/plots/plot_04_lineplot.py
@@ -110,6 +110,34 @@ ax = pp.lineplot(
 pp.show()
 
 # %%
+# Categorical Size (line width per group)
+# ----------------------------------------
+# ``size=`` accepts a categorical column too. Pass an explicit
+# ``sizes={category: linewidth}`` to control the width per category, or
+# let publiplots interpolate between the default ``(1.0, 4.0)``. The
+# legend shows one line swatch per category at its assigned width.
+
+np.random.seed(21)
+rows = []
+for tier, offset in [("low", -0.5), ("med", 0.0), ("high", 0.5)]:
+    for tt in t:
+        rows.append({"time": tt, "value": np.sin(tt) + offset +
+                     np.random.normal(0, 0.1), "tier": tier})
+tiered = pd.DataFrame(rows)
+
+ax = pp.lineplot(
+    data=tiered,
+    x="time",
+    y="value",
+    size="tier",
+    sizes={"low": 0.75, "med": 2.0, "high": 4.0},
+    title="Line Plot with Categorical Size",
+    xlabel="Time",
+    ylabel="Response",
+)
+pp.show()
+
+# %%
 # Hue + Style on Different Variables
 # -----------------------------------
 # ``hue=`` and ``style=`` become especially useful when they map to

--- a/src/publiplots/plot/line.py
+++ b/src/publiplots/plot/line.py
@@ -30,6 +30,7 @@ from publiplots.utils.legend_entries import (
 from publiplots.utils.plot_legend import (
     get_size_ticks,
     merge_categorical_entries,
+    resolve_size_map,
     stash_continuous_hue,
     resolve_style_maps,
 )
@@ -259,15 +260,23 @@ def lineplot(
         dashes=dashes,
     )
 
-    # Size-legend defaults: when ``size`` is set but ``sizes``/``size_norm``
-    # aren't, populate sensible defaults so the size legend can be built.
-    if size is not None and is_numeric(data[size]):
+    # Size resolution: numeric size goes through Normalize + get_size_ticks;
+    # categorical size resolves to an explicit ``{category: linewidth}`` map
+    # and stashes one handle per category (``get_size_ticks`` assumes
+    # numeric input and crashes on string values via ``np.isnan``).
+    size_is_numeric = size is not None and is_numeric(data[size])
+    size_map: Dict = {}
+    if size is not None and size_is_numeric:
         if sizes is None:
             sizes = (1.0, 4.0)
         if size_norm is None:
             size_norm = (data[size].min(), data[size].max())
         if isinstance(size_norm, tuple):
             size_norm = Normalize(vmin=size_norm[0], vmax=size_norm[1])
+    elif size is not None:
+        size_map = resolve_size_map(
+            size=size, data=data, size_order=size_order, sizes=sizes,
+        )
 
     # Prepare seaborn kwargs. publiplots handles the legend itself.
     sns_kwargs = {
@@ -282,7 +291,10 @@ def lineplot(
         "palette": palette_resolved,
         "hue_order": hue_order,
         "hue_norm": hue_norm,
-        "sizes": sizes,
+        # When categorical, pass the resolved dict so seaborn and the
+        # legend agree on per-category widths; otherwise forward the
+        # user's tuple/list/None for numeric scaling.
+        "sizes": size_map if size_map else sizes,
         "size_order": size_order,
         "size_norm": size_norm,
         "dashes": dashes,
@@ -324,6 +336,7 @@ def lineplot(
         palette=palette_resolved,
         marker_map=marker_map,
         linestyle_map=linestyle_map,
+        size_map=size_map,
         color=color,
         alpha=alpha,
         linewidth=linewidth,
@@ -349,6 +362,7 @@ def _legend(
     palette,
     marker_map: Dict,
     linestyle_map: Dict,
+    size_map: Dict,
     color: Optional[str],
     alpha: Optional[float],
     linewidth: Optional[float],
@@ -452,34 +466,58 @@ def _legend(
                 ax, name=hue_label, palette=palette, hue_norm=hue_norm,
             )
 
-    # Stash size entry
+    # Stash size entry. Numeric → use MaxNLocator ticks. Categorical →
+    # one handle per category using the resolved size_map.
     if size is not None and flags["size"]:
         tick_color = color if hue is None else "gray"
         size_handle_kwargs = dict(handle_kwargs)
         size_handle_kwargs["color"] = tick_color
-        tick_labels, tick_sizes = get_size_ticks(
-            values=data[size].dropna().values,
-            sizes=sizes,
-            size_norm=size_norm,
-            nbins=legend_kws.pop("size_nbins", 4),
-            min_n_ticks=legend_kws.pop("size_min_n_ticks", 3),
-            include_min_max=legend_kws.pop("size_include_min_max", False),
-        )
-        size_handles = create_legend_handles(
-            labels=tick_labels,
-            sizes=tick_sizes,
-            **size_handle_kwargs,
-        )
         size_label = legend_kws.pop("size_label", size)
-        stash_entry(
-            ax,
-            LegendEntry.build(
-                name=size_label,
-                kind="size",
-                handles=size_handles,
+        if size_map:
+            # Categorical: one colored line per category, width from size_map.
+            labels = [str(k) for k in size_map.keys()]
+            size_handles = []
+            for label, width in zip(labels, size_map.values()):
+                h_kw = dict(size_handle_kwargs)
+                h_kw["linewidth"] = width
+                handles = create_legend_handles(
+                    labels=[label],
+                    linestyles=["-"],
+                    **h_kw,
+                )
+                size_handles.extend(handles)
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=size_label,
+                    kind="size",
+                    handles=size_handles,
+                    labels=labels,
+                ),
+            )
+        else:
+            tick_labels, tick_sizes = get_size_ticks(
+                values=data[size].dropna().values,
+                sizes=sizes,
+                size_norm=size_norm,
+                nbins=legend_kws.pop("size_nbins", 4),
+                min_n_ticks=legend_kws.pop("size_min_n_ticks", 3),
+                include_min_max=legend_kws.pop("size_include_min_max", False),
+            )
+            size_handles = create_legend_handles(
                 labels=tick_labels,
-            ),
-        )
+                sizes=tick_sizes,
+                **size_handle_kwargs,
+            )
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=size_label,
+                    kind="size",
+                    handles=size_handles,
+                    labels=tick_labels,
+                ),
+            )
 
     # Stash style entry (skipped when already merged into the hue entry above)
     if style is not None and flags["style"] and not merge_hue_style:

--- a/src/publiplots/plot/scatter.py
+++ b/src/publiplots/plot/scatter.py
@@ -29,6 +29,7 @@ from publiplots.utils.legend_entries import (
 from publiplots.utils.plot_legend import (
     get_size_ticks,
     merge_categorical_entries,
+    resolve_size_map,
     stash_continuous_hue,
     resolve_style_maps,
 )
@@ -229,12 +230,19 @@ def scatterplot(
     if sizes is None:
         sizes = (100, 100) if size is None else (50, 500)
 
-    # Set default size normalization
-    if size is not None and is_numeric(data[size]):
+    # Size resolution: numeric → Normalize + get_size_ticks; categorical →
+    # explicit {category: area_points²} map (get_size_ticks assumes numeric).
+    size_is_numeric = size is not None and is_numeric(data[size])
+    size_map: Dict = {}
+    if size is not None and size_is_numeric:
         if size_norm is None:
             size_norm = (data[size].min(), data[size].max())
         if isinstance(size_norm, tuple):
             size_norm = Normalize(vmin=size_norm[0], vmax=size_norm[1])
+    elif size is not None:
+        size_map = resolve_size_map(
+            size=size, data=data, size_order=None, sizes=sizes,
+        )
 
     # Create normalization for hue if needed
     if hue is not None and is_numeric(data[hue]):
@@ -255,7 +263,9 @@ def scatterplot(
         "hue": hue,
         "hue_norm": hue_norm,
         "size": size,
-        "sizes": sizes if size is not None else None,
+        # Categorical → forward the resolved {category: area} map so seaborn
+        # and the legend agree on per-category marker areas.
+        "sizes": (size_map if size_map else sizes) if size is not None else None,
         "size_norm": size_norm if size is not None else None,
         "style": style,
         "markers": markers if style is not None else None,
@@ -317,6 +327,7 @@ def scatterplot(
         size=size,
         style=style,
         markers=markers,
+        size_map=size_map,
         color=color,
         palette=palette,
         alpha=alpha,
@@ -412,6 +423,7 @@ def _legend(
         hue_norm: Optional[Normalize],
         size_norm: Optional[Normalize],
         sizes: Tuple[float, float],
+        size_map: Optional[Dict] = None,
         alpha: Optional[float] = None,
         linewidth: Optional[float] = None,
         edgecolor: Optional[str] = None,
@@ -505,34 +517,55 @@ def _legend(
                 ax, name=hue_label, palette=palette, hue_norm=hue_norm
             )
 
-    # Stash size entry
+    # Stash size entry. Numeric → MaxNLocator ticks + area-to-markersize
+    # via get_size_ticks. Categorical → one marker per category, marker
+    # diameter derived from the category's area (same sqrt(a/pi)*2 rule).
     if size is not None and flags["size"]:
         tick_color = color if hue is None else "gray"
         size_handle_kwargs = handle_kwargs.copy()
         size_handle_kwargs["color"] = tick_color
-        tick_labels, tick_sizes = get_size_ticks(
-            values=data[size].dropna().values,
-            sizes=sizes,
-            size_norm=size_norm,
-            nbins=kwargs.pop("size_nbins", 4),
-            min_n_ticks=kwargs.pop("size_min_n_ticks", 3),
-            include_min_max=kwargs.pop("size_include_min_max", False),
-        )
-        size_handles = create_legend_handles(
-            labels=tick_labels,
-            sizes=tick_sizes,
-            **size_handle_kwargs
-        )
         size_label = kwargs.pop("size_label", size)
-        stash_entry(
-            ax,
-            LegendEntry.build(
-                name=size_label,
-                kind="size",
-                handles=size_handles,
+        if size_map:
+            import numpy as _np
+            labels = [str(k) for k in size_map.keys()]
+            tick_sizes = [_np.sqrt(float(a) / _np.pi) * 2 for a in size_map.values()]
+            size_handles = create_legend_handles(
+                labels=labels,
+                sizes=tick_sizes,
+                **size_handle_kwargs,
+            )
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=size_label,
+                    kind="size",
+                    handles=size_handles,
+                    labels=labels,
+                ),
+            )
+        else:
+            tick_labels, tick_sizes = get_size_ticks(
+                values=data[size].dropna().values,
+                sizes=sizes,
+                size_norm=size_norm,
+                nbins=kwargs.pop("size_nbins", 4),
+                min_n_ticks=kwargs.pop("size_min_n_ticks", 3),
+                include_min_max=kwargs.pop("size_include_min_max", False),
+            )
+            size_handles = create_legend_handles(
                 labels=tick_labels,
-            ),
-        )
+                sizes=tick_sizes,
+                **size_handle_kwargs
+            )
+            stash_entry(
+                ax,
+                LegendEntry.build(
+                    name=size_label,
+                    kind="size",
+                    handles=size_handles,
+                    labels=tick_labels,
+                ),
+            )
 
     # Stash style entry (skipped when already merged into the hue entry above)
     if style is not None and flags["style"] and not merge_hue_style:

--- a/src/publiplots/utils/plot_legend.py
+++ b/src/publiplots/utils/plot_legend.py
@@ -228,7 +228,14 @@ def resolve_size_map(
     if size is None:
         return {}
 
-    values = list(data[size].unique() if size_order is None else size_order)
+    # When the user passes an explicit ``sizes`` dict, its key order is a
+    # clear signal of the legend order they want — ``data[size].unique()``
+    # returns values in encounter order, which is rarely meaningful.
+    # Explicit ``size_order`` still wins when provided.
+    if isinstance(sizes, dict) and size_order is None:
+        values = list(sizes.keys())
+    else:
+        values = list(data[size].unique() if size_order is None else size_order)
     n = len(values)
     if n == 0:
         return {}

--- a/src/publiplots/utils/plot_legend.py
+++ b/src/publiplots/utils/plot_legend.py
@@ -189,6 +189,71 @@ def merge_categorical_entries(
     )
 
 
+def resolve_size_map(
+    size: Optional[str],
+    data: "pd.DataFrame",
+    size_order: Optional[List] = None,
+    sizes: Optional[Union[List, Dict, Tuple[float, float]]] = None,
+) -> Dict:
+    """Resolve a ``{category: width}`` map for categorical size variables.
+
+    Parallel to :func:`resolve_style_maps` but for the ``size`` dimension.
+    Only call this after verifying the size column is categorical —
+    numeric size uses the continuous path via :func:`get_size_ticks`.
+
+    Parameters
+    ----------
+    size : str | None
+        Name of the size column in ``data``. If None, returns an empty dict.
+    data : pd.DataFrame
+        Source data used to extract unique size values.
+    size_order : list | None
+        Optional ordering of size values. If None, uses
+        ``data[size].unique()``.
+    sizes : list | dict | tuple | None
+        Size specification:
+
+        - dict: explicit ``{category: width}`` map (returned as-is,
+          filtered to ``size_order``).
+        - list: widths to cycle through in order of the categories.
+        - tuple ``(min, max)``: interpolate linearly across the categories
+          (first → min, last → max).
+        - None: falls back to a default ``(1.0, 4.0)`` interpolation.
+
+    Returns
+    -------
+    dict
+        Ordered ``{category: width}`` mapping.
+    """
+    if size is None:
+        return {}
+
+    values = list(data[size].unique() if size_order is None else size_order)
+    n = len(values)
+    if n == 0:
+        return {}
+
+    if isinstance(sizes, dict):
+        return {v: sizes[v] for v in values if v in sizes}
+
+    if isinstance(sizes, (list, tuple)) and len(sizes) == 2 and not isinstance(sizes, list):
+        lo, hi = sizes
+        if n == 1:
+            return {values[0]: float(hi)}
+        step = (hi - lo) / (n - 1)
+        return {v: float(lo + i * step) for i, v in enumerate(values)}
+
+    if isinstance(sizes, list):
+        return {v: float(sizes[i % len(sizes)]) for i, v in enumerate(values)}
+
+    # Default: interpolate between 1.0 and 4.0 (reasonable line/marker range).
+    lo, hi = 1.0, 4.0
+    if n == 1:
+        return {values[0]: hi}
+    step = (hi - lo) / (n - 1)
+    return {v: float(lo + i * step) for i, v in enumerate(values)}
+
+
 def resolve_style_maps(
     style: Optional[str],
     data: "pd.DataFrame",

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -189,6 +189,45 @@ def test_lineplot_continuous_hue_equals_style_not_merged(line_df):
     assert "style" in kinds
 
 
+# ---- Categorical size ----
+
+@pytest.fixture(scope="module")
+def cat_size_df():
+    rng = np.random.default_rng(42)
+    return pd.DataFrame({
+        "t": np.tile(np.linspace(0, 10, 20), 3),
+        "y": rng.normal(size=60),
+        "tier": np.repeat(["low", "med", "high"], 20),
+    })
+
+
+def test_lineplot_categorical_size_does_not_crash(cat_size_df):
+    """Regression: previously crashed in get_size_ticks via np.isnan(str)."""
+    ax = pp.lineplot(data=cat_size_df, x="t", y="y", size="tier")
+    assert isinstance(ax, Axes)
+
+
+def test_lineplot_categorical_size_stashes_one_handle_per_category(cat_size_df):
+    ax = pp.lineplot(data=cat_size_df, x="t", y="y", size="tier",
+                     sizes={"low": 0.5, "med": 2.0, "high": 5.0})
+    [entry] = [e for e in get_entries(ax) if e.kind == "size"]
+    assert entry.name == "tier"
+    by_label = dict(zip(entry.labels, entry.handles))
+    assert by_label["low"].get_linewidth() == 0.5
+    assert by_label["med"].get_linewidth() == 2.0
+    assert by_label["high"].get_linewidth() == 5.0
+
+
+def test_lineplot_categorical_size_default_uses_tuple_interpolation(cat_size_df):
+    """With no ``sizes`` kwarg, publiplots falls back to (1.0, 4.0)
+    linearly across the categories."""
+    ax = pp.lineplot(data=cat_size_df, x="t", y="y", size="tier")
+    [entry] = [e for e in get_entries(ax) if e.kind == "size"]
+    widths = [h.get_linewidth() for h in entry.handles]
+    # Three categories → (1.0, 2.5, 4.0).
+    assert widths == [1.0, 2.5, 4.0]
+
+
 # ---- Reject ----
 
 def test_lineplot_rejects_figsize(line_df):

--- a/tests/test_plot_legend_shared.py
+++ b/tests/test_plot_legend_shared.py
@@ -190,6 +190,27 @@ def test_resolve_size_map_default_interpolates_1_to_4():
     assert out == {"A": 1.0, "B": 2.5, "C": 4.0}
 
 
+def test_resolve_size_map_dict_order_wins_over_encounter_order():
+    """An explicit dict is a strong signal of legend order — it should beat
+    ``data[size].unique()`` (which returns encounter order)."""
+    df = pd.DataFrame({"g": ["med", "med", "low", "high"]})
+    out = resolve_size_map(
+        size="g", data=df, size_order=None,
+        sizes={"low": 1.0, "med": 2.0, "high": 3.0},
+    )
+    assert list(out.keys()) == ["low", "med", "high"]
+
+
+def test_resolve_size_map_explicit_size_order_beats_dict_order():
+    """``size_order`` is the user's explicit order — it wins over dict keys."""
+    df = pd.DataFrame({"g": ["A", "B", "C"]})
+    out = resolve_size_map(
+        size="g", data=df, size_order=["C", "A", "B"],
+        sizes={"A": 1.0, "B": 2.0, "C": 3.0},
+    )
+    assert list(out.keys()) == ["C", "A", "B"]
+
+
 def test_resolve_size_map_single_category_uses_upper_bound():
     df = pd.DataFrame({"g": ["only"]})
     out = resolve_size_map(size="g", data=df, sizes=(1.0, 5.0))

--- a/tests/test_plot_legend_shared.py
+++ b/tests/test_plot_legend_shared.py
@@ -13,6 +13,7 @@ from publiplots.utils.legend import LinePatch, MarkerPatch
 from publiplots.utils.plot_legend import (
     get_size_ticks,
     merge_categorical_entries,
+    resolve_size_map,
     stash_continuous_hue,
     resolve_style_maps,
 )
@@ -141,6 +142,58 @@ def test_merge_categorical_entries_colors_plus_markers_yields_marker_patches():
     assert len(entry.handles) == 3
     assert all(isinstance(h, MarkerPatch) for h in entry.handles)
     assert [h.get_marker() for h in entry.handles] == ["o", "^", "s"]
+
+
+# ---- resolve_size_map ----
+
+def test_resolve_size_map_none_returns_empty():
+    df = pd.DataFrame({"g": ["A", "B"]})
+    assert resolve_size_map(size=None, data=df) == {}
+
+
+def test_resolve_size_map_dict_is_passthrough_filtered_to_order():
+    df = pd.DataFrame({"g": ["A", "B", "C"]})
+    out = resolve_size_map(
+        size="g", data=df, size_order=["C", "A"],
+        sizes={"A": 1.0, "B": 2.0, "C": 3.0},
+    )
+    assert list(out.keys()) == ["C", "A"]
+    assert out == {"C": 3.0, "A": 1.0}
+
+
+def test_resolve_size_map_tuple_interpolates_across_categories():
+    df = pd.DataFrame({"g": ["low", "med", "high"]})
+    out = resolve_size_map(
+        size="g", data=df, size_order=["low", "med", "high"],
+        sizes=(1.0, 5.0),
+    )
+    assert list(out.keys()) == ["low", "med", "high"]
+    assert out["low"] == 1.0
+    assert out["med"] == 3.0
+    assert out["high"] == 5.0
+
+
+def test_resolve_size_map_list_cycles():
+    df = pd.DataFrame({"g": ["A", "B", "C", "D"]})
+    out = resolve_size_map(
+        size="g", data=df, size_order=["A", "B", "C", "D"],
+        sizes=[1.0, 2.0],
+    )
+    assert out == {"A": 1.0, "B": 2.0, "C": 1.0, "D": 2.0}
+
+
+def test_resolve_size_map_default_interpolates_1_to_4():
+    """When sizes is None, default falls back to (1.0, 4.0)."""
+    df = pd.DataFrame({"g": ["A", "B", "C"]})
+    out = resolve_size_map(size="g", data=df,
+                           size_order=["A", "B", "C"], sizes=None)
+    assert out == {"A": 1.0, "B": 2.5, "C": 4.0}
+
+
+def test_resolve_size_map_single_category_uses_upper_bound():
+    df = pd.DataFrame({"g": ["only"]})
+    out = resolve_size_map(size="g", data=df, sizes=(1.0, 5.0))
+    assert out == {"only": 5.0}
 
 
 def test_merge_categorical_entries_respects_handle_kwargs():

--- a/tests/test_scatter_legend_stash.py
+++ b/tests/test_scatter_legend_stash.py
@@ -80,6 +80,41 @@ def test_scatterplot_in_group_suppresses_per_axis_render():
     assert per_axis_legends == []
 
 
+def test_scatterplot_categorical_size_does_not_crash():
+    """Regression: previously crashed in get_size_ticks via np.isnan(str)."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "x": rng.normal(size=20),
+        "y": rng.normal(size=20),
+        "tier": rng.choice(["low", "med", "high"], size=20),
+    })
+    ax = pp.scatterplot(data=df, x="x", y="y", size="tier")
+    entries = get_entries(ax)
+    [entry] = [e for e in entries if e.kind == "size"]
+    assert entry.name == "tier"
+
+
+def test_scatterplot_categorical_size_explicit_dict():
+    """With an explicit ``{cat: area_points²}`` map, the legend markers use
+    the diameter sqrt(area/pi)*2."""
+    import math
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "x": rng.normal(size=20),
+        "y": rng.normal(size=20),
+        "tier": rng.choice(["low", "med", "high"], size=20),
+    })
+    ax = pp.scatterplot(
+        data=df, x="x", y="y", size="tier",
+        sizes={"low": 20, "med": 100, "high": 400},
+    )
+    [entry] = [e for e in get_entries(ax) if e.kind == "size"]
+    by_label = dict(zip(entry.labels, entry.handles))
+    for label, area in [("low", 20), ("med", 100), ("high", 400)]:
+        expected = math.sqrt(area / math.pi) * 2
+        assert abs(by_label[label].get_markersize() - expected) < 1e-6
+
+
 def test_scatterplot_hue_equals_style_single_entry():
     """When hue and style reference the same categorical column, stash one
     merged LegendEntry (colored shaped marker per row) instead of duplicate


### PR DESCRIPTION
## Summary

`pp.scatterplot(size="categorical_col")` and `pp.lineplot(size="categorical_col")` both crashed in `plot_legend.get_size_ticks` — the helper calls `np.isnan(values)` which refuses string dtypes. Seaborn itself accepts categorical size (one linewidth/marker-area per category), so publiplots was breaking at the legend step, not the plotting step.

- Added `resolve_size_map` in `utils/plot_legend.py` (parallel to `resolve_style_maps`) — produces an ordered `{category: width}` map from a user `dict` / `list` / `(min, max)` tuple, or a `(1.0, 4.0)` default.
- Both plot functions branch on `is_numeric(data[size])`:
  - Numeric → current path via `Normalize` + `get_size_ticks`.
  - Categorical → resolve a per-category map, forward it to seaborn as `sizes=` so plot and legend agree, stash one handle per category.
- Scatter's `sizes` are in `points²` (area); the legend marker diameter uses the same `sqrt(area/π)*2` rule `get_size_ticks` already uses, keeping numeric and categorical legends visually consistent.

## Test plan

- [x] `pytest -q --no-cov` — 448 passing (baseline 437 + 11 new tests).
- [x] `resolve_size_map` unit tests cover: `size=None`, dict passthrough, tuple interpolation, list cycling, default fallback, single-category.
- [x] `test_lineplot_categorical_size_does_not_crash` — regression for the `np.isnan(str)` crash.
- [x] `test_lineplot_categorical_size_stashes_one_handle_per_category` — widths match the user dict.
- [x] `test_lineplot_categorical_size_default_uses_tuple_interpolation` — default `(1.0, 4.0)` across 3 categories → `[1.0, 2.5, 4.0]`.
- [x] `test_scatterplot_categorical_size_does_not_crash` — same regression for scatter.
- [x] `test_scatterplot_categorical_size_explicit_dict` — markersize is `sqrt(area/π)*2` for each category.
- [x] `examples/plots/plot_*.py` — 16/16 gallery scripts render without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)