### PR TITLE
fix(legend): normalize bare dash tuples in HandlerLineMarker

### DIFF
--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -26,6 +26,27 @@ import matplotlib.pyplot as plt
 # Custom Legend Handlers
 # =============================================================================
 
+
+def _normalize_dash_linestyle(ls: Any) -> Any:
+    """Normalize a bare on-off dash tuple to matplotlib's canonical form.
+
+    Seaborn accepts ``dashes={label: (on, off)}`` and stores the bare tuple
+    verbatim on the handle; matplotlib's ``Line2D._get_dash_pattern`` only
+    accepts named strings or the ``(offset, (on, off, ...))`` form, so a
+    ``(on, off)`` tuple fed straight back into a new ``Line2D`` crashes with
+    ``TypeError: 'int' object is not iterable``.
+
+    Returns anything other than a bare numeric 2-tuple unchanged.
+    """
+    if (
+        isinstance(ls, tuple)
+        and len(ls) == 2
+        and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in ls)
+    ):
+        return (0, ls)
+    return ls
+
+
 class RectanglePatch(Patch):
     """
     Custom rectangle patch object for legend handles.
@@ -457,7 +478,7 @@ class HandlerLineMarker(HandlerBase):
             color = orig_handle.get_facecolor()
             edgecolor = orig_handle.get_edgecolor()
             alpha = orig_handle.get_alpha() if orig_handle.get_alpha() is not None else alpha
-            linestyle = orig_handle.get_linestyle()
+            linestyle = _normalize_dash_linestyle(orig_handle.get_linestyle())
             linewidth = orig_handle.get_linewidth()
             markeredgewidth = orig_handle.get_markeredgewidth()
             # Use actual markersize from patch (already in correct units)
@@ -468,7 +489,7 @@ class HandlerLineMarker(HandlerBase):
         # Extract from Line2D (standard matplotlib - fallback)
         elif isinstance(orig_handle, Line2D):
             marker = orig_handle.get_marker() or marker
-            linestyle = orig_handle.get_linestyle()
+            linestyle = _normalize_dash_linestyle(orig_handle.get_linestyle())
             color = orig_handle.get_color() or orig_handle.get_markerfacecolor()
             line_size = orig_handle.get_markersize()
             if line_size:
@@ -508,17 +529,9 @@ class HandlerLine(HandlerBase):
         color = orig_handle.get_facecolor()
         linewidth = orig_handle.get_linewidth()
         linestyle = orig_handle.get_linestyle() if hasattr(orig_handle, "get_linestyle") else "-"
+        linestyle = _normalize_dash_linestyle(linestyle)
         if not linewidth:
             linewidth = resolve_param("lines.linewidth")
-
-        # Normalize seaborn-style dash tuples (on, off) → matplotlib's
-        # (offset, (on, off)) form. A plain (on, off) tuple is how seaborn
-        # accepts ``dashes={label: (4, 2)}``; matplotlib's Line2D needs the
-        # (offset, dash_seq) form.
-        if isinstance(linestyle, tuple) and len(linestyle) == 2 and all(
-            isinstance(v, (int, float)) for v in linestyle
-        ):
-            linestyle = (0, linestyle)
 
         # Legend line is always fully opaque for readability, matching
         # HandlerLineMarker's behavior. The stored alpha on the handle

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -110,6 +110,37 @@ def test_lineplot_style_dashes_uses_line_patch_with_dash_linestyle(line_df):
     assert (1, 1) in linestyles
 
 
+def test_lineplot_hue_style_dashes_markers_renders(line_df):
+    """Regression for issue #99: hue + style + dashes={...(on, off)...} + markers
+    used to crash in matplotlib's ``_get_dash_pattern`` during legend render
+    because ``HandlerLineMarker`` forwarded the raw on-off tuple to a fresh
+    ``Line2D``. Rendering must not raise."""
+    fig, ax = pp.subplots(axes_size=(50, 40))
+    pp.lineplot(
+        data=line_df, x="t", y="y",
+        hue="g", style="m",
+        palette={"A": "#43adaa", "B": "#6565eb"},
+        dashes={"raw": "", "smoothed": (4, 2)},
+        markers=True, ax=ax, sort=False, errorbar=None, legend=True,
+    )
+    fig.canvas.draw()
+
+
+def test_lineplot_hue_equals_style_dashes_markers_renders(line_df):
+    """Regression for issue #99, merge_hue_style branch: when hue == style the
+    handle is a merged ``LineMarkerPatch`` carrying the raw dash tuple. It must
+    render without crashing too."""
+    fig, ax = pp.subplots(axes_size=(50, 40))
+    pp.lineplot(
+        data=line_df, x="t", y="y",
+        hue="g", style="g",
+        palette={"A": "#43adaa", "B": "#6565eb"},
+        dashes={"A": (4, 2), "B": (1, 1)},
+        markers=True, ax=ax, sort=False, errorbar=None, legend=True,
+    )
+    fig.canvas.draw()
+
+
 # ---- Legend stash ----
 
 def test_lineplot_legend_false_stashes_nothing(line_df):


### PR DESCRIPTION
Closes #99.

## Summary

- `pp.lineplot(hue=..., style=..., dashes={'X': (4, 2)}, markers=True)` crashed in matplotlib's `Line2D._get_dash_pattern` because `HandlerLineMarker._extract_properties` forwarded the raw `(on, off)` tuple to a fresh `Line2D`, which only accepts the canonical `(offset, (on, off, ...))` form.
- `HandlerLine` already normalized this inline; extracted the logic into a shared `_normalize_dash_linestyle` helper and called it from both handlers so they can't drift again.
- Added two regression tests: the issue's exact path (`hue + style + dashes{tuple} + markers`) and the `merge_hue_style` branch (`hue == style`) that also flows through `HandlerLineMarker`.

## Root cause

`HandlerLine.create_artists` (the pure-`style` path, no markers) was already handling this — lines ~514–521 in `utils/legend.py`. But the `hue + style + markers` path lands in `HandlerLineMarker`, which was never updated to do the same normalization. The fix is render-time only; the stash-time contract (user tuples preserved verbatim on the handle) is unchanged.

## Test plan

- [x] Issue #99 repro now renders without crashing
- [x] New test `test_lineplot_hue_style_dashes_markers_renders` passes
- [x] New test `test_lineplot_hue_equals_style_dashes_markers_renders` passes
- [x] Full `tests/test_line.py` + `tests/test_legend_*.py` pass (42 tests)
- [x] Full repo suite passes (465 tests)

Minimal repro now works:

```python
import matplotlib; matplotlib.use("Agg")
import pandas as pd, numpy as np, publiplots as pp

df = pd.DataFrame({
    "x": ["a","b","c"] * 4, "y": np.random.rand(12),
    "h": ["A"]*6 + ["B"]*6, "s": (["D"]*3 + ["U"]*3) * 2,
})
fig, ax = pp.subplots()
pp.lineplot(data=df, x="x", y="y", hue="h", style="s",
            palette={"A": "#43adaa", "B": "#6565eb"},
            dashes={"D": "", "U": (4, 2)},
            markers=True, ax=ax, sort=False, errorbar=None, legend=True)
fig.savefig("/tmp/x.png")  # no longer raises
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
