### PR TITLE
chore(release): 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2026-05-04
+
+### Added
+- `pp.scatterplot` gains `background_marker: bool | str = False`. When
+  truthy, each point gets a solid background-colored twin (white by
+  default; any color string overrides it) so overlap is hidden —
+  useful for publication panels, small-multiples, and categorical
+  bubble plots where each point should read independently. Off by
+  default because duplicating every point doubles artist count and
+  overlap is often informative. The real work is foreground
+  pre-compositing: face colors are blended over `background_color`
+  at the user's `alpha` and drawn at full opacity, so overlapping
+  points last-draw-wins instead of alpha-blending into muddy
+  patches. A lower-zorder `PathCollection` twin is also emitted so
+  the effect survives non-white axes patches (PR #110).
+- Gallery panel "Hiding Overlap with `background_marker`" in
+  `plot_02_scatter_plots.py` showing the three modes side by side
+  (PR #110).
+
+### Internal
+- New `composite_facecolors_over` and `apply_background_markers`
+  helpers in `publiplots.utils.transparency`, reusing the same
+  abstraction boundary as `apply_double_layer_markers` (Line2D
+  counterpart used by `pp.pointplot` / `pp.lineplot`) (PR #110).
+
+[0.8.4]: https://github.com/jorgebotas/publiplots/releases/tag/v0.8.4
+
 ## [0.8.3] - 2026-05-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.8.3"
+version = "0.8.4"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
## Summary

Release 0.8.4. One scatter feature:

- **PR #110** — `pp.scatterplot` gains `background_marker: bool | str = False`. When truthy, each point gets a solid background-colored twin (white by default; any color string overrides it) so overlap is hidden — useful for publication panels, small-multiples, and categorical bubble plots. Off by default because duplicating every point doubles artist count and overlap is often informative.

The real work is foreground pre-compositing: face colors are blended over `background_color` at the user's `alpha` and drawn at full opacity, so overlapping points last-draw-wins instead of alpha-blending into muddy patches. A lower-zorder `PathCollection` twin is also emitted so the effect survives non-white axes patches. New helpers `composite_facecolors_over` and `apply_background_markers` live in `publiplots.utils.transparency`, matching the same abstraction boundary as `apply_double_layer_markers`.

## Test plan

- [x] `uv run pytest tests/ --no-cov -q` — **481 passing**.
- [x] `publiplots.__version__` reports `0.8.4`.
- [x] Scatter gallery renders the new `background_marker` panel.
- [ ] Tag `v0.8.4` + create GitHub release to trigger PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)