### PR TITLE
chore(release): 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-05-04
+
+### Fixed
+- `pp.lineplot` markers now follow the publiplots double-layer
+  convention (pale fill + solid colored ring), matching `pp.pointplot`.
+  Seaborn's default was a white edge on an opaque pastel face, which
+  clashed visually. Lifts pointplot's two-pass marker renderer into a
+  shared `apply_double_layer_markers` helper in
+  `utils/transparency.py` so both plots stay in sync (PR #106).
+- `pp.lineplot(hue=..., style=..., dashes={'X': (on, off)}, markers=True)`
+  crashed in matplotlib's `Line2D._get_dash_pattern` because
+  `HandlerLineMarker` forwarded the raw on-off tuple to a fresh
+  `Line2D`. Extracted a `_normalize_dash_linestyle` helper and
+  routed both `HandlerLine` and `HandlerLineMarker` through it so
+  they can't drift again. Closes #99 (PR #104).
+
+### Added
+- Gallery panel "Markers on Aggregated Points" in
+  `plot_04_lineplot.py` demonstrating the double-layer marker
+  styling on a lineplot (PR #106).
+
+### Internal
+- Shared marker renderer `apply_double_layer_markers` now lives in
+  `publiplots.utils.transparency`; `pp.pointplot` and `pp.lineplot`
+  both delegate to it. Removes ~75 lines of duplicated logic from
+  `plot/point.py` (PR #106).
+
+[0.8.2]: https://github.com/jorgebotas/publiplots/releases/tag/v0.8.2
+
 ## [0.8.1] - 2026-05-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.8.1"
+version = "0.8.2"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
## Summary

Release 0.8.2. Two lineplot fixes:

- **PR #104** — `pp.lineplot(..., dashes={'X': (on, off)}, markers=True)` crashed in matplotlib's `Line2D._get_dash_pattern`. `HandlerLineMarker` now normalizes bare on-off tuples via a shared `_normalize_dash_linestyle` helper (`HandlerLine` already did this inline; extracted so they can't drift). Closes #99.
- **PR #106** — lineplot markers follow the publiplots double-layer convention (pale fill + solid colored ring) instead of seaborn's default white-edge-on-opaque-face. Lifts pointplot's two-pass renderer into a shared `apply_double_layer_markers` helper in `utils/transparency.py` so both plots stay in sync. Removes ~75 lines of duplicated logic.

## Test plan

- [x] `pytest -q --no-cov` — 467 passing.
- [x] `examples/plots/plot_*.py` — 16/16 render.
- [x] `publiplots.__version__` reports `0.8.2`.
- [ ] Tag `v0.8.2` + create GitHub release to trigger PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)