### PR TITLE
fix(lineplot): apply publiplots double-layer marker styling

### DIFF
--- a/examples/plots/plot_04_lineplot.py
+++ b/examples/plots/plot_04_lineplot.py
@@ -170,6 +170,32 @@ ax = pp.lineplot(
 pp.show()
 
 # %%
+# Markers on Aggregated Points
+# -----------------------------
+# ``markers=True`` draws a marker at each aggregated x position —
+# useful to emphasise discrete observations on top of the trend line.
+# publiplots styles markers with the same double-layer convention as
+# ``pp.pointplot``: a semi-transparent fill over a solid colored ring,
+# so the fill reads the group color without hiding the connecting
+# line. ``edgecolor=`` overrides the ring color if you want a neutral
+# outline for high-density plots.
+
+ax = pp.lineplot(
+    data=two_vars,
+    x="time",
+    y="value",
+    hue="group",
+    style="method",
+    palette="pastel",
+    markers=True,
+    dashes=False,
+    title="Hue + Style with Markers",
+    xlabel="Time",
+    ylabel="Response",
+)
+pp.show()
+
+# %%
 # Hue and Style on the Same Variable
 # -----------------------------------
 # When ``hue=`` and ``style=`` map to the *same* column, publiplots

--- a/src/publiplots/plot/line.py
+++ b/src/publiplots/plot/line.py
@@ -318,6 +318,19 @@ def lineplot(
     sns_kwargs.update(kwargs)
     sns.lineplot(**sns_kwargs)
 
+    # Apply publiplots double-layer marker styling (shared with pointplot):
+    # pale fill, solid ring, no line bleed-through. Seaborn's default is
+    # a white edge on an opaque pastel face, which clashes with the
+    # visual language pointplot established.
+    from publiplots.utils.transparency import apply_double_layer_markers
+    apply_double_layer_markers(
+        ax,
+        alpha=alpha,
+        markersize=markersize,
+        markeredgewidth=markeredgewidth,
+        edgecolor=edgecolor,
+    )
+
     # Labels
     if xlabel:
         ax.set_xlabel(xlabel)

--- a/src/publiplots/plot/point.py
+++ b/src/publiplots/plot/point.py
@@ -9,7 +9,7 @@ from publiplots.utils.validation import is_categorical
 import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
-from matplotlib.colors import to_rgba, Normalize
+from matplotlib.colors import Normalize
 from matplotlib.cm import ScalarMappable
 import numpy as np
 import pandas as pd
@@ -301,9 +301,10 @@ def pointplot(
     # Create pointplot
     sns.pointplot(**pointplot_kwargs)
 
-    # Apply marker styling (double-layer effect)
-    _apply_marker_styling(
-        ax=ax,
+    # Apply marker styling (double-layer effect — shared with lineplot)
+    from publiplots.utils.transparency import apply_double_layer_markers
+    apply_double_layer_markers(
+        ax,
         alpha=alpha,
         edgecolor=edgecolor,
     )
@@ -389,78 +390,6 @@ def _format_for_custom_errorbar(
     data[value_col] = data["__value"]
     data.drop(columns=["__value"], inplace=True)
     return data
-
-
-def _apply_marker_styling(
-    ax: Axes,
-    alpha: float,
-    edgecolor: Optional[str] = None,
-) -> List[Dict]:
-    """
-    Apply double-layer marker styling to pointplot.
-
-    Extracts markers from lines, removes them, and redraws with:
-    1. White background layer
-    2. Semi-transparent colored fill layer
-
-    Parameters
-    ----------
-    ax : Axes
-        Axes containing the pointplot.
-    alpha : float
-        Transparency for marker fill.
-    markeredgewidth : float
-        Width of marker edges.
-
-    """
-    # Extract markers and line info from lines
-    markers = []
-    for line in ax.lines:
-        marker = line.get_marker()
-        if marker != "None":
-            markers.append({
-                'x': line.get_xdata(),
-                'y': line.get_ydata(),
-                'marker': marker,
-                'color': line.get_color(),
-                'markersize': line.get_markersize(),
-                'linestyle': line.get_linestyle(),
-                'linewidth': line.get_linewidth(),
-                'markeredgewidth': line.get_markeredgewidth(),
-            })
-            # Remove marker from original line (keep the line itself)
-            line.set_markersize(0)
-
-    # Redraw markers with double-layer effect
-    for data in markers:
-        x = data['x']
-        y = data['y']
-        marker = data['marker']
-        color = data['color']
-        size = data['markersize']
-        markeredgewidth = data['markeredgewidth'] 
-
-        # Layer 1: White background (no edge)
-        ax.plot(
-            x, y, marker,
-            markeredgecolor=edgecolor if edgecolor else color,
-            markerfacecolor="white",
-            markersize=size,
-            markeredgewidth=0,
-            linestyle='none',
-            zorder=99
-        )
-
-        # Layer 2: Semi-transparent colored fill with edge
-        ax.plot(
-            x, y, marker,
-            markeredgecolor=edgecolor if edgecolor else color,
-            markerfacecolor=to_rgba(color, alpha),
-            markersize=size,
-            markeredgewidth=markeredgewidth,
-            linestyle='none',
-            zorder=100
-        )
 
 
 def _legend(

--- a/src/publiplots/utils/transparency.py
+++ b/src/publiplots/utils/transparency.py
@@ -108,6 +108,89 @@ class ArtistTracker:
                 apply_transparency(new_patches, face_alpha=face_alpha, edge_alpha=edge_alpha)
 
 
+def apply_double_layer_markers(
+    ax: Axes,
+    *,
+    alpha: float,
+    edgecolor: Optional[str] = None,
+    markersize: Optional[float] = None,
+    markeredgewidth: Optional[float] = None,
+) -> None:
+    """Replace every line's markers with publiplots' double-layer style.
+
+    For each ``Line2D`` on ``ax`` that has a marker, strip the marker
+    off the original line (keeping the connecting line intact) and
+    draw two stacked marker-only lines on top:
+
+    1. **Background layer**: white-filled, same shape and size, no
+       edge. Masks the connecting line where markers overlap it — so
+       the transparent fill in layer 2 doesn't blend with the line.
+    2. **Foreground layer**: line-color fill at ``alpha``, line-color
+       edge (or explicit ``edgecolor``) at full opacity.
+
+    Called by ``pp.pointplot`` and ``pp.lineplot`` so both plots share
+    the exact same marker rendering: pale fill, solid ring, no line
+    bleed-through.
+
+    Parameters
+    ----------
+    ax : Axes
+        Axes containing lines with markers to style.
+    alpha : float
+        Transparency applied to the foreground fill (``0.0``..``1.0``).
+        The foreground edge stays at full opacity.
+    edgecolor : str, optional
+        Override for the ring color. If None, the line's own color is
+        used.
+    markersize : float, optional
+        Override for the marker size. If None, preserves each line's
+        current size.
+    markeredgewidth : float, optional
+        Override for the ring width. If None, preserves each line's
+        current markeredgewidth.
+    """
+    layers: list = []
+    for line in ax.lines:
+        marker = line.get_marker()
+        if marker in (None, "None", ""):
+            continue
+        layers.append({
+            "x": line.get_xdata(),
+            "y": line.get_ydata(),
+            "marker": marker,
+            "color": line.get_color(),
+            "size": markersize if markersize is not None else line.get_markersize(),
+            "edgewidth": (
+                markeredgewidth if markeredgewidth is not None
+                else line.get_markeredgewidth()
+            ),
+        })
+        line.set_markersize(0)
+
+    for data in layers:
+        ring = edgecolor if edgecolor else data["color"]
+        # Layer 1: white masks the underlying line.
+        ax.plot(
+            data["x"], data["y"], data["marker"],
+            markeredgecolor=ring,
+            markerfacecolor="white",
+            markersize=data["size"],
+            markeredgewidth=0,
+            linestyle="none",
+            zorder=99,
+        )
+        # Layer 2: semi-transparent colored fill + opaque ring.
+        ax.plot(
+            data["x"], data["y"], data["marker"],
+            markeredgecolor=ring,
+            markerfacecolor=to_rgba(data["color"], alpha),
+            markersize=data["size"],
+            markeredgewidth=data["edgewidth"],
+            linestyle="none",
+            zorder=100,
+        )
+
+
 def apply_transparency(
     artists: Union[PathCollection, Sequence[Patch]],
     face_alpha: float,

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -228,6 +228,72 @@ def test_lineplot_categorical_size_default_uses_tuple_interpolation(cat_size_df)
     assert widths == [1.0, 2.5, 4.0]
 
 
+# ---- Double-layer marker styling ----
+
+def _foreground_marker_lines(ax):
+    """Pick only the double-layer foreground marker lines.
+
+    publiplots' ``apply_double_layer_markers`` draws *three* artists
+    per group: the original connecting line (ms=0, markers stripped);
+    a white-background marker layer; and a foreground marker layer
+    with alpha fill + opaque ring. We assert the contract on the
+    foreground layer, detected by its transparent markerfacecolor.
+    """
+    from matplotlib.colors import to_rgba
+    fg = []
+    for line in ax.lines:
+        if line.get_markersize() in (None, 0, 0.0):
+            continue
+        mfc = to_rgba(line.get_markerfacecolor())
+        if mfc[3] < 1.0:  # alpha-filled layer
+            fg.append(line)
+    return fg
+
+
+def test_lineplot_markers_use_double_layer_style(line_df):
+    """Markers must follow publiplots' double-layer convention: face in
+    the line's color at rcParams['alpha'] (pale fill), edge in the
+    line's color at full opacity (solid ring). Seaborn's default is a
+    white edge on an opaque pastel face — this test guards against
+    regression back to that styling."""
+    from matplotlib.colors import to_rgba
+    from publiplots.themes.rcparams import resolve_param
+    alpha_rc = resolve_param("alpha", None)
+
+    ax = pp.lineplot(
+        data=line_df, x="t", y="y",
+        hue="g", style="m",
+        palette="pastel", markers=True,
+    )
+    foreground = _foreground_marker_lines(ax)
+    assert foreground, "no foreground marker layer produced"
+    for line in foreground:
+        mfc = to_rgba(line.get_markerfacecolor())
+        mec = to_rgba(line.get_markeredgecolor())
+        # Face RGB equals edge RGB; alphas differ (face dim, edge opaque).
+        assert mfc[:3] == mec[:3]
+        assert abs(mfc[3] - alpha_rc) < 1e-6
+        assert mec[3] == 1.0
+
+
+def test_lineplot_edgecolor_override_applies_to_markers(line_df):
+    """``edgecolor=`` overrides the ring color while the face stays
+    in the line's own color."""
+    from matplotlib.colors import to_rgba
+    ax = pp.lineplot(
+        data=line_df, x="t", y="y",
+        hue="g", style="m",
+        palette="pastel", markers=True,
+        edgecolor="black",
+    )
+    black = to_rgba("black")
+    foreground = _foreground_marker_lines(ax)
+    assert foreground
+    for line in foreground:
+        mec = to_rgba(line.get_markeredgecolor())
+        assert mec[:3] == black[:3]
+
+
 # ---- Reject ----
 
 def test_lineplot_rejects_figsize(line_df):


### PR DESCRIPTION
## Summary

Lineplot markers inherited seaborn's default (white edge on opaque pastel face), breaking the visual language pointplot established (pale fill + solid colored ring, no line bleed-through).

Lift pointplot's two-pass marker renderer into a shared `apply_double_layer_markers(ax, alpha, edgecolor, markersize, markeredgewidth)` helper in `utils/transparency.py` and call it from both `pp.pointplot` and `pp.lineplot`. Single source of truth for the marker rendering contract — future fixes land in one place.

## How it works

The helper strips markers off each original `Line2D` (keeping the connecting line), then draws two stacked marker-only lines on top:

1. **White-filled layer** — masks the connecting line where markers overlap it, so the semi-transparent fill in layer 2 doesn't blend with the line.
2. **Foreground layer** — colored fill at `alpha`, colored ring (or user `edgecolor=`) at full opacity.

## Test plan

- [x] Two new regression tests in `tests/test_line.py`:
  - `test_lineplot_markers_use_double_layer_style` — default styling: face RGB equals edge RGB, face alpha = `rcParams['alpha']` (0.1), edge alpha = 1.0.
  - `test_lineplot_edgecolor_override_applies_to_markers` — `edgecolor=` kwarg overrides the ring color while face stays in the line's own color.
- [x] Both tests **fail** on pre-patch `main` (foreground marker layer doesn't exist there) — confirmed they're real regression tests.
- [x] `pytest -q --no-cov` — 465 passing (baseline 463 + 2 new).
- [x] `examples/plots/plot_*.py` — 16/16 render.

## Net diff

- `utils/transparency.py`: +83 (new shared helper)
- `plot/point.py`: −77 (local copy deleted, now calls shared helper) +4
- `plot/line.py`: +13 (calls shared helper after `sns.lineplot`)
- `tests/test_line.py`: +66 (two regression tests)

Independent of PR #104 (dash-tuple legend fix); no textual conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)