### PR TITLE
fix(bar): honor color= when hatch= is set (#105)

### DIFF
--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -137,6 +137,61 @@ ax = pp.barplot(
 pp.show()
 
 # %%
+# Single Color + Hatch on a Separate Column
+# ------------------------------------------
+# When a single fixed color represents the family of bars and a second
+# categorical column differentiates bars by pattern only, pass ``color=``
+# together with ``hatch=`` pointing at that other column. All bars get
+# the same face color; the hatch encodes the sub-category.
+
+np.random.seed(2024)
+encoder_data = pd.DataFrame({
+    "model": np.repeat(["Baseline", "Proposed"], 24),
+    "encoder": np.tile(np.repeat(["1D CNN", "2D CNN"], 12), 2),
+    "score": np.concatenate([
+        np.random.normal(0.70, 0.04, 12), np.random.normal(0.73, 0.04, 12),
+        np.random.normal(0.78, 0.03, 12), np.random.normal(0.82, 0.03, 12),
+    ]),
+})
+
+ax = pp.barplot(
+    data=encoder_data,
+    x="model",
+    y="score",
+    color="#43adaa",
+    hatch="encoder",
+    hatch_map={"1D CNN": "", "2D CNN": "///"},
+    errorbar="se",
+    title="Fixed color + hatch differentiates encoder",
+    xlabel="Model family",
+    ylabel="Score",
+)
+pp.show()
+
+# %%
+# Hue and Hatch on the Same Column
+# ---------------------------------
+# When ``hue=`` and ``hatch=`` point at the *same* column, publiplots
+# merges them into a single legend whose swatches encode both color and
+# pattern — useful when a single categorical variable is the organizing
+# axis of the figure.
+
+ax = pp.barplot(
+    data=encoder_data,
+    x="model",
+    y="score",
+    hue="encoder",
+    hatch="encoder",
+    palette={"1D CNN": "#8E8EC1", "2D CNN": "#60a8a8"},
+    hatch_map={"1D CNN": "", "2D CNN": "///"},
+    errorbar="se",
+    title="hue == hatch → combined legend",
+    xlabel="Model family",
+    ylabel="Score",
+)
+pp.show()
+
+# %%
 # Bar Plot with Hue and Hatch (Double Split)
 # -------------------------------------------
 # Combine color grouping (hue) and pattern differentiation (hatch) for
@@ -180,6 +235,29 @@ ax = pp.barplot(
     errorbar="se",
     palette={"Vehicle": "#8E8EC1", "Drug": "#60a8a8"},
     hatch_map={"24h": "", "48h": "///"},
+)
+pp.show()
+
+# %%
+# Explicit Edge Color with Hatch
+# -------------------------------
+# The ``edgecolor=`` argument overrides the automatic face-derived edges
+# on *every* bar, independently of whether a hatch is active. Pair it
+# with ``hatch=`` to produce classic print-style bars: colored fill,
+# consistent black outline, pattern fill on the hatched subset.
+
+ax = pp.barplot(
+    data=encoder_data,
+    x="model",
+    y="score",
+    color="#43adaa",
+    edgecolor="black",
+    hatch="encoder",
+    hatch_map={"1D CNN": "", "2D CNN": "///"},
+    errorbar="se",
+    title="edgecolor='black' + hatch",
+    xlabel="Model family",
+    ylabel="Score",
 )
 pp.show()
 

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -264,48 +264,27 @@ def barplot(
     # Create bars
     sns.barplot(**barplot_kwargs)
 
-    # When hue == categorical axis, recolor bars from palette
-    if hue is not None and hue == categorical_axis and palette:
-        categories = order if order else list(data[categorical_axis].cat.categories)
-        for idx, patch in enumerate(tracker.get_new_patches()):
-            if idx < len(categories):
-                bar_color = palette.get(categories[idx], color)
-                # Set edge to palette color so the main flow copies it to face correctly
-                patch.set_edgecolor(bar_color)
-        # Also recolor error bar lines
-        for idx, line in enumerate(tracker.get_new_lines()):
-            if idx < len(categories):
-                line.set_color(edgecolor if edgecolor is not None else palette.get(categories[idx], color))
+    # Paint face, hatch, and edge in one deterministic pass. Replaces the
+    # prior chain of ``seaborn fill=False puts palette on edge`` + ``copy
+    # edge to face later`` tricks which were order-dependent and broke
+    # under mpl 3.10.8 when ``color=`` was set alongside ``hatch=`` (#105).
+    _paint_bars(
+        patches=tracker.get_new_patches(),
+        errorbars=tracker.get_new_lines(),
+        data=data,
+        split=_split,
+        hue=hue,
+        hatch=hatch,
+        categorical_axis=categorical_axis,
+        linewidth=linewidth,
+        color=color,
+        edgecolor=edgecolor,
+        palette=palette,
+        hatch_map=hatch_map,
+    )
 
-    # Apply hatch patterns and override colors if needed
-    if hatch is not None:
-        _apply_hatches_and_override_colors(
-            ax=ax,
-            data=data,
-            hue=hue,
-            hatch=hatch,
-            categorical_axis=categorical_axis,
-            double_split=double_split,
-            linewidth=linewidth,
-            color=color,
-            edgecolor=edgecolor,
-            palette=palette,
-            hatch_map=hatch_map,
-        )
-
-    # Set facecolor from seaborn's edge (palette color), optionally override edgecolor
-    for patch in tracker.get_new_patches():
-        palette_color = patch.get_edgecolor()  # seaborn fill=False puts palette color on edge
-        patch.set_facecolor(palette_color)
-        if edgecolor is not None:
-            patch.set_edgecolor(edgecolor)
     # Apply differential transparency to face vs edge
     tracker.apply_transparency(on="patches", face_alpha=alpha, edge_alpha=1.0)
-
-    # Apply edgecolor to error bar lines
-    if edgecolor is not None:
-        for line in tracker.get_new_lines():
-            line.set_color(edgecolor)
 
     # Stash entries and render per-axis unless claimed by a figure-level group.
     _legend(
@@ -406,76 +385,89 @@ def _prepare_split_data(
         )
     return data
 
-def _apply_hatches_and_override_colors(
-        ax: Axes,
+def _paint_bars(
+        patches: List,
+        errorbars: List,
         data: pd.DataFrame,
+        split,
         hue: Optional[str],
-        hatch: str,
+        hatch: Optional[str],
         categorical_axis: str,
-        double_split: bool,
         linewidth: float,
         color: Optional[str],
         edgecolor: Optional[str],
-        palette: Optional[Union[str, Dict, List]],
+        palette: Optional[Dict[str, str]],
         hatch_map: Optional[Dict[str, str]],
     ) -> None:
-    """
-    Apply hatch patterns using patch.get_label() and idx // n_x, then override colors.
+    """Paint face, hatch, and edge on each bar in a single deterministic pass.
 
-    Uses the approach from user"s example:
-    - Track which category each patch belongs to via idx // n_x
-    - Use patch.get_label() or hue_order to determine the category
-    - Apply hatch based on the hatch column value
-    - Override colors if needed
-    """
-    # Override color if hue is not defined (default to color argument)
-    # Or if hue is not the same as hatch
-    override_color = hue is None or hue != hatch
-    n_axis = len(data[categorical_axis].unique())
-    n_hue = len(data[hue].unique()) if hue is not None else 1
-    n_hatch = len(data[hatch].unique())  # always defined
-    total_bars = n_axis * n_hue * n_hatch
-    hue_order = list(palette.keys())
-    hatch_order = list(hatch_map.keys())
-    errorbars = ax.get_lines()
+    For every new patch produced by ``sns.barplot(fill=False)``:
 
-    for idx, patch in enumerate(ax.patches):
-        if not hasattr(patch, "get_height"):
+    1. Choose the face color from the appropriate source (``palette``
+       keyed by axis/hue/hatch category, or scalar ``color``).
+    2. Apply the hatch pattern (empty when ``hatch`` is None).
+    3. Set the edge color to ``edgecolor`` if provided, else to the face
+       color so bars read as solid shapes.
+    4. Match the paired error-bar line color.
+
+    Iteration order is taken from ``BarSplitSpec.iter_draw_order`` — the
+    same authoritative iterator the annotate layer uses — so the
+    per-bar ``(cat, hue_value, hatch_value)`` triples line up 1:1 with
+    the patches seaborn drew.
+
+    Single-pass ordering avoids the cross-version matplotlib fragility
+    where reading ``patch.get_edgecolor()`` after an in-place mutation
+    returned a stale sentinel and black face colors leaked through
+    (issue #105).
+    """
+    bar_patches = [p for p in patches if hasattr(p, "get_height")]
+    triples = list(split.iter_draw_order(data))
+
+    for idx, patch in enumerate(bar_patches):
+        if idx >= len(triples):
+            # Safety: seaborn drew more patches than the spec iterates.
+            # Shouldn't happen; skip rather than crash.
             continue
+        cat, hue_value, hatch_value = triples[idx]
 
-        bar_idx = idx % total_bars
-        axis_idx = bar_idx % n_axis
-        # Get hatch and hue index in palette and hatch_map
-        # If hatch is the same as the categorical axis, we need to use the axis_idx
-        hatch_idx = (bar_idx // n_axis) % n_hatch if hatch != categorical_axis else axis_idx
-        # If double split, we take into account the combined index
-        # Otherwise, if matching hatch and hue, we use the hatch index
-        # Otherwise, we use the axis index
-        hue_idx = (bar_idx // (n_axis * n_hatch)) if double_split else (
-            hatch_idx if hue == hatch else axis_idx
-        )
+        # Resolve face color. The branches are mutually exclusive and
+        # map 1:1 to the legend dispatch in ``_legend``; keep them in
+        # sync.
+        if split.split_hue is not None:
+            # ``hue`` genuinely dodges. ``hue_value`` is authoritative.
+            face_color = palette[hue_value]
+        elif hue is not None and hue == categorical_axis and palette:
+            # hue collapses onto the categorical axis — color by cat.
+            face_color = palette.get(cat, color)
+        elif hue is not None and hue == hatch and palette:
+            # hue == hatch: palette keyed by hatch value.
+            face_color = palette.get(hatch_value, color)
+        else:
+            # No hue split — fall back to the scalar ``color``.
+            face_color = color
 
-        # Apply hatch pattern to all patches
-        hatch_pattern = hatch_map.get(hatch_order[hatch_idx], "")
-        patch.set_hatch(hatch_pattern)
-        # set_hatch_linewidth
-        patch.set_hatch_linewidth(linewidth)
+        patch.set_facecolor(face_color)
 
-        # Repaint the bars when needed (override colors if not using double
-        # split AND hatch isn't the categorical axis). `hue_idx` is only a
-        # valid `hue_order` index on this branch — on the `hatch == categorical_axis`
-        # branch it was computed from `axis_idx`, which ranges over `[0, n_axis)`
-        # and can exceed `len(hue_order)` when n_hue < n_axis. Gating the
-        # `bar_color` computation behind the same condition as the recolor
-        # avoids an IndexError on paths where the value was never used anyway.
-        if not (double_split or hatch == categorical_axis):
-            bar_color = palette[hue_order[hue_idx]] if hue is not None else color
-            patch.set_edgecolor(edgecolor if edgecolor is not None else bar_color)
-            patch.set_facecolor(bar_color)
+        if hatch is not None:
+            # Resolve the hatch key:
+            # - split_hatch active → hatch_value is authoritative.
+            # - hue == hatch → split_hatch is None; use hue_value.
+            # - hatch == categorical axis → use the category label.
+            if hatch_value is not None:
+                hatch_key = hatch_value
+            elif hue is not None and hue == hatch:
+                hatch_key = hue_value
+            else:
+                hatch_key = cat
+            patch.set_hatch(hatch_map.get(hatch_key, ""))
+            patch.set_hatch_linewidth(linewidth)
 
-            # Match error bar colors to bar colors
-            if bar_idx < len(errorbars):
-                errorbars[bar_idx].set_color(edgecolor if edgecolor is not None else bar_color)
+        patch.set_edgecolor(edgecolor if edgecolor is not None else face_color)
+
+        if idx < len(errorbars):
+            errorbars[idx].set_color(
+                edgecolor if edgecolor is not None else face_color
+            )
 
 def _legend(
         ax: Axes,

--- a/tests/test_bar_color_with_hatch.py
+++ b/tests/test_bar_color_with_hatch.py
@@ -1,0 +1,126 @@
+"""Regression tests for issue #105: barplot face color ignored when hatch= is set.
+
+Before the fix, ``pp.barplot(color="#43adaa", hatch="enc", hatch_map=...)`` would
+render bars with a black (or palette-cycled) face because the face color was
+inferred from ``patch.get_edgecolor()`` in a post-hoc pass that was order- and
+matplotlib-version-dependent. The fix rewrites the paint pass to set face,
+hatch, and edge in one deterministic step driven by ``BarSplitSpec``.
+
+These tests assert only the RGB channels of face/edge colors — alpha varies
+with the publiplots ``alpha`` rcParam.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from matplotlib.colors import to_rgba
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame([
+        ("a", "1D", 0.80), ("a", "2D", 0.82),
+        ("b", "1D", 0.75), ("b", "2D", 0.79),
+    ], columns=["row", "enc", "val"])
+
+
+def _rgb(color) -> tuple:
+    return to_rgba(color)[:3]
+
+
+def _face_rgb(patch) -> tuple:
+    return tuple(patch.get_facecolor()[:3])
+
+
+def _edge_rgb(patch) -> tuple:
+    return tuple(patch.get_edgecolor()[:3])
+
+
+def _bars(ax):
+    return [p for p in ax.patches if hasattr(p, "get_height")]
+
+
+def test_color_honored_with_hatch_no_hue(df):
+    """color=<hex> + hatch=<col> without hue: every bar face is <hex>."""
+    teal = _rgb("#43adaa")
+    ax = pp.barplot(
+        data=df, x="val", y="row",
+        color="#43adaa",
+        hatch="enc",
+        hatch_map={"1D": "", "2D": "///"},
+    )
+    bars = _bars(ax)
+    assert len(bars) == 4
+    for i, p in enumerate(bars):
+        assert _face_rgb(p) == pytest.approx(teal, abs=1e-6), (
+            f"bar {i}: expected face {teal}, got {_face_rgb(p)}"
+        )
+
+
+def test_color_honored_with_hatch_uniform_palette_hue(df):
+    """hue=<col> + palette={k: color, ...} uniform + hatch=<col>: all bars color."""
+    teal = _rgb("#43adaa")
+    ax = pp.barplot(
+        data=df, x="val", y="row",
+        hue="enc",
+        palette={"1D": "#43adaa", "2D": "#43adaa"},
+        hatch="enc",
+        hatch_map={"1D": "", "2D": "///"},
+    )
+    bars = _bars(ax)
+    assert len(bars) == 4
+    for i, p in enumerate(bars):
+        assert _face_rgb(p) == pytest.approx(teal, abs=1e-6)
+    # Hatch pattern must still distinguish the two groups.
+    hatches = {p.get_hatch() for p in bars}
+    assert hatches == {"", "///"}
+
+
+def test_edgecolor_override_with_hatch(df):
+    """edgecolor='black' + color=<hex> + hatch: face=<hex>, edge=black."""
+    teal = _rgb("#43adaa")
+    black = _rgb("black")
+    ax = pp.barplot(
+        data=df, x="val", y="row",
+        color="#43adaa", edgecolor="black",
+        hatch="enc",
+        hatch_map={"1D": "", "2D": "///"},
+    )
+    bars = _bars(ax)
+    assert len(bars) == 4
+    for p in bars:
+        assert _face_rgb(p) == pytest.approx(teal, abs=1e-6)
+        assert _edge_rgb(p) == pytest.approx(black, abs=1e-6)
+    # Hatch patterns still applied.
+    assert {p.get_hatch() for p in bars} == {"", "///"}
+
+
+def test_face_color_matches_palette_under_double_split(df):
+    """Double split (hue=row, hatch=enc): each row gets its palette color."""
+    teal = _rgb("#43adaa")
+    red = _rgb("#b34343")
+    ax = pp.barplot(
+        data=df, x="val", y="row",
+        hue="row",
+        palette={"a": "#43adaa", "b": "#b34343"},
+        hatch="enc",
+        hatch_map={"1D": "", "2D": "///"},
+    )
+    bars = _bars(ax)
+    assert len(bars) == 4
+    # Every bar should match one of the two palette colors, and both colors
+    # must appear — no black leakage.
+    face_colors = {_face_rgb(p) for p in bars}
+    assert teal in face_colors
+    assert red in face_colors
+    # Hatches applied.
+    assert {p.get_hatch() for p in bars} == {"", "///"}


### PR DESCRIPTION
## Summary

Closes #105.

`pp.barplot(color="#43adaa", hatch="enc", hatch_map=...)` rendered black bars on the user's matplotlib 3.10.8 (and inconsistent behavior on 3.10.9). The face color was silently dropped whenever `hatch=` was set.

## Root cause

The paint flow was a chain of four in-place passes over `ax.patches`:

1. `sns.barplot(fill=False)` — seaborn drew the bars; the palette color ended up on the **edge** by side effect of `fill=False`.
2. `if hue == categorical_axis:` pre-pass rewrote the edge per patch.
3. `_apply_hatches_and_override_colors` applied hatches AND rewrote face+edge on some branches.
4. Final loop: `palette_color = patch.get_edgecolor(); patch.set_facecolor(palette_color); if edgecolor: patch.set_edgecolor(edgecolor)`.

Pass 4 assumed that `patch.get_edgecolor()` would reflect what the earlier passes had just written. Under mpl 3.10.8 it returned a stale `"face"` sentinel that resolved to `(0, 0, 0, 0.8)`, which then leaked onto the face.

## Fix

Drive the whole paint in one pass from `BarSplitSpec.iter_draw_order` — the same iterator the `annotate` layer already uses — so each `(cat, hue_value, hatch_value)` triple maps 1:1 to a patch. For each patch:

1. Resolve the face color from `palette` or scalar `color`.
2. `set_facecolor`, then apply hatch, then `set_edgecolor(edgecolor or face_color)`.
3. Match the paired error-bar line color.

No more round-trip through `get_edgecolor()`, no more per-matplotlib divergence. The old `_apply_hatches_and_override_colors` + both face-copy loops collapse into a single `_paint_bars` helper (+90/-98 LOC on `bar.py`).

## Test plan

- [x] New `tests/test_bar_color_with_hatch.py` — 4 tests cover: `color=` + `hatch=` no hue, uniform `palette` + `hue==hatch`, `edgecolor` override, double split.
- [x] `pytest tests/` — 471/471 pass (baseline 467 + 4 new).
- [x] All 16 gallery examples still render without errors.
- [x] Exact issue repro now prints teal facecolors for all 4 bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)