### PR TITLE
chore(release): bump version to 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-05-04
+
+### Fixed
+- `pp.barplot(color=<hex>, hatch=<col>, hatch_map=...)` rendered black
+  bars regardless of `color=` or `palette=` under matplotlib 3.10.8,
+  and was inconsistent across matplotlib versions. The face-color flow
+  round-tripped through `patch.get_edgecolor()` after several in-place
+  rewrites, picking up a stale sentinel. Replaced the four sequential
+  paint passes with a single `_paint_bars` helper driven by
+  `BarSplitSpec.iter_draw_order` that sets face → hatch → edge in one
+  pass. Closes #105 (PR #108).
+
+### Added
+- Gallery panels in `plot_01_bar_plots.py` covering the previously
+  undocumented combinations: fixed `color=` + `hatch=` on a separate
+  column, `hue == hatch` on the same column (combined legend), and
+  `edgecolor=` override paired with `hatch=` (PR #108).
+
+[0.8.3]: https://github.com/jorgebotas/publiplots/releases/tag/v0.8.3
+
 ## [0.8.2] - 2026-05-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.8.2"
+version = "0.8.3"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
## Summary

Patch release bundling PR #108 (fix #105: `pp.barplot` ignored `color=` / `palette=` when `hatch=` was set).

- `pyproject.toml` 0.8.2 → 0.8.3
- `src/publiplots/__init__.py` __version__ → 0.8.3
- `CHANGELOG.md` new `[0.8.3]` section

## Test plan

- [x] Release notes cover the shipped fix (#108) and the gallery additions.
- [ ] Merge → tag `v0.8.3` → create GitHub Release → publish workflow pushes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)