### PR TITLE
feat(legend_group): 4-sided + figure/axes anchor modes

### DIFF
--- a/examples/plots/plot_17_legend_placement.py
+++ b/examples/plots/plot_17_legend_placement.py
@@ -110,14 +110,14 @@ for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
 pp.show()
 
 # %%
-# 4b. Bottom with ``align='end'``
-# -------------------------------
-# Override the default center-alignment to pin the legend to the right
-# edge of the grid — useful when the legend should align with a
-# particular panel column rather than the figure midline.
+# 4b. Bottom with ``align='start'``
+# ---------------------------------
+# Override the default center-alignment to pin the legend to the left
+# edge of the grid — a common choice when the legend should align with
+# the first panel column rather than the figure midline.
 
 fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
-pp.legend_group(side="bottom", align="end")
+pp.legend_group(side="bottom", align="start")
 for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
     pp.scatterplot(
         data=_df[_df["panel"] == panel], x="x", y="y",

--- a/examples/plots/plot_17_legend_placement.py
+++ b/examples/plots/plot_17_legend_placement.py
@@ -1,0 +1,172 @@
+"""
+Legend Placement
+================
+
+publiplots offers three complementary legend-placement knobs:
+
+1. **Per-axis inside**: ``legend_kws={'inside': True, 'loc': 'upper right'}``
+   drops the legend inside the axes using matplotlib's corner-based
+   placement. No reactor, no layout reservation — just a local legend.
+
+2. **Figure-anchored group**: ``pp.legend_group(side=...)`` (no anchor)
+   spans the full subplot grid on the chosen side. The figure grows on
+   that side to accommodate the legend; panel sizes stay inviolate.
+
+3. **Axes-anchored group**: ``pp.legend_group(anchor=axes[r,c], side=...)``
+   pins the band to a single cell. The corresponding per-cell reservation
+   (``right[c]`` for ``side='right'``, ``xlabel_space[r]`` for
+   ``side='bottom'``, ...) absorbs the band width, pushing just that
+   axes' column/row larger.
+
+This gallery walks through each mode.
+"""
+
+import publiplots as pp
+import pandas as pd
+import numpy as np
+
+# Shared fixture --------------------------------------------------------------
+
+np.random.seed(42)
+_df = pd.DataFrame({
+    "x": np.random.randn(240),
+    "y": np.random.randn(240),
+    "group": np.tile(["Control", "Low", "High"], 80),
+    "panel": np.repeat(["A", "B", "C", "D"], 60),
+})
+
+# %%
+# 1. Default outside-right (no legend_group)
+# ------------------------------------------
+# A single ``pp.scatterplot`` with a categorical ``hue`` renders its legend
+# just past the axes' right edge — the publication-ready default.
+
+pp.scatterplot(
+    data=_df, x="x", y="y", hue="group", palette="pastel",
+    title="Default outside-right",
+)
+pp.show()
+
+# %%
+# 2. Per-axis inside legend
+# -------------------------
+# ``legend_kws={'inside': True, 'loc': ...}`` keeps the legend local to
+# the axes. Useful when vertical real estate is precious or the data
+# leaves a natural empty corner.
+
+pp.scatterplot(
+    data=_df, x="x", y="y", hue="group", palette="pastel",
+    legend_kws={"inside": True, "loc": "upper right"},
+    title='legend_kws={"inside": True, "loc": "upper right"}',
+)
+pp.show()
+
+# %%
+# 3. Figure-anchored ``side='right'`` on a 2×2 grid
+# -------------------------------------------------
+# ``pp.legend_group()`` without an ``anchor=`` spans the full figure
+# vertically, tucked past the rightmost column. Auto-collects every
+# stashed entry from every panel; dedupes by name.
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend_group(side="right")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.show()
+
+# %%
+# 4. Figure-anchored ``side='bottom'`` on a 2×2 grid
+# --------------------------------------------------
+# When panels leave spare vertical headroom, a bottom-anchored legend
+# uses that space instead of the figure's right column. Same call, just
+# ``side='bottom'``.
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend_group(side="bottom")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.show()
+
+# %%
+# 5. Figure-anchored ``side='top'`` + ``side='left'``
+# ---------------------------------------------------
+# All four sides are supported. Top/left are less common but useful for
+# figures with a strong vertical hierarchy or right-to-left reading order.
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend_group(side="top")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.show()
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend_group(side="left")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.show()
+
+# %%
+# 6. Axes-anchored: pin the band to a single cell
+# -----------------------------------------------
+# Pass ``anchor=axes[r, c]`` to pin the band to one cell. The
+# corresponding per-cell reservation (the column's ``right`` for
+# ``side='right'``, the row's ``xlabel_space`` for ``side='bottom'``,
+# etc.) absorbs the band width. Useful when one panel deserves its own
+# annotation band without growing the rest of the figure.
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+# Anchor the band to the top-right panel only.
+pp.legend_group(anchor=axes[0, 1], side="right")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.show()
+
+# %%
+# 7. Combining inside + figure-anchored group
+# -------------------------------------------
+# The two modes compose: collect one shared dimension into the
+# figure-level group (here ``group``) and render other per-panel
+# legends inside each axes. ``collect=['group']`` filters the group's
+# auto-collect pass; ``legend_kws={'inside': True}`` on each scatter
+# renders the non-collected style (``replicate`` below) as a local
+# legend in each panel.
+
+rng = np.random.default_rng(7)
+split_df = pd.DataFrame({
+    "x": rng.normal(size=240),
+    "y": rng.normal(size=240),
+    "group": np.tile(["Control", "Low", "High"], 80),
+    "replicate": np.tile(["R1", "R2"], 120),
+    "panel": np.repeat(["A", "B", "C", "D"], 60),
+})
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend_group(side="bottom", collect=["group"])
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=split_df[split_df["panel"] == panel], x="x", y="y",
+        hue="group", style="replicate", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+        legend_kws={"inside": True, "loc": "upper right"},
+    )
+pp.show()

--- a/examples/plots/plot_17_legend_placement.py
+++ b/examples/plots/plot_17_legend_placement.py
@@ -18,6 +18,18 @@ publiplots offers three complementary legend-placement knobs:
    ``side='bottom'``, ...) absorbs the band width, pushing just that
    axes' column/row larger.
 
+``pp.legend_group`` also chooses its **orientation** and **alignment**
+per side by default:
+
+- ``side='top'`` / ``'bottom'`` → ``orientation='horizontal'`` (entries
+  run along the edge, ``ncol`` defaults to ``len(handles)``) and
+  ``align='center'`` (centered along the anchor edge).
+- ``side='left'`` / ``'right'`` → ``orientation='vertical'`` and
+  ``align='start'`` (legend begins at the anchor's top corner).
+
+Override either with ``orientation='vertical'|'horizontal'`` or
+``align='start'|'center'|'end'`` when the default isn't what you want.
+
 This gallery walks through each mode.
 """
 
@@ -83,10 +95,29 @@ pp.show()
 # --------------------------------------------------
 # When panels leave spare vertical headroom, a bottom-anchored legend
 # uses that space instead of the figure's right column. Same call, just
-# ``side='bottom'``.
+# ``side='bottom'``. The default orientation flips to ``horizontal``
+# (entries run along the edge) and ``align='center'`` keeps the block
+# balanced under the grid.
 
 fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
 pp.legend_group(side="bottom")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.show()
+
+# %%
+# 4b. Bottom with ``align='end'``
+# -------------------------------
+# Override the default center-alignment to pin the legend to the right
+# edge of the grid — useful when the legend should align with a
+# particular panel column rather than the figure midline.
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend_group(side="bottom", align="end")
 for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
     pp.scatterplot(
         data=_df[_df["panel"] == panel], x="x", y="y",

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -21,7 +21,10 @@ from publiplots.layout.figure_layout import FigureLayout
 
 _MM2INCH = 1 / 25.4
 _UPDATE_THRESHOLD_MM = 0.1
-_ALL_SIDES = {"title_space", "xlabel_space", "ylabel_space", "right", "legend_column"}
+_ALL_SIDES = {
+    "title_space", "xlabel_space", "ylabel_space", "right",
+    "legend_column", "legend_band_bottom", "legend_band_top", "legend_band_left",
+}
 # Cap on settle() draws; 1-3 is typical.
 _MAX_CONVERGENCE_ITERS = 5
 
@@ -210,10 +213,14 @@ class SubplotsAutoLayout:
             if getattr(reg, "external_to_axis", False)
         }
 
+    _SCALAR_SIDES = {
+        "legend_column", "legend_band_bottom", "legend_band_top", "legend_band_left",
+    }
+
     def _needs_update(self, measured: Dict[str, Tuple[float, ...]]) -> bool:
         for side, new_val in measured.items():
             current = getattr(self._layout, side)
-            if side == "legend_column":
+            if side in self._SCALAR_SIDES:
                 if abs(new_val - current) >= _UPDATE_THRESHOLD_MM:
                     return True
             else:

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -139,8 +139,10 @@ class SubplotsAutoLayout:
                     per.append(max(max_px / dpi * 25.4, 0.0))
                 measured[side] = tuple(per)
 
-        if "legend_column" not in self._locked:
-            measured["legend_column"] = self._measure_legend_column()
+        # Measure the single figure's legend_group (if any) and dispatch
+        # its overhang to the right reservation field based on (side,
+        # anchor_kind).
+        self._apply_legend_band_measurement(measured, axes_matrix)
         return measured
 
     def _side_extent(self, ax, calc, managed_artist_ids) -> float:
@@ -232,32 +234,83 @@ class SubplotsAutoLayout:
                         return True
         return False
 
-    def _measure_legend_column(self) -> float:
-        """mm width past the anchor axes' right edge, plus 1 mm padding."""
+    # Per-side overhang calculators. Each returns the signed distance
+    # (in pixels) that 'obj' projects past the 'anchor_bb' edge in the
+    # chosen direction. Distances are non-negative after the max() below.
+    _OVERHANG_BY_SIDE = {
+        "right":  lambda anchor_bb, obj_bb: obj_bb.x1 - anchor_bb.x1,
+        "left":   lambda anchor_bb, obj_bb: anchor_bb.x0 - obj_bb.x0,
+        "bottom": lambda anchor_bb, obj_bb: anchor_bb.y0 - obj_bb.y0,
+        "top":    lambda anchor_bb, obj_bb: obj_bb.y1 - anchor_bb.y1,
+    }
+
+    # side → (figure-anchored FigureLayout field, axes-anchored per-cell field)
+    _FIELD_BY_SIDE = {
+        "right":  ("legend_column",       "right",        "col"),
+        "left":   ("legend_band_left",    "ylabel_space", "col"),
+        "bottom": ("legend_band_bottom",  "xlabel_space", "row"),
+        "top":    ("legend_band_top",     "title_space",  "row"),
+    }
+
+    def _apply_legend_band_measurement(self, measured: dict, axes_matrix) -> None:
+        """Measure the figure's pp.legend_group overhang and write it
+        into the correct FigureLayout reservation based on the group's
+        ``side`` and anchor kind."""
         group = getattr(self._fig, "_publiplots_legend_group", None)
         if group is None:
-            return 0.0
-
-        # Force collection so artists exist to measure.
-        group._materialize()
-        if not group._builder.elements:
-            return 0.0
-
+            return
         dpi = self._fig.dpi
         if dpi <= 0:
-            return 0.0
+            return
+
+        # Force materialization so artists exist to measure.
+        group._materialize()
+        if not group._builder.elements:
+            return
+
+        side = group._side
+        overhang_fn = self._OVERHANG_BY_SIDE[side]
+        figure_field, cell_field, axis_kind = self._FIELD_BY_SIDE[side]
 
         anchor_bb = group.anchor.get_window_extent()
-        max_x1 = anchor_bb.x1
+        max_overhang_px = 0.0
         for _, obj in group._builder.elements:
             extent = self._artist_window_extent(obj)
             if extent is None:
                 continue
-            max_x1 = max(max_x1, extent.x1)
-        overhang_px = max_x1 - anchor_bb.x1
-        if overhang_px <= 0:
-            return 0.0
-        return overhang_px / dpi * 25.4 + 1.0
+            max_overhang_px = max(max_overhang_px, overhang_fn(anchor_bb, extent))
+        if max_overhang_px <= 0:
+            return
+        overhang_mm = max_overhang_px / dpi * 25.4 + 1.0
+
+        if group._anchor_kind == "figure":
+            if figure_field in self._locked:
+                return
+            measured[figure_field] = overhang_mm
+            return
+
+        # Axes-anchored: grow the per-cell reservation for the anchor's
+        # row/column. Merge with whatever the auto-measurement already
+        # produced (so label/title space co-exists with legend space).
+        if cell_field in self._locked:
+            return
+        ax = group.anchor
+        r, c = self._find_ax_indices(ax, axes_matrix)
+        if axis_kind == "col":
+            existing = list(measured.get(cell_field, getattr(self._layout, cell_field)))
+            existing[c] = max(existing[c], overhang_mm)
+            measured[cell_field] = tuple(existing)
+        else:  # "row"
+            existing = list(measured.get(cell_field, getattr(self._layout, cell_field)))
+            existing[r] = max(existing[r], overhang_mm)
+            measured[cell_field] = tuple(existing)
+
+    def _find_ax_indices(self, ax, axes_matrix):
+        for r, row in enumerate(axes_matrix):
+            for c, a in enumerate(row):
+                if a is ax:
+                    return r, c
+        return 0, 0
 
     def _artist_window_extent(self, obj):
         """Duck-typed tight-bbox accessor (Legend/Colorbar/Text).

--- a/src/publiplots/layout/figure_layout.py
+++ b/src/publiplots/layout/figure_layout.py
@@ -37,7 +37,13 @@ class FigureLayout:
     outer_pad : float
         Figure outer margin (same on all four sides).
     legend_column : float
-        Extra width on the far right, outside the grid. Never auto-measured.
+        Extra width on the far right, outside the grid. Used by
+        figure-anchored ``pp.legend_group(side='right')``.
+    legend_band_bottom, legend_band_top, legend_band_left : float
+        Extra mm on the bottom / top / left of the figure, outside the
+        grid. Used by figure-anchored ``pp.legend_group(side=...)``.
+        Default ``0.0``. All four scalars only kick in when a
+        figure-anchored legend group asks for space on that side.
     """
 
     nrows: int
@@ -51,6 +57,9 @@ class FigureLayout:
     wspace: float
     outer_pad: float
     legend_column: float
+    legend_band_bottom: float = 0.0
+    legend_band_top: float = 0.0
+    legend_band_left: float = 0.0
 
     def __post_init__(self) -> None:
         for side in ("title_space", "xlabel_space", "ylabel_space", "right"):
@@ -82,6 +91,7 @@ class FigureLayout:
         w_ax, h_ax = self.axes_size
         W = (
             self.outer_pad
+            + self.legend_band_left
             + sum(self.ylabel_space)
             + self.ncols * w_ax
             + sum(self.right)
@@ -91,10 +101,12 @@ class FigureLayout:
         )
         H = (
             self.outer_pad
+            + self.legend_band_top
             + sum(self.title_space)
             + self.nrows * h_ax
             + sum(self.xlabel_space)
             + max(self.nrows - 1, 0) * self.hspace
+            + self.legend_band_bottom
             + self.outer_pad
         )
         return W, H
@@ -103,11 +115,11 @@ class FigureLayout:
         """Figure-fraction (x0, y0, w, h) for the cell at (row, col)."""
         W, H = self.figure_size()
         w_ax, h_ax = self.axes_size
-        x0_mm = self.outer_pad
+        x0_mm = self.outer_pad + self.legend_band_left
         for c in range(col):
             x0_mm += self.ylabel_space[c] + w_ax + self.right[c] + self.wspace
         x0_mm += self.ylabel_space[col]
-        y0_mm = self.outer_pad
+        y0_mm = self.outer_pad + self.legend_band_bottom
         for r in range(self.nrows - 1, row, -1):
             y0_mm += self.xlabel_space[r] + h_ax + self.title_space[r] + self.hspace
         y0_mm += self.xlabel_space[row]

--- a/src/publiplots/utils/layout_reactor.py
+++ b/src/publiplots/utils/layout_reactor.py
@@ -34,10 +34,19 @@ _DISPLACEMENT_WARNING = (
 class _Registration:
     ax: Axes
     artist: object  # Legend or Colorbar; duck-typed via set_bbox_to_anchor
+    # mm_x_from_right / mm_y_from_top keep their historical names for
+    # back-compat with the side='right' path that predates side= support.
+    # Semantically they encode (outward_mm, along_mm) from the chosen
+    # anchor corner:
+    #   side='right'  → outward=rightward from ax.x1,  along=downward from ax.y1
+    #   side='left'   → outward=leftward  from ax.x0,  along=downward from ax.y1
+    #   side='bottom' → outward=downward  from ax.y0,  along=rightward from ax.x0
+    #   side='top'    → outward=upward    from ax.y1,  along=rightward from ax.x0
     mm_x_from_right: float
     mm_y_from_top: float
     mm_width: Optional[float] = None
     mm_height: Optional[float] = None
+    side: str = "right"
     # External overlays (e.g., pp.legend_group anchored to an axes) should
     # NOT count toward the axes' tightbbox in SubplotsAutoLayout. Their
     # geometry is owned by the reactor + user's legend_column reservation,
@@ -82,6 +91,7 @@ class LayoutReactor:
         mm_y_from_top: float,
         mm_width: Optional[float] = None,
         mm_height: Optional[float] = None,
+        side: str = "right",
         external_to_axis: bool = False,
     ) -> None:
         """Track this element; its bbox_to_anchor will be refreshed every draw.
@@ -107,6 +117,7 @@ class LayoutReactor:
             mm_y_from_top=mm_y_from_top,
             mm_width=mm_width,
             mm_height=mm_height,
+            side=side,
             external_to_axis=external_to_axis,
         ))
 
@@ -145,17 +156,47 @@ class LayoutReactor:
         fig = self._fig
         ax_pos = reg.ax.get_position()
         fig_extent = fig.get_window_extent()
-        # Convert mm offsets to figure fractions
-        x_frac = (reg.mm_x_from_right * _MM2INCH * fig.dpi) / fig_extent.width
-        y_frac = (reg.mm_y_from_top * _MM2INCH * fig.dpi) / fig_extent.height
-        new_x = ax_pos.x1 + x_frac
-        new_y = ax_pos.y1 - y_frac
+        # Convert mm offsets to figure fractions. outward_frac is mm away
+        # from the chosen edge; along_frac is mm into the edge's tangent.
+        outward_frac_x = (reg.mm_x_from_right * _MM2INCH * fig.dpi) / fig_extent.width
+        outward_frac_y = (reg.mm_x_from_right * _MM2INCH * fig.dpi) / fig_extent.height
+        along_frac_x = (reg.mm_y_from_top * _MM2INCH * fig.dpi) / fig_extent.width
+        along_frac_y = (reg.mm_y_from_top * _MM2INCH * fig.dpi) / fig_extent.height
+
+        if reg.side == "right":
+            new_x = ax_pos.x1 + outward_frac_x
+            new_y = ax_pos.y1 - along_frac_y
+        elif reg.side == "left":
+            new_x = ax_pos.x0 - outward_frac_x
+            new_y = ax_pos.y1 - along_frac_y
+        elif reg.side == "bottom":
+            new_x = ax_pos.x0 + along_frac_x
+            new_y = ax_pos.y0 - outward_frac_y
+        elif reg.side == "top":
+            new_x = ax_pos.x0 + along_frac_x
+            new_y = ax_pos.y1 + outward_frac_y
+        else:
+            raise ValueError(f"unknown side: {reg.side!r}")
 
         # Colorbar path — artist has .ax and we stored mm dimensions.
         if reg.mm_width is not None and reg.mm_height is not None:
             w_frac = (reg.mm_width * _MM2INCH * fig.dpi) / fig_extent.width
             h_frac = (reg.mm_height * _MM2INCH * fig.dpi) / fig_extent.height
-            reg.artist.ax.set_position([new_x, new_y - h_frac, w_frac, h_frac])
+            # Colorbar set_position uses the bottom-left corner.
+            # For side='right' (legacy), new_y is the top edge → subtract h.
+            # For side='top'   new_y is the bottom edge of the colorbar → keep.
+            # For side='bottom' new_y is the top edge → subtract h.
+            # For side='left'  new_y is the top edge → subtract h.
+            # Also flip x for left: new_x is the right edge → subtract w.
+            if reg.side in ("right", "bottom", "left"):
+                bottom_y = new_y - h_frac
+            else:  # "top"
+                bottom_y = new_y
+            if reg.side == "left":
+                left_x = new_x - w_frac
+            else:
+                left_x = new_x
+            reg.artist.ax.set_position([left_x, bottom_y, w_frac, h_frac])
             return
 
         # Text path — figure-level text (e.g., colorbar titles added via fig.text).

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -863,6 +863,7 @@ class LegendBuilder:
         max_width: Optional[float] = None,
         anchor_ax: Optional[Axes] = None,
         external_to_axis: bool = False,
+        side: str = "right",
     ):
         """Initialize legend builder. All dimensions in millimeters.
 
@@ -872,17 +873,28 @@ class LegendBuilder:
             Axes the legend/colorbar artist is attached to (for picking,
             ``ax.legend_`` association, etc.).
         anchor_ax : Axes, optional
-            Axes whose right edge is used as the origin for mm-based
-            placement math and for reactor registration. Defaults to `ax`.
-            Used by MultiAxesLegendGroup to attach artists to one axes
-            while positioning them relative to another.
+            Axes whose chosen edge is used as the origin for mm-based
+            placement math and for reactor registration. Defaults to
+            ``ax``. Used by MultiAxesLegendGroup to attach artists to one
+            axes while positioning them relative to another (or to a
+            virtual grid anchor for figure-anchored groups).
+        side : {'right', 'left', 'bottom', 'top'}, default 'right'
+            Which edge of ``anchor_ax`` the legend grows outward from.
+            'right' matches the historical placement (columns fill
+            rightward, rows downward).
         """
         from publiplots.utils.legend_layout import LegendLayout
         from publiplots.utils.layout_reactor import LayoutReactor
 
+        if side not in ("right", "left", "bottom", "top"):
+            raise ValueError(
+                f"side must be 'right' | 'left' | 'bottom' | 'top', got {side!r}"
+            )
+
         self.ax = ax
         self._anchor_ax = anchor_ax if anchor_ax is not None else ax
         self.fig = self._anchor_ax.get_figure()
+        self._side = side
         self._layout = LegendLayout(
             x_offset=x_offset,
             y_offset=y_offset,
@@ -891,11 +903,29 @@ class LegendBuilder:
             vpad=vpad,
             max_width=max_width,
         )
-        self._layout.reset_to(axes_height_mm=self._get_axes_height())
+        self._layout.reset_to(axes_height_mm=self._get_edge_length())
         self._reactor = LayoutReactor.get(self.fig)
         self._external_to_axis = external_to_axis
         # Element storage: list of (type, object) tuples
         self.elements = []
+
+    def _get_edge_length(self) -> float:
+        """Along-edge length of the anchor in mm.
+
+        For side='right'|'left' that's the axes height; for
+        side='top'|'bottom' it's the axes width. The ``LegendLayout``
+        cursor treats this uniformly as the 'down the edge' distance
+        available before overflowing to a new column.
+        """
+        if self._side in ("right", "left"):
+            return self._get_axes_height()
+        return self._get_axes_width()
+
+    def _get_axes_width(self) -> float:
+        ax_pos = self._anchor_ax.get_position()
+        fig_width_px = self.fig.get_window_extent().width
+        axes_width_px = ax_pos.width * fig_width_px
+        return axes_width_px / self.fig.dpi / self.MM2INCH
 
     # =========================================================================
     # Conversion Utilities
@@ -910,34 +940,44 @@ class LegendBuilder:
 
     def _mm_to_figure_coords(self, x_mm: float, y_mm: float) -> Tuple[float, float]:
         """
-        Convert mm position to figure coordinates.
+        Convert mm position to figure coordinates at the chosen edge.
 
         Parameters
         ----------
         x_mm : float
-            Horizontal distance from right edge of axes (mm)
+            Outward distance from the edge (mm). Rightward for
+            ``side='right'``, leftward for ``'left'``, downward for
+            ``'bottom'``, upward for ``'top'``.
         y_mm : float
-            Remaining vertical space (mm). Converted to position from top internally.
+            Remaining along-edge space (mm). Converted to position from
+            the starting corner internally.
 
         Returns
         -------
         x_fig, y_fig : float
-            Position in figure coordinates
+            Position in figure coordinates.
         """
         ax_pos = self._anchor_ax.get_position()
         fig_extent = self.fig.get_window_extent()
 
-        # y_mm represents remaining space, convert to position from top
-        axes_height = self._get_axes_height()
-        position_from_top = axes_height - y_mm
+        # y_mm represents remaining along-edge space; position_from_start
+        # is how far we've advanced from the corner where the cursor
+        # began (top for right/left, left for bottom/top).
+        edge_length = self._get_edge_length()
+        position_from_start = edge_length - y_mm
 
-        # Convert mm to figure fraction
-        x_offset_fig = (x_mm * self.MM2INCH * self.fig.dpi) / fig_extent.width
-        y_offset_fig = (position_from_top * self.MM2INCH * self.fig.dpi) / fig_extent.height
-
-        # Position relative to axes
-        x_fig = ax_pos.x1 + x_offset_fig
-        y_fig = ax_pos.y1 - y_offset_fig
+        if self._side in ("right", "left"):
+            outward_frac = (x_mm * self.MM2INCH * self.fig.dpi) / fig_extent.width
+            along_frac = (position_from_start * self.MM2INCH * self.fig.dpi) / fig_extent.height
+            y_fig = ax_pos.y1 - along_frac
+            x_fig = (ax_pos.x1 + outward_frac) if self._side == "right" \
+                    else (ax_pos.x0 - outward_frac)
+        else:  # bottom | top
+            outward_frac = (x_mm * self.MM2INCH * self.fig.dpi) / fig_extent.height
+            along_frac = (position_from_start * self.MM2INCH * self.fig.dpi) / fig_extent.width
+            x_fig = ax_pos.x0 + along_frac
+            y_fig = (ax_pos.y0 - outward_frac) if self._side == "bottom" \
+                    else (ax_pos.y1 + outward_frac)
 
         return x_fig, y_fig
 
@@ -1213,9 +1253,21 @@ class LegendBuilder:
         fontsize = resolve_param("legend.fontsize", resolve_param("font.size"))
         default_labelspacing = compute_min_labelspacing(handles, fontsize)
 
-        # Prepare legend kwargs
+        # Prepare legend kwargs. ``loc`` maps to the matplotlib corner of
+        # the legend box that coincides with bbox_to_anchor — pick it so
+        # the legend grows *away from* the anchor edge:
+        #   side='right'  → anchor sits at legend's upper-left corner.
+        #   side='left'   → anchor sits at legend's upper-right corner.
+        #   side='bottom' → anchor sits at legend's upper-left corner (cursor rotates).
+        #   side='top'    → anchor sits at legend's lower-left corner.
+        loc_by_side = {
+            "right": "upper left",
+            "left": "upper right",
+            "bottom": "upper left",
+            "top": "lower left",
+        }
         legend_kwargs = {
-            "loc": "upper left",
+            "loc": loc_by_side[self._side],
             "bbox_to_anchor": (x_fig, y_fig),
             "bbox_transform": self.fig.transFigure,  # Use figure coords
             "frameon": frameon,
@@ -1267,6 +1319,7 @@ class LegendBuilder:
             artist=legend,
             mm_x_from_right=placement_x_mm,
             mm_y_from_top=mm_y_from_top,
+            side=self._side,
             external_to_axis=self._external_to_axis,
         )
 
@@ -1274,7 +1327,7 @@ class LegendBuilder:
         self.elements.append(("legend", legend))
 
         return legend
-    
+
     def add_colorbar(
         self,
         mappable: Optional[ScalarMappable] = None,
@@ -1396,6 +1449,7 @@ class LegendBuilder:
                 artist=title_obj,
                 mm_x_from_right=title_x_mm,
                 mm_y_from_top=title_mm_y_from_top,
+                side=self._side,
                 external_to_axis=self._external_to_axis,
             )
 
@@ -1476,6 +1530,7 @@ class LegendBuilder:
             mm_y_from_top=mm_y_from_top,
             mm_width=width,        # the mm width parameter of add_colorbar
             mm_height=cbar_height, # measured mm height (from _measure_object_dimensions)
+            side=self._side,
             external_to_axis=self._external_to_axis,
         )
 

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -864,6 +864,7 @@ class LegendBuilder:
         anchor_ax: Optional[Axes] = None,
         external_to_axis: bool = False,
         side: str = "right",
+        orientation: str = "vertical",
     ):
         """Initialize legend builder. All dimensions in millimeters.
 
@@ -882,6 +883,14 @@ class LegendBuilder:
             Which edge of ``anchor_ax`` the legend grows outward from.
             'right' matches the historical placement (columns fill
             rightward, rows downward).
+        orientation : {'vertical', 'horizontal'}, default 'vertical'
+            Primary stacking direction of successive legends and of
+            entries within each legend. ``'vertical'`` stacks entries
+            downward and advances successive legends downward; overflow
+            (exhausted along-edge length) starts a new band *outward*.
+            ``'horizontal'`` lays entries along the edge (default
+            ``ncol = len(handles)``) and advances successive legends
+            rightward; overflow starts a new band further outward.
         """
         from publiplots.utils.legend_layout import LegendLayout
         from publiplots.utils.layout_reactor import LayoutReactor
@@ -890,11 +899,16 @@ class LegendBuilder:
             raise ValueError(
                 f"side must be 'right' | 'left' | 'bottom' | 'top', got {side!r}"
             )
+        if orientation not in ("vertical", "horizontal"):
+            raise ValueError(
+                f"orientation must be 'vertical' | 'horizontal', got {orientation!r}"
+            )
 
         self.ax = ax
         self._anchor_ax = anchor_ax if anchor_ax is not None else ax
         self.fig = self._anchor_ax.get_figure()
         self._side = side
+        self._orientation = orientation
         self._layout = LegendLayout(
             x_offset=x_offset,
             y_offset=y_offset,
@@ -902,6 +916,7 @@ class LegendBuilder:
             column_spacing=column_spacing,
             vpad=vpad,
             max_width=max_width,
+            orientation=orientation,
         )
         self._layout.reset_to(edge_length_mm=self._get_edge_length())
         self._reactor = LayoutReactor.get(self.fig)
@@ -1226,6 +1241,11 @@ class LegendBuilder:
             self.elements.append(("legend", legend))
             return legend
 
+        # Horizontal orientation default: lay out every handle in a
+        # single row. User-provided ncol wins.
+        if self._orientation == "horizontal" and "ncol" not in kwargs:
+            kwargs["ncol"] = max(1, len(handles))
+
         # Auto-adjust ncol if max_height specified
         if max_height is not None:
             optimal_ncol = self._adjust_legend_ncol_for_height(
@@ -1233,11 +1253,15 @@ class LegendBuilder:
             )
             kwargs['ncol'] = optimal_ncol
 
-        # Estimate height
-        estimated_height = self._estimate_legend_height(handles, label, **kwargs)
+        # Estimate the legend's along-edge extent: height when stacking
+        # vertically, width when laying out horizontally.
+        if self._orientation == "horizontal":
+            estimated_along = self._estimate_legend_width(handles, label, **kwargs)
+        else:
+            estimated_along = self._estimate_legend_height(handles, label, **kwargs)
 
         # Check overflow
-        if self._check_overflow(estimated_height):
+        if self._check_overflow(estimated_along):
             self._start_new_band()
 
         # Convert current position to figure coordinates
@@ -1309,9 +1333,17 @@ class LegendBuilder:
         # axes height changes from constrained_layout etc).
         mm_y_from_top = self._layout.along_from_start
 
-        # Update layout cursor for the next element
-        self._layout.update_width(width)
-        self._layout.advance_along(height)
+        # Update layout cursor for the next element.
+        # - vertical: height advances along the edge, width is the band's
+        #   outward extent.
+        # - horizontal: width advances along the edge, height is the
+        #   band's outward extent.
+        if self._orientation == "horizontal":
+            self._layout.update_width(height)
+            self._layout.advance_along(width)
+        else:
+            self._layout.update_width(width)
+            self._layout.advance_along(height)
 
         # Register with the reactor so the anchor follows axes changes.
         self._reactor.register(

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -859,7 +859,7 @@ class LegendBuilder:
         y_offset: Optional[float] = None,
         gap: float = 2,
         column_spacing: float = 5,
-        vpad: float = 5,
+        vpad: Optional[float] = None,
         max_width: Optional[float] = None,
         anchor_ax: Optional[Axes] = None,
         external_to_axis: bool = False,
@@ -909,6 +909,19 @@ class LegendBuilder:
         self.fig = self._anchor_ax.get_figure()
         self._side = side
         self._orientation = orientation
+
+        # Default vpad: when the anchor is a real Axes (per-axis legend
+        # or axes-anchored legend_group), vpad=0 lands the legend's top
+        # flush with the axes rectangle top — title_space lives above
+        # axes.y1 so it's already accounted for by pp.subplots. When
+        # the anchor is a _GridAnchor (figure-anchored group),
+        # ``anchor.y1`` is the decorated-grid top which sits ABOVE every
+        # axes' title_space; vpad=5 keeps the legend from hugging that
+        # top border visually.
+        if vpad is None:
+            from publiplots.utils.legend_group import _GridAnchor
+            vpad = 5 if isinstance(self._anchor_ax, _GridAnchor) else 0
+
         self._layout = LegendLayout(
             x_offset=x_offset,
             y_offset=y_offset,
@@ -1665,7 +1678,7 @@ def legend(
     x_offset: float = 2,
     gap: float = 2,
     column_spacing: float = 5,
-    vpad: float = 5,
+    vpad: Optional[float] = None,
     **kwargs
 ) -> LegendBuilder:
     """

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -903,7 +903,7 @@ class LegendBuilder:
             vpad=vpad,
             max_width=max_width,
         )
-        self._layout.reset_to(axes_height_mm=self._get_edge_length())
+        self._layout.reset_to(edge_length_mm=self._get_edge_length())
         self._reactor = LayoutReactor.get(self.fig)
         self._external_to_axis = external_to_axis
         # Element storage: list of (type, object) tuples
@@ -1098,16 +1098,16 @@ class LegendBuilder:
         return handle_width + text_width + padding
 
     # =========================================================================
-    # Column Management
+    # Band Management
     # =========================================================================
 
-    def _check_overflow(self, required_height: float) -> bool:
-        """Check if element fits in current column."""
-        return self._layout.check_overflow(required_height)
+    def _check_overflow(self, required_along: float) -> bool:
+        """True if an element of this along-edge size overflows the current band."""
+        return self._layout.check_overflow(required_along)
 
-    def _start_new_column(self):
-        """Create a new column when vertical space exhausted."""
-        self._layout.start_new_column()
+    def _start_new_band(self):
+        """Create a new band outward when along-edge space is exhausted."""
+        self._layout.start_new_band()
 
     def _adjust_legend_ncol_for_height(
         self,
@@ -1238,11 +1238,11 @@ class LegendBuilder:
 
         # Check overflow
         if self._check_overflow(estimated_height):
-            self._start_new_column()
+            self._start_new_band()
 
         # Convert current position to figure coordinates
         x_fig, y_fig = self._mm_to_figure_coords(
-            self._layout.current_x, self._layout.current_y
+            self._layout.current_outward, self._layout.current_along
         )
 
         # Adaptive row spacing: when a handle's marker exceeds the font
@@ -1304,14 +1304,14 @@ class LegendBuilder:
 
         # Capture position BEFORE advancing the cursor — this is where the
         # legend was actually placed, and what the reactor needs.
-        placement_x_mm = self._layout.current_x
+        placement_x_mm = self._layout.current_outward
         # mm_y_from_top is tracked directly in the layout (stable across
         # axes height changes from constrained_layout etc).
-        mm_y_from_top = self._layout.current_y_from_top
+        mm_y_from_top = self._layout.along_from_start
 
         # Update layout cursor for the next element
         self._layout.update_width(width)
-        self._layout.advance_y(height)
+        self._layout.advance_along(height)
 
         # Register with the reactor so the anchor follows axes changes.
         self._reactor.register(
@@ -1422,13 +1422,13 @@ class LegendBuilder:
 
         # Check overflow using estimate
         if self._check_overflow(total_estimated_height):
-            self._start_new_column()
+            self._start_new_band()
 
         # Add title if needed and measure actual height
         title_height_actual = 0
         if title_position == "top" and label:
             x_fig, y_fig = self._mm_to_figure_coords(
-                self._layout.current_x, self._layout.current_y
+                self._layout.current_outward, self._layout.current_along
             )
             title_obj = self.fig.text(
                 x_fig, y_fig, label,
@@ -1442,8 +1442,8 @@ class LegendBuilder:
 
             # Register the title with the reactor so it follows axes changes
             # (otherwise the colorbar would reposition but the title would stay pinned).
-            title_x_mm = self._layout.current_x
-            title_mm_y_from_top = self._layout.current_y_from_top
+            title_x_mm = self._layout.current_outward
+            title_mm_y_from_top = self._layout.along_from_start
             self._reactor.register(
                 ax=self._anchor_ax,
                 artist=title_obj,
@@ -1454,13 +1454,13 @@ class LegendBuilder:
             )
 
             # Position colorbar below measured title
-            cbar_y_start = self._layout.current_y - title_height_actual - title_pad
+            cbar_y_start = self._layout.current_along - title_height_actual - title_pad
         else:
-            cbar_y_start = self._layout.current_y
+            cbar_y_start = self._layout.current_along
             title_width_actual = 0
 
         # Create colorbar axes
-        x_fig, y_fig_top = self._mm_to_figure_coords(self._layout.current_x, cbar_y_start)
+        x_fig, y_fig_top = self._mm_to_figure_coords(self._layout.current_outward, cbar_y_start)
 
         fig_extent = self.fig.get_window_extent()
         cbar_width_fig = (width * self.MM2INCH * self.fig.dpi) / fig_extent.width
@@ -1508,17 +1508,17 @@ class LegendBuilder:
         # Colorbar top sits below the title (if any) by title_height + title_pad.
         # The layout cursor still points at the title position, so we compute
         # the colorbar's offset explicitly before advancing.
-        placement_x_mm = self._layout.current_x
+        placement_x_mm = self._layout.current_outward
         if title_position == "top" and label:
             mm_y_from_top = (
-                self._layout.current_y_from_top + title_height_actual + title_pad
+                self._layout.along_from_start + title_height_actual + title_pad
             )
         else:
-            mm_y_from_top = self._layout.current_y_from_top
+            mm_y_from_top = self._layout.along_from_start
 
         # Update layout cursor past the full title+colorbar block.
         self._layout.update_width(actual_width)
-        self._layout.advance_y(total_height_actual)
+        self._layout.advance_along(total_height_actual)
 
         # Register with the reactor. Colorbars need mm_width + mm_height so
         # the reactor dispatches to cbar.ax.set_position instead of
@@ -1590,7 +1590,7 @@ class LegendBuilder:
 
     def get_remaining_height(self) -> float:
         """Get remaining vertical space."""
-        return max(0, self._layout.current_y)
+        return max(0, self._layout.current_along)
 
 
 def _get_legend_data(ax: Axes) -> dict:

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -1,19 +1,22 @@
 """
-Shared legend column across multiple subplots.
+Shared legend band across multiple subplots.
 
-MultiAxesLegendGroup composes one unified legend column anchored to a
-chosen axes even when individual legends/colorbars are attached to other
-axes in the same figure. This is the primary tool for complex subplot
-layouts.
+MultiAxesLegendGroup composes one unified legend band anchored to a
+chosen side of the figure (or a single axes) even when individual
+legends/colorbars are attached to other axes in the same figure. This
+is the primary tool for complex subplot layouts.
 """
 
 import warnings
 from typing import List, Optional, Sequence
 
+import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from matplotlib.legend import Legend
 from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
+from matplotlib.transforms import Bbox
 
 from publiplots.utils.legend import LegendBuilder
 from publiplots.utils.legend_entries import (
@@ -23,19 +26,75 @@ from publiplots.utils.legend_entries import (
 )
 
 
+class _GridAnchor:
+    """Virtual Axes proxy spanning the whole publiplots subplot grid.
+
+    Duck-types the small slice of ``matplotlib.axes.Axes`` that
+    ``LegendBuilder`` and ``LayoutReactor`` use (``get_position()`` +
+    ``get_figure()`` + ``get_window_extent()``). Lets figure-anchored
+    ``pp.legend_group`` share exactly the same placement machinery as
+    axes-anchored groups — the anchor just happens to be the grid bbox
+    instead of a single axes' bbox.
+    """
+
+    def __init__(self, fig: Figure) -> None:
+        self._fig = fig
+
+    def get_figure(self) -> Figure:
+        return self._fig
+
+    def get_position(self) -> Bbox:
+        """Union of all publiplots axes positions, in figure fractions."""
+        matrix = getattr(self._fig, "_publiplots_axes", None)
+        if matrix is None:
+            return Bbox.from_extents(0.0, 0.0, 1.0, 1.0)
+        x0 = y0 = 1.0
+        x1 = y1 = 0.0
+        for row in matrix:
+            for ax in row:
+                pos = ax.get_position()
+                x0, y0 = min(x0, pos.x0), min(y0, pos.y0)
+                x1, y1 = max(x1, pos.x1), max(y1, pos.y1)
+        if x0 >= x1 or y0 >= y1:
+            return Bbox.from_extents(0.0, 0.0, 1.0, 1.0)
+        return Bbox.from_extents(x0, y0, x1, y1)
+
+    def get_window_extent(self, renderer=None):
+        """Pixel extent of the grid bbox — matches ``Axes.get_window_extent``."""
+        pos = self.get_position()
+        fig_w = self._fig.get_window_extent().width
+        fig_h = self._fig.get_window_extent().height
+        return Bbox.from_extents(
+            pos.x0 * fig_w, pos.y0 * fig_h,
+            pos.x1 * fig_w, pos.y1 * fig_h,
+        )
+
+
 class MultiAxesLegendGroup:
     """
-    Unified legend column across multiple axes.
+    Unified legend band across multiple axes.
 
-    All elements share a single mm-based layout anchored to ``anchor``. Each
-    element can be attached to a different axes (via ``ax=`` on ``add_*``
-    calls) for hit-testing and picking; its POSITION is always computed
-    against the anchor's right edge regardless of which axes owns the artist.
+    All elements share a single mm-based layout anchored to the chosen
+    side of ``anchor``. Each element can be attached to a different
+    axes (via ``ax=`` on ``add_*`` calls) for hit-testing and picking;
+    its POSITION is always computed against the anchor's chosen edge
+    regardless of which axes owns the artist.
 
     Parameters
     ----------
-    anchor : Axes
-        The axes whose right edge defines x=0 for the shared column.
+    anchor : Axes, optional
+        The axes whose chosen edge defines the origin for the shared
+        band. When ``None`` (default), the group is **figure-anchored**:
+        it spans the full subplot grid on the chosen side (e.g.,
+        ``side='right'`` anchors to the rightmost cells' right edge and
+        extends vertically across every row). Pass an explicit axes to
+        pin the band to that single cell instead (axes-anchored).
+    side : {'right', 'bottom', 'left', 'top'}, default 'right'
+        Which edge of the anchor the band grows outward from. ``'right'``
+        is the classic publiplots outside-right column.
+    figure : Figure, optional
+        Figure to attach a figure-anchored group to. Defaults to
+        ``plt.gcf()``; only needed when no current figure exists.
     collect : list or tuple of str, optional
         Names of entries to auto-collect from across the grid's stashed
         ``LegendEntry`` objects. ``None`` (default) collects everything.
@@ -47,8 +106,11 @@ class MultiAxesLegendGroup:
 
     def __init__(
         self,
-        anchor: Axes,
+        anchor: Optional[Axes] = None,
         collect: Optional[Sequence[str]] = None,
+        *,
+        side: str = "right",
+        figure: Optional[Figure] = None,
         x_offset: float = 2,
         y_offset: Optional[float] = None,
         gap: float = 2,
@@ -56,7 +118,23 @@ class MultiAxesLegendGroup:
         vpad: float = 5,
         max_width: Optional[float] = None,
     ):
-        self.anchor = anchor
+        if side not in ("right", "left", "bottom", "top"):
+            raise ValueError(
+                f"side must be 'right' | 'left' | 'bottom' | 'top', got {side!r}"
+            )
+        self._side = side
+
+        # Decide anchor kind. When the caller passes an explicit axes we
+        # pin the band to that one axes (and its per-cell reservation
+        # tuple grows). Otherwise span the whole grid via _GridAnchor.
+        if anchor is None:
+            fig = figure if figure is not None else plt.gcf()
+            self.anchor = _GridAnchor(fig)
+            self._anchor_kind = "figure"
+        else:
+            self.anchor = anchor
+            self._anchor_kind = "axes"
+
         if collect is not None:
             if isinstance(collect, str) or not hasattr(collect, "__iter__"):
                 raise TypeError(
@@ -65,14 +143,17 @@ class MultiAxesLegendGroup:
                 )
             collect = list(collect)
         self._collect = collect
-        # Track whether _materialize has already run (set by Task 3).
         self._materialized = False
         self._warned_mismatch = False
-        # anchor_ax=anchor pins position math/reactor to the anchor regardless
-        # of self.ax swaps during add_* calls.
+        # anchor_ax=self.anchor pins position math/reactor to the anchor
+        # regardless of self.ax swaps during add_* calls. For
+        # figure-anchored groups anchor_ax is the _GridAnchor proxy,
+        # which exposes the same get_position()/get_figure() API.
+        builder_ax = self.anchor if self._anchor_kind == "axes" \
+                     else self._pick_builder_ax()
         self._builder = LegendBuilder(
-            ax=anchor,
-            anchor_ax=anchor,
+            ax=builder_ax,
+            anchor_ax=self.anchor,
             x_offset=x_offset,
             y_offset=y_offset,
             gap=gap,
@@ -80,9 +161,31 @@ class MultiAxesLegendGroup:
             vpad=vpad,
             max_width=max_width,
             external_to_axis=True,
+            side=side,
         )
         # Register on the figure so plot functions can check claims.
-        anchor.get_figure()._publiplots_legend_group = self
+        self.anchor.get_figure()._publiplots_legend_group = self
+
+    def _pick_builder_ax(self) -> Axes:
+        """Pick a real axes from the figure to attach Legend artists to.
+
+        Figure-anchored groups use ``_GridAnchor`` only for position
+        math; the actual matplotlib ``Legend`` artist still needs a
+        real Axes parent. Default to the corner cell closest to the
+        legend's edge so hit-testing lines up with where the user sees
+        the band sitting.
+        """
+        fig = self.anchor.get_figure()
+        matrix = getattr(fig, "_publiplots_axes", None)
+        if matrix is None:
+            return fig.axes[0]
+        if self._side == "right":
+            return matrix[0][-1]
+        if self._side == "left":
+            return matrix[0][0]
+        if self._side == "bottom":
+            return matrix[-1][0]
+        return matrix[0][0]  # "top"
 
     def claims(self, name: str) -> bool:
         """True if the group will render an entry with this name."""
@@ -145,6 +248,17 @@ class MultiAxesLegendGroup:
                 label=entry.name,
             )
 
+    def _default_target_ax(self) -> Axes:
+        """Axes to attach a Legend artist to when no explicit ax= is passed.
+
+        For axes-anchored groups, that's the anchor. For figure-anchored
+        groups the anchor is a ``_GridAnchor`` proxy (not a real Axes);
+        the builder's pre-picked corner cell is used instead.
+        """
+        if self._anchor_kind == "axes":
+            return self.anchor
+        return self._builder.ax  # corner cell picked in __init__
+
     def add_legend(
         self,
         handles: List,
@@ -153,12 +267,13 @@ class MultiAxesLegendGroup:
         ax: Optional[Axes] = None,
         **kwargs,
     ) -> Legend:
-        """Add a legend to the shared column.
+        """Add a legend to the shared band.
 
-        The artist is attached to ax (defaults to anchor); position is
-        always computed against the anchor's right edge.
+        The artist is attached to ``ax`` (defaults to a sensible corner
+        cell for figure-anchored groups, or the anchor for axes-anchored);
+        position is always computed against the anchor's chosen edge.
         """
-        target_ax = ax if ax is not None else self.anchor
+        target_ax = ax if ax is not None else self._default_target_ax()
         original_ax = self._builder.ax
         try:
             self._builder.ax = target_ax
@@ -174,8 +289,8 @@ class MultiAxesLegendGroup:
         ax: Optional[Axes] = None,
         **kwargs,
     ) -> Colorbar:
-        """Add a colorbar to the shared column. See add_legend for ax semantics."""
-        target_ax = ax if ax is not None else self.anchor
+        """Add a colorbar to the shared band. See add_legend for ax semantics."""
+        target_ax = ax if ax is not None else self._default_target_ax()
         original_ax = self._builder.ax
         try:
             self._builder.ax = target_ax
@@ -186,8 +301,10 @@ class MultiAxesLegendGroup:
 
 
 def legend_group(
-    anchor: Axes,
+    anchor: Optional[Axes] = None,
     *,
+    side: str = "right",
+    figure: Optional[Figure] = None,
     collect: Optional[Sequence[str]] = None,
     x_offset: float = 2,
     y_offset: Optional[float] = None,
@@ -196,12 +313,21 @@ def legend_group(
     vpad: float = 5,
     max_width: Optional[float] = None,
 ) -> MultiAxesLegendGroup:
-    """Create a shared legend column anchored to ``anchor``.
+    """Create a shared legend band.
 
-    See :class:`MultiAxesLegendGroup` for parameter docs.
+    Pass ``anchor=None`` (default) for a **figure-anchored** band that
+    spans the full subplot grid on the chosen side. Pass
+    ``anchor=axes[r, c]`` to pin the band to a single cell; the
+    corresponding per-cell reservation (``right[c]`` for ``side='right'``,
+    ``xlabel_space[r]`` for ``side='bottom'``, etc.) absorbs the band
+    width.
+
+    See :class:`MultiAxesLegendGroup` for all parameter docs.
     """
     return MultiAxesLegendGroup(
         anchor=anchor,
+        side=side,
+        figure=figure,
         collect=collect,
         x_offset=x_offset,
         y_offset=y_offset,

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -27,14 +27,28 @@ from publiplots.utils.legend_entries import (
 
 
 class _GridAnchor:
-    """Virtual Axes proxy spanning the whole publiplots subplot grid.
+    """Virtual Axes proxy spanning the whole publiplots subplot grid
+    **including its decorations** (tick labels, axis labels, titles).
 
     Duck-types the small slice of ``matplotlib.axes.Axes`` that
     ``LegendBuilder`` and ``LayoutReactor`` use (``get_position()`` +
     ``get_figure()`` + ``get_window_extent()``). Lets figure-anchored
     ``pp.legend_group`` share exactly the same placement machinery as
-    axes-anchored groups — the anchor just happens to be the grid bbox
-    instead of a single axes' bbox.
+    axes-anchored groups — the anchor just happens to be the decorated
+    grid rectangle (the outer boundary of everything *except* legend
+    bands) rather than a single axes' rectangle.
+
+    The decorated-grid bbox is computed from the ``FigureLayout``:
+
+        x0 = (outer_pad + legend_band_left)     / W
+        x1 = (W - outer_pad - legend_column)    / W
+        y0 = (outer_pad + legend_band_bottom)   / H
+        y1 = (H - outer_pad - legend_band_top)  / H
+
+    Anchoring here (rather than the axes-rectangle union) guarantees
+    that side='bottom' sits BELOW all xlabel_space, side='top' sits
+    ABOVE all title_space, side='left' sits LEFT of all ylabel_space,
+    etc. — i.e., the legend doesn't overlap with axis decorations.
     """
 
     def __init__(self, fig: Figure) -> None:
@@ -44,7 +58,21 @@ class _GridAnchor:
         return self._fig
 
     def get_position(self) -> Bbox:
-        """Union of all publiplots axes positions, in figure fractions."""
+        """Decorated-grid bbox in figure fractions."""
+        layout = getattr(self._fig, "_publiplots_layout", None)
+        if layout is not None:
+            W, H = layout.figure_size()
+            # Sanity guard: avoid division by zero if the layout hasn't
+            # measured yet (e.g., during the first draw before sizes are
+            # known).
+            if W > 0 and H > 0:
+                x0 = (layout.outer_pad + layout.legend_band_left) / W
+                x1 = (W - layout.outer_pad - layout.legend_column) / W
+                y0 = (layout.outer_pad + layout.legend_band_bottom) / H
+                y1 = (H - layout.outer_pad - layout.legend_band_top) / H
+                return Bbox.from_extents(x0, y0, x1, y1)
+        # Fallback when no publiplots layout is installed (figure built
+        # by raw matplotlib): union the axes rectangles only.
         matrix = getattr(self._fig, "_publiplots_axes", None)
         if matrix is None:
             return Bbox.from_extents(0.0, 0.0, 1.0, 1.0)
@@ -60,7 +88,7 @@ class _GridAnchor:
         return Bbox.from_extents(x0, y0, x1, y1)
 
     def get_window_extent(self, renderer=None):
-        """Pixel extent of the grid bbox — matches ``Axes.get_window_extent``."""
+        """Pixel extent of the decorated-grid bbox."""
         pos = self.get_position()
         fig_w = self._fig.get_window_extent().width
         fig_h = self._fig.get_window_extent().height
@@ -104,6 +132,13 @@ class MultiAxesLegendGroup:
         Same meaning as :class:`LegendBuilder` — all in millimeters.
     """
 
+    # Default outward gap (mm) between the anchor's edge and the
+    # legend's near side. For side='right' the gap sits in otherwise
+    # empty space, so 2 mm suffices. For the other sides the gap sits
+    # adjacent to tick labels / titles and needs more air for the legend
+    # not to crowd them.
+    _DEFAULT_X_OFFSET_MM = {"right": 2, "left": 5, "bottom": 5, "top": 5}
+
     def __init__(
         self,
         anchor: Optional[Axes] = None,
@@ -111,7 +146,7 @@ class MultiAxesLegendGroup:
         *,
         side: str = "right",
         figure: Optional[Figure] = None,
-        x_offset: float = 2,
+        x_offset: Optional[float] = None,
         y_offset: Optional[float] = None,
         gap: float = 2,
         column_spacing: float = 5,
@@ -123,6 +158,8 @@ class MultiAxesLegendGroup:
                 f"side must be 'right' | 'left' | 'bottom' | 'top', got {side!r}"
             )
         self._side = side
+        if x_offset is None:
+            x_offset = self._DEFAULT_X_OFFSET_MM[side]
 
         # Decide anchor kind. When the caller passes an explicit axes we
         # pin the band to that one axes (and its per-cell reservation
@@ -306,7 +343,7 @@ def legend_group(
     side: str = "right",
     figure: Optional[Figure] = None,
     collect: Optional[Sequence[str]] = None,
-    x_offset: float = 2,
+    x_offset: Optional[float] = None,
     y_offset: Optional[float] = None,
     gap: float = 2,
     column_spacing: float = 5,

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -139,6 +139,22 @@ class MultiAxesLegendGroup:
     # not to crowd them.
     _DEFAULT_X_OFFSET_MM = {"right": 2, "left": 5, "bottom": 5, "top": 5}
 
+    # side → default orientation. Horizontal makes sense on top/bottom
+    # where there's plenty of figure width; vertical stays the default
+    # for right/left where width is narrow.
+    _DEFAULT_ORIENTATION = {
+        "right": "vertical", "left": "vertical",
+        "bottom": "horizontal", "top": "horizontal",
+    }
+
+    # side → default along-edge alignment. Horizontal bands center to
+    # balance the figure; vertical bands start at the top (current
+    # 'upper' behaviour).
+    _DEFAULT_ALIGN = {
+        "right": "start", "left": "start",
+        "bottom": "center", "top": "center",
+    }
+
     def __init__(
         self,
         anchor: Optional[Axes] = None,
@@ -146,6 +162,8 @@ class MultiAxesLegendGroup:
         *,
         side: str = "right",
         figure: Optional[Figure] = None,
+        orientation: str = "auto",
+        align: str = "auto",
         x_offset: Optional[float] = None,
         y_offset: Optional[float] = None,
         gap: float = 2,
@@ -157,7 +175,22 @@ class MultiAxesLegendGroup:
             raise ValueError(
                 f"side must be 'right' | 'left' | 'bottom' | 'top', got {side!r}"
             )
+        if orientation not in ("auto", "vertical", "horizontal"):
+            raise ValueError(
+                f"orientation must be 'auto' | 'vertical' | 'horizontal', "
+                f"got {orientation!r}"
+            )
+        if align not in ("auto", "start", "center", "end"):
+            raise ValueError(
+                f"align must be 'auto' | 'start' | 'center' | 'end', got {align!r}"
+            )
         self._side = side
+        self._orientation = (
+            self._DEFAULT_ORIENTATION[side] if orientation == "auto" else orientation
+        )
+        self._align = (
+            self._DEFAULT_ALIGN[side] if align == "auto" else align
+        )
         if x_offset is None:
             x_offset = self._DEFAULT_X_OFFSET_MM[side]
 
@@ -182,6 +215,8 @@ class MultiAxesLegendGroup:
         self._collect = collect
         self._materialized = False
         self._warned_mismatch = False
+        self._align_connected = False
+        self._aligning = False  # re-entrancy guard for _on_draw_align
         # anchor_ax=self.anchor pins position math/reactor to the anchor
         # regardless of self.ax swaps during add_* calls. For
         # figure-anchored groups anchor_ax is the _GridAnchor proxy,
@@ -199,6 +234,7 @@ class MultiAxesLegendGroup:
             max_width=max_width,
             external_to_axis=True,
             side=side,
+            orientation=self._orientation,
         )
         # Register on the figure so plot functions can check claims.
         self.anchor.get_figure()._publiplots_legend_group = self
@@ -274,6 +310,109 @@ class MultiAxesLegendGroup:
         for key in order:
             self._render_entry(seen[key])
 
+        # Align pass runs on each draw via the reactor hook so it uses
+        # the current (possibly still-settling) figure geometry.
+        # Absolute positioning → idempotent as geometry converges.
+        if self._align != "start" and not self._align_connected:
+            # Wrap the reactor's _refresh_all to run alignment AFTER it
+            # repositions every registration. That way align sees the
+            # post-refresh anchor position but can still override the
+            # along-edge offsets before matplotlib renders.
+            reactor = self._builder._reactor
+            if not hasattr(reactor, "_align_callbacks"):
+                reactor._align_callbacks = []
+                _orig_refresh = reactor._refresh_all
+
+                def _refresh_then_align():
+                    result = _orig_refresh()
+                    for cb in reactor._align_callbacks:
+                        cb()
+                    return result
+
+                reactor._refresh_all = _refresh_then_align
+            reactor._align_callbacks.append(self._on_draw_align_cb)
+            self._align_connected = True
+
+    def _on_draw_align_cb(self) -> None:
+        """Post-reactor-refresh alignment hook. Runs inside each draw
+        after LayoutReactor has repositioned every registration; our
+        alignment override fires on the registrations this group owns,
+        then those overrides reach the canvas via the reactor's next
+        refresh. Guarded against re-entrancy (measuring triggers draws).
+        """
+        if self._aligning:
+            return
+        self._aligning = True
+        try:
+            self._apply_along_alignment()
+            # Re-run reactor refresh with the updated mm_y_from_top
+            # values so matplotlib renders the new positions in this
+            # draw (not the next one).
+            self._builder._reactor._refresh_all()
+        finally:
+            self._aligning = False
+
+    def _apply_along_alignment(self) -> None:
+        """Re-position all placed reactor registrations along the anchor edge
+        to honor ``self._align``.
+
+        Each row (legends sharing an outward offset) is aligned
+        independently so a wrapped block stays visually balanced. We
+        recompute each registration's **absolute** along-edge offset
+        (``mm_y_from_top`` — historical field name, semantically
+        "along-edge mm from the starting corner") from the known legend
+        extents, then re-run the reactor so the legends snap to the new
+        figure-fraction positions.
+
+        The starting corner of the along-edge axis is ``ax_pos.y1`` for
+        side=right/left (top of anchor) and ``ax_pos.x0`` for
+        side=top/bottom (left of anchor). "Along-edge mm from start"
+        increases as we move AWAY from that corner.
+        """
+        if self._align == "start":
+            return
+        if not self._builder.elements:
+            return
+
+        reactor = self._builder._reactor
+        element_ids = {id(a) for _, a in self._builder.elements}
+        regs = [r for r in reactor._registrations if id(r.artist) in element_ids]
+        if not regs:
+            return
+
+        orient = self._orientation
+        edge_length_mm = self._builder._get_edge_length()
+        gap_mm = self._builder._layout.gap
+
+        # Group regs into rows sharing the same outward offset.
+        rows = {}
+        for reg in regs:
+            key = round(reg.mm_x_from_right, 3)
+            rows.setdefault(key, []).append(reg)
+
+        for row_regs in rows.values():
+            # Measure each legend's along-edge extent.
+            extents = []
+            for reg in row_regs:
+                w, h = self._builder._measure_object_dimensions(reg.artist)
+                extents.append(w if orient == "horizontal" else h)
+            total = sum(extents) + gap_mm * (len(row_regs) - 1)
+            if total >= edge_length_mm:
+                # Block already fills the edge — no room to align.
+                continue
+            if self._align == "center":
+                start = (edge_length_mm - total) / 2
+            elif self._align == "end":
+                start = edge_length_mm - total - self._builder._layout.vpad
+            else:
+                start = self._builder._layout.vpad
+            cursor = start
+            for reg, extent in zip(row_regs, extents):
+                reg.mm_y_from_top = cursor
+                cursor += extent + gap_mm
+
+        reactor._refresh_all()
+
     def _render_entry(self, entry: LegendEntry) -> None:
         """Route to add_legend (categorical) or add_colorbar (continuous)."""
         if entry.kind == "hue" and is_continuous_hue(entry.handles):
@@ -342,6 +481,8 @@ def legend_group(
     *,
     side: str = "right",
     figure: Optional[Figure] = None,
+    orientation: str = "auto",
+    align: str = "auto",
     collect: Optional[Sequence[str]] = None,
     x_offset: Optional[float] = None,
     y_offset: Optional[float] = None,
@@ -359,12 +500,21 @@ def legend_group(
     ``xlabel_space[r]`` for ``side='bottom'``, etc.) absorbs the band
     width.
 
+    ``orientation`` defaults to ``'horizontal'`` for ``side='top'|'bottom'``
+    (entries run along the edge left-to-right, multiple legends sit
+    side-by-side, overflow spills outward in new rows) and
+    ``'vertical'`` for ``'right'|'left'`` (current behaviour).
+    ``align`` defaults to ``'center'`` for top/bottom and ``'start'``
+    for left/right.
+
     See :class:`MultiAxesLegendGroup` for all parameter docs.
     """
     return MultiAxesLegendGroup(
         anchor=anchor,
         side=side,
         figure=figure,
+        orientation=orientation,
+        align=align,
         collect=collect,
         x_offset=x_offset,
         y_offset=y_offset,

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -167,7 +167,7 @@ class MultiAxesLegendGroup:
         y_offset: Optional[float] = None,
         gap: float = 2,
         column_spacing: float = 5,
-        vpad: float = 5,
+        vpad: Optional[float] = None,
         max_width: Optional[float] = None,
     ):
         if side not in ("right", "left", "bottom", "top"):
@@ -203,6 +203,15 @@ class MultiAxesLegendGroup:
         else:
             self.anchor = anchor
             self._anchor_kind = "axes"
+
+        # Default vpad: axes-anchored groups align their legend's top
+        # edge with the axes rectangle (no top padding), while
+        # figure-anchored groups sit inside the decorated-grid rectangle
+        # which already includes title_space above every axes — a
+        # small vpad keeps the legend from crowding that title. Both
+        # paths end up with the legend top at roughly axes-top.
+        if vpad is None:
+            vpad = 0 if self._anchor_kind == "axes" else 5
 
         if collect is not None:
             if isinstance(collect, str) or not hasattr(collect, "__iter__"):
@@ -487,7 +496,7 @@ def legend_group(
     y_offset: Optional[float] = None,
     gap: float = 2,
     column_spacing: float = 5,
-    vpad: float = 5,
+    vpad: Optional[float] = None,
     max_width: Optional[float] = None,
 ) -> MultiAxesLegendGroup:
     """Create a shared legend band.

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -133,11 +133,10 @@ class MultiAxesLegendGroup:
     """
 
     # Default outward gap (mm) between the anchor's edge and the
-    # legend's near side. For side='right' the gap sits in otherwise
-    # empty space, so 2 mm suffices. For the other sides the gap sits
-    # adjacent to tick labels / titles and needs more air for the legend
-    # not to crowd them.
-    _DEFAULT_X_OFFSET_MM = {"right": 2, "left": 5, "bottom": 5, "top": 5}
+    # legend's near side. Per-side mapping so the defaults can be tuned
+    # independently in the future (e.g., if tick labels start crowding
+    # a specific side more than others).
+    _DEFAULT_X_OFFSET_MM = {"right": 2, "left": 2, "bottom": 2, "top": 2}
 
     # side → default orientation. Horizontal makes sense on top/bottom
     # where there's plenty of figure width; vertical stays the default

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -196,6 +196,9 @@ class MultiAxesLegendGroup:
         # Decide anchor kind. When the caller passes an explicit axes we
         # pin the band to that one axes (and its per-cell reservation
         # tuple grows). Otherwise span the whole grid via _GridAnchor.
+        # LegendBuilder resolves the default vpad from self._anchor_ax
+        # (real Axes → 0; _GridAnchor → 5) so both anchor modes end up
+        # visually aligned with the axes top.
         if anchor is None:
             fig = figure if figure is not None else plt.gcf()
             self.anchor = _GridAnchor(fig)
@@ -203,15 +206,6 @@ class MultiAxesLegendGroup:
         else:
             self.anchor = anchor
             self._anchor_kind = "axes"
-
-        # Default vpad: axes-anchored groups align their legend's top
-        # edge with the axes rectangle (no top padding), while
-        # figure-anchored groups sit inside the decorated-grid rectangle
-        # which already includes title_space above every axes — a
-        # small vpad keeps the legend from crowding that title. Both
-        # paths end up with the legend top at roughly axes-top.
-        if vpad is None:
-            vpad = 0 if self._anchor_kind == "axes" else 5
 
         if collect is not None:
             if isinstance(collect, str) or not hasattr(collect, "__iter__"):

--- a/src/publiplots/utils/legend_layout.py
+++ b/src/publiplots/utils/legend_layout.py
@@ -1,10 +1,22 @@
 """
 Pure-geometry legend layout tracking for publiplots.
 
-This module provides LegendLayout — an mm-based cursor that tracks column
+This module provides LegendLayout — an mm-based cursor that tracks
 positions and overflow for legend placement. It contains no matplotlib
 imports; LegendBuilder is responsible for converting mm positions to
 matplotlib coordinates and creating artists.
+
+Terminology (orientation-neutral):
+
+- **outward**: distance from the anchor edge. For ``side='right'`` this
+  is rightward; for ``'bottom'`` it's downward.
+- **along**: remaining space along the anchor edge. For ``side='right'``
+  this is the remaining height below the cursor; for ``'bottom'`` it's
+  the remaining width to the right of the cursor.
+- **row/column**: abstract names for orthogonal bands of legend entries.
+  In vertical orientation (default for right/left), overflow starts a
+  new *column* further outward; in horizontal orientation (default for
+  top/bottom), overflow starts a new *row* further outward.
 """
 
 from dataclasses import dataclass, field
@@ -14,27 +26,35 @@ from typing import List, Optional
 @dataclass
 class LegendLayout:
     """
-    Mm-based cursor for legend column/row positioning.
+    Mm-based cursor for legend row/column positioning.
 
     All dimensions are in millimeters. Pure geometry — no matplotlib imports.
     LegendBuilder uses this to track where each element should go and when
-    to overflow into a new column.
+    to overflow into a new band (column for vertical orientation, row for
+    horizontal).
 
     Parameters
     ----------
     x_offset : float, default=2
-        Horizontal distance from anchor edge (mm).
+        Outward distance from anchor edge (mm).
     y_offset : float, optional
-        Explicit starting y position (mm). If None, reset_to() uses
-        (axes_height - vpad) instead.
+        Explicit starting position along the edge (mm). If None,
+        ``reset_to()`` uses ``(edge_length - vpad)`` instead.
     gap : float, default=2
-        Vertical space between elements (mm).
+        Space between successive elements along the edge (mm).
     column_spacing : float, default=5
-        Horizontal space between columns (mm).
+        Spacing between parallel bands (columns for vertical, rows for
+        horizontal) in mm.
     vpad : float, default=5
-        Padding from top of axes when y_offset is None (mm).
+        Padding from the starting corner along the edge when
+        ``y_offset`` is None (mm).
     max_width : float, optional
-        Maximum column width hint (mm). Currently informational only.
+        Maximum band width hint (mm). Currently informational only.
+    orientation : {'vertical', 'horizontal'}, default='vertical'
+        Primary stacking direction. Informational — LegendBuilder reads
+        it to decide whether overflow checks use estimated height
+        (vertical) or width (horizontal) and whether a new band runs
+        outward as a column or row.
     """
 
     x_offset: float = 2
@@ -43,53 +63,61 @@ class LegendLayout:
     column_spacing: float = 5
     vpad: float = 5
     max_width: Optional[float] = None
+    orientation: str = "vertical"
 
-    # Mutable cursor state (init=False so they aren't constructor args)
-    current_x: float = field(init=False, default=0.0)
-    current_y: float = field(init=False, default=0.0)
-    current_column_width: float = field(init=False, default=0.0)
-    columns: List[float] = field(init=False, default_factory=list)
-    _column_top_y: float = field(init=False, default=0.0)
-    _y_from_top_mm: float = field(init=False, default=0.0)
+    # Mutable cursor state (init=False so they aren't constructor args).
+    # Field names use orientation-neutral semantics ("outward" +
+    # "along-edge") so the same geometry serves both vertical and
+    # horizontal legends.
+    current_outward: float = field(init=False, default=0.0)
+    current_along: float = field(init=False, default=0.0)
+    current_band_width: float = field(init=False, default=0.0)
+    bands: List[float] = field(init=False, default_factory=list)
+    _band_start_along: float = field(init=False, default=0.0)
+    _along_from_start: float = field(init=False, default=0.0)
 
-    def reset_to(self, axes_height_mm: float) -> None:
-        """Reset the cursor. Called at builder init and after axes resize."""
-        self.current_x = self.x_offset
-        top_y = self.y_offset if self.y_offset is not None else (
-            axes_height_mm - self.vpad
+    def reset_to(self, edge_length_mm: float) -> None:
+        """Reset the cursor. Called at builder init and after anchor resize.
+
+        ``edge_length_mm`` is the along-edge extent available (height
+        for vertical orientation, width for horizontal).
+        """
+        self.current_outward = self.x_offset
+        start_along = self.y_offset if self.y_offset is not None else (
+            edge_length_mm - self.vpad
         )
-        self.current_y = top_y
-        self._column_top_y = top_y
-        self.current_column_width = 0.0
-        self.columns = []
-        # mm offset from axes top — starts at vpad for the first element.
-        # Unlike current_y, this does NOT depend on axes_height_mm, so it's
-        # stable across layout changes.
-        self._y_from_top_mm: float = self.vpad
+        self.current_along = start_along
+        self._band_start_along = start_along
+        self.current_band_width = 0.0
+        self.bands = []
+        # mm offset from the starting corner along the edge. Starts at
+        # vpad for the first element and does NOT depend on
+        # edge_length_mm, so it's stable across anchor resizes.
+        self._along_from_start = self.vpad
 
-    def check_overflow(self, required_height: float) -> bool:
-        """True if an element of this height would overflow the current column."""
-        return self.current_y < required_height
+    def check_overflow(self, required_along: float) -> bool:
+        """True if an element of this along-edge size would overflow the current band."""
+        return self.current_along < required_along
 
-    def start_new_column(self) -> None:
-        """Record current column's width, shift cursor right, reset y."""
-        self.columns.append(self.current_column_width)
-        self.current_x += self.current_column_width + self.column_spacing
-        self.current_column_width = 0.0
-        self.current_y = self._column_top_y
-        self._y_from_top_mm = self.vpad  # reset for new column
+    def start_new_band(self) -> None:
+        """Record current band's width, shift cursor outward, reset along-cursor."""
+        self.bands.append(self.current_band_width)
+        self.current_outward += self.current_band_width + self.column_spacing
+        self.current_band_width = 0.0
+        self.current_along = self._band_start_along
+        self._along_from_start = self.vpad
 
-    def advance_y(self, element_height: float) -> None:
-        """Move cursor down by element_height + gap."""
-        self.current_y -= element_height + self.gap
-        self._y_from_top_mm += element_height + self.gap
+    def advance_along(self, element_along: float) -> None:
+        """Move cursor along the edge by ``element_along + gap``."""
+        self.current_along -= element_along + self.gap
+        self._along_from_start += element_along + self.gap
 
     def update_width(self, element_width: float) -> None:
-        """Grow current column width to at least this value (never shrinks)."""
-        if element_width > self.current_column_width:
-            self.current_column_width = element_width
+        """Grow current band's outward width to at least this value (never shrinks)."""
+        if element_width > self.current_band_width:
+            self.current_band_width = element_width
 
     @property
-    def current_y_from_top(self) -> float:
-        """mm offset of the current cursor from the axes top (stable across layout)."""
-        return self._y_from_top_mm
+    def along_from_start(self) -> float:
+        """mm offset of the current cursor from the starting corner (stable)."""
+        return self._along_from_start

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -376,3 +376,32 @@ def test_right_side_legend_top_aligned_with_axes_top(anchor_kind):
         f"{anchor_kind}-anchored: legend top should be within ~1 mm of "
         f"axes top; got delta={delta_mm:.2f} mm"
     )
+
+
+def test_per_axis_outside_right_legend_top_aligned_with_axes():
+    """Regression: ``pp.scatterplot(..., title=...)`` with the default
+    outside-right legend used to sit 5 mm below the axes top because
+    LegendBuilder defaulted vpad=5 regardless of anchor kind. Now
+    LegendBuilder resolves the default vpad from self._anchor_ax:
+    a real Axes gets vpad=0 (flush with axes top), a _GridAnchor gets
+    vpad=5. This regression covers the per-axis path (no legend_group)."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "x": rng.normal(size=40),
+        "y": rng.normal(size=40),
+        "g": np.tile(list("AB"), 20),
+    })
+    ax = pp.scatterplot(
+        data=df, x="x", y="y", hue="g", palette="pastel",
+        title="per-axis",
+    )
+    fig = ax.get_figure()
+    fig.canvas.draw()
+    assert ax.legend_ is not None
+    ax_top_px = ax.get_window_extent().y1
+    legend_top_px = ax.legend_.get_window_extent().y1
+    delta_mm = (ax_top_px - legend_top_px) / fig.dpi * 25.4
+    assert abs(delta_mm) < 1.5, (
+        f"per-axis legend top should be within ~1 mm of axes top; "
+        f"got delta={delta_mm:.2f} mm"
+    )

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -221,3 +221,131 @@ def test_figure_anchored_grid_bbox_excludes_xlabel_space():
             f"anchor y0={anc_y0:.2f} px but ax tight y0={tb.y0:.2f} px: "
             "anchor must sit below tick labels."
         )
+
+
+# --- orientation + align ---------------------------------------------------
+
+
+@pytest.mark.parametrize("side,expected_orientation,expected_align", [
+    ("right", "vertical", "start"),
+    ("left", "vertical", "start"),
+    ("bottom", "horizontal", "center"),
+    ("top", "horizontal", "center"),
+])
+def test_default_orientation_and_align_per_side(side, expected_orientation, expected_align):
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side=side)
+    assert group._orientation == expected_orientation
+    assert group._align == expected_align
+
+
+def test_bottom_horizontal_legend_is_wider_than_tall():
+    """side='bottom' defaults to horizontal layout: the legend's pixel
+    width should comfortably exceed its height (>= 2x)."""
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="bottom")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    bb = group._builder.elements[0][1].get_window_extent()
+    assert (bb.x1 - bb.x0) > 2 * (bb.y1 - bb.y0), (
+        f"expected horizontal layout (w>>h); got w={bb.x1-bb.x0:.1f} "
+        f"h={bb.y1-bb.y0:.1f}"
+    )
+
+
+def test_right_vertical_legend_is_taller_than_wide():
+    """side='right' keeps the historical vertical layout."""
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="right")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    bb = group._builder.elements[0][1].get_window_extent()
+    assert (bb.y1 - bb.y0) > (bb.x1 - bb.x0), (
+        f"expected vertical layout (h>w); got w={bb.x1-bb.x0:.1f} "
+        f"h={bb.y1-bb.y0:.1f}"
+    )
+
+
+def test_bottom_center_align_places_legend_at_grid_midpoint():
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="bottom")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    anc = group.anchor.get_window_extent()
+    bb = group._builder.elements[0][1].get_window_extent()
+    anc_mid = (anc.x0 + anc.x1) / 2
+    leg_mid = (bb.x0 + bb.x1) / 2
+    delta_mm = abs(anc_mid - leg_mid) / fig.dpi * 25.4
+    assert delta_mm < 1.0, f"expected legend centered on anchor; got delta={delta_mm:.2f} mm"
+
+
+def test_explicit_align_end_on_bottom():
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="bottom", align="end")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    anc = group.anchor.get_window_extent()
+    bb = group._builder.elements[0][1].get_window_extent()
+    # Legend right edge should be close to anchor right edge.
+    right_gap_mm = (anc.x1 - bb.x1) / fig.dpi * 25.4
+    # ... and far from the left edge.
+    left_gap_mm = (bb.x0 - anc.x0) / fig.dpi * 25.4
+    assert right_gap_mm < 10.0 and left_gap_mm > 30.0, (
+        f"expected end-aligned; got right_gap={right_gap_mm:.1f}, "
+        f"left_gap={left_gap_mm:.1f}"
+    )
+
+
+def test_explicit_orientation_vertical_on_bottom():
+    """Explicit orientation='vertical' on a bottom-side group produces
+    a stacked (tall) legend even though bottom defaults to horizontal."""
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="bottom", orientation="vertical")
+    assert group._orientation == "vertical"
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    bb = group._builder.elements[0][1].get_window_extent()
+    # Vertical layout: height > width.
+    assert (bb.y1 - bb.y0) > (bb.x1 - bb.x0), (
+        f"explicit orientation=vertical should stack; got w={bb.x1-bb.x0:.1f} "
+        f"h={bb.y1-bb.y0:.1f}"
+    )
+
+
+def test_user_ncol_override_wins_on_horizontal():
+    """Passing ncol=1 via add_legend on a horizontal-orientation group
+    still stacks vertically (user override wins over the orientation
+    default)."""
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="bottom")
+    group.add_legend(handles=_sample_handles(), label="group", ncol=1)
+    fig.canvas.draw()
+    bb = group._builder.elements[0][1].get_window_extent()
+    assert (bb.y1 - bb.y0) > (bb.x1 - bb.x0), (
+        f"ncol=1 should stack vertically; got w={bb.x1-bb.x0:.1f} "
+        f"h={bb.y1-bb.y0:.1f}"
+    )
+
+
+def test_orientation_invalid_raises():
+    with pytest.raises(ValueError, match="orientation must be"):
+        pp.legend_group(orientation="diagonal")
+
+
+def test_align_invalid_raises():
+    with pytest.raises(ValueError, match="align must be"):
+        pp.legend_group(align="middle")

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -1,0 +1,149 @@
+"""4-sided × 2-anchor test matrix for ``pp.legend_group``.
+
+Verifies that the right ``FigureLayout`` reservation field grows for each
+combination of ``side=`` and anchor mode (figure-anchored via no
+``anchor=``, axes-anchored via an explicit axes). Also guards the
+back-compat call signature.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.utils.legend import create_legend_handles
+from publiplots.utils.legend_entries import LegendEntry, stash_entry
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _sample_handles():
+    return create_legend_handles(
+        labels=["A", "B", "C"],
+        colors=list(pp.color_palette("pastel", 3)),
+        alpha=0.2, linewidth=1.0,
+    )
+
+
+# --- figure-anchored ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("side,field", [
+    ("right", "legend_column"),
+    ("bottom", "legend_band_bottom"),
+    ("left", "legend_band_left"),
+    ("top", "legend_band_top"),
+])
+def test_figure_anchored_reserves_correct_field(side, field):
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side=side)
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    layout = fig._publiplots_layout
+    assert getattr(layout, field) > 5.0, (
+        f"side={side!r}: {field} should absorb the legend; "
+        f"got {getattr(layout, field):.1f}"
+    )
+    for other_field in (
+        "legend_column", "legend_band_bottom", "legend_band_left", "legend_band_top"
+    ):
+        if other_field == field:
+            continue
+        assert getattr(layout, other_field) < 0.5, (
+            f"side={side!r}: {other_field} should stay zero; "
+            f"got {getattr(layout, other_field):.1f}"
+        )
+
+
+# --- axes-anchored -----------------------------------------------------------
+
+
+def test_axes_anchored_right_pins_to_column():
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    # Anchor to axes[0, 0] — column 0. The legend should push column 0
+    # wider, not figure-level legend_column.
+    group = pp.legend_group(anchor=axes[0, 0], side="right")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    layout = fig._publiplots_layout
+    assert layout.right[0] > 10.0, (
+        f"right[0] should absorb the legend (axes-anchored); "
+        f"got {layout.right[0]:.1f}"
+    )
+    assert layout.right[1] < 5.0, f"right[1] baseline, got {layout.right[1]:.1f}"
+    assert layout.legend_column < 0.5, (
+        f"legend_column should stay zero for axes-anchored; "
+        f"got {layout.legend_column:.1f}"
+    )
+
+
+def test_axes_anchored_bottom_pins_to_row():
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    # anchor=axes[0, 0] is in row 0. Bottom-anchored pushes xlabel_space[0]
+    # wider (the row's bottom reservation), not legend_band_bottom.
+    group = pp.legend_group(anchor=axes[0, 0], side="bottom")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    layout = fig._publiplots_layout
+    assert layout.xlabel_space[0] > 10.0, (
+        f"xlabel_space[0] should absorb legend; got {layout.xlabel_space[0]:.1f}"
+    )
+    assert layout.legend_band_bottom < 0.5, (
+        f"legend_band_bottom should stay zero; got {layout.legend_band_bottom:.1f}"
+    )
+
+
+# --- validation / back-compat ------------------------------------------------
+
+
+def test_side_invalid_raises():
+    fig, _ = pp.subplots(1, 1, axes_size=(40, 30))
+    with pytest.raises(ValueError, match="side must be"):
+        pp.legend_group(side="diagonal")
+
+
+def test_back_compat_anchor_axes_defaults_to_side_right():
+    """The pre-0.9 signature pp.legend_group(anchor=axes[-1]) must keep
+    working as axes-anchored side='right'."""
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    for ax in axes:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(anchor=axes[-1])
+    assert group._side == "right"
+    assert group._anchor_kind == "axes"
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    layout = fig._publiplots_layout
+    # Axes-anchored right on the last column → right[-1] grows.
+    assert layout.right[-1] > 10.0
+    assert layout.legend_column < 0.5
+
+
+def test_figure_anchored_auto_collect_still_works():
+    """pp.legend_group() without anchor auto-collects stashed entries."""
+    fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
+    stash_entry(
+        axes[0],
+        LegendEntry.build(
+            "g", "hue",
+            handles=_sample_handles(),
+            labels=("A", "B", "C"),
+        ),
+    )
+    group = pp.legend_group()
+    fig.canvas.draw()
+    assert group._materialized
+    assert len(group._builder.elements) == 1
+    assert group._builder.elements[0][1].get_title().get_text() == "g"

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -154,14 +154,14 @@ def test_figure_anchored_auto_collect_still_works():
 
 @pytest.mark.parametrize("side,expected_gap_mm", [
     ("right", 2.0),
-    ("left", 5.0),
-    ("bottom", 5.0),
-    ("top", 5.0),
+    ("left", 2.0),
+    ("bottom", 2.0),
+    ("top", 2.0),
 ])
 def test_figure_anchored_default_outward_gap_per_side(side, expected_gap_mm):
     """The outward gap between the decorated-grid edge and the legend's
-    near side defaults to 2 mm for side='right' (back-compat) and 5 mm
-    for the other sides (so tick labels / titles don't crowd the legend)."""
+    near side defaults to 2 mm on every side. The per-side mapping
+    exists so defaults can be tuned independently later."""
     fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
     for ax in np.atleast_2d(axes).flat:
         ax.plot([0, 1, 2], [0, 1, 0])

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -147,3 +147,77 @@ def test_figure_anchored_auto_collect_still_works():
     assert group._materialized
     assert len(group._builder.elements) == 1
     assert group._builder.elements[0][1].get_title().get_text() == "g"
+
+
+# --- spacing / overlap guards -----------------------------------------------
+
+
+@pytest.mark.parametrize("side,expected_gap_mm", [
+    ("right", 2.0),
+    ("left", 5.0),
+    ("bottom", 5.0),
+    ("top", 5.0),
+])
+def test_figure_anchored_default_outward_gap_per_side(side, expected_gap_mm):
+    """The outward gap between the decorated-grid edge and the legend's
+    near side defaults to 2 mm for side='right' (back-compat) and 5 mm
+    for the other sides (so tick labels / titles don't crowd the legend)."""
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side=side)
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+
+    anc = group.anchor.get_window_extent()
+    legend = group._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    dpi = fig.dpi
+    if side == "right":
+        gap_mm = (lb.x0 - anc.x1) / dpi * 25.4
+    elif side == "left":
+        gap_mm = (anc.x0 - lb.x1) / dpi * 25.4
+    elif side == "bottom":
+        gap_mm = (anc.y0 - lb.y1) / dpi * 25.4
+    else:  # "top"
+        gap_mm = (lb.y0 - anc.y1) / dpi * 25.4
+    assert abs(gap_mm - expected_gap_mm) < 0.5, (
+        f"side={side}: expected ~{expected_gap_mm:.1f} mm gap, got {gap_mm:.2f}"
+    )
+
+
+def test_figure_anchored_grid_bbox_excludes_xlabel_space():
+    """The _GridAnchor's bottom edge sits at the bottom of the xlabel_space
+    zone (not the raw axes rectangle), so a bottom-anchored legend never
+    overlaps with x-tick labels.
+    """
+    from matplotlib.legend import Legend
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(side="bottom")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+
+    # Measure each axes' tight bbox WITHOUT the group's Legend child —
+    # that legend is a visual sibling of the tick labels, not part of
+    # the panel's own decoration footprint.
+    anc_y0 = group.anchor.get_window_extent().y0
+    group_legend_id = id(group._builder.elements[0][1])
+    for ax in np.atleast_2d(axes).flat:
+        toggled = []
+        for child in ax.get_children():
+            if isinstance(child, Legend) and id(child) == group_legend_id:
+                child.set_in_layout(False)
+                toggled.append(child)
+        try:
+            tb = ax.get_tightbbox()
+        finally:
+            for c in toggled:
+                c.set_in_layout(True)
+        if tb is None:
+            continue
+        assert tb.y0 >= anc_y0 - 0.5, (
+            f"anchor y0={anc_y0:.2f} px but ax tight y0={tb.y0:.2f} px: "
+            "anchor must sit below tick labels."
+        )

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -349,3 +349,30 @@ def test_orientation_invalid_raises():
 def test_align_invalid_raises():
     with pytest.raises(ValueError, match="align must be"):
         pp.legend_group(align="middle")
+
+
+@pytest.mark.parametrize("anchor_kind", ["figure", "axes"])
+def test_right_side_legend_top_aligned_with_axes_top(anchor_kind):
+    """Regression: axes-anchored groups used to leave ~vpad extra white
+    space above the legend because the default vpad=5 landed the legend
+    below axes.y1 by 5 mm, while figure-anchored groups reach the same
+    visual position because the _GridAnchor sits higher. Both modes now
+    put the legend top within ~1 mm of the anchor axes' top."""
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    for ax in axes:
+        ax.plot([0, 1, 2], [0, 1, 0])
+        ax.set_title("title")
+    if anchor_kind == "figure":
+        group = pp.legend_group(side="right")
+    else:
+        group = pp.legend_group(anchor=axes[-1], side="right")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+
+    ax_top_px = axes[-1].get_window_extent().y1
+    legend_top_px = group._builder.elements[0][1].get_window_extent().y1
+    delta_mm = (ax_top_px - legend_top_px) / fig.dpi * 25.4
+    assert abs(delta_mm) < 1.5, (
+        f"{anchor_kind}-anchored: legend top should be within ~1 mm of "
+        f"axes top; got delta={delta_mm:.2f} mm"
+    )

--- a/tests/test_legend_layout.py
+++ b/tests/test_legend_layout.py
@@ -5,129 +5,129 @@ from publiplots.utils.legend_layout import LegendLayout
 
 def test_fresh_layout_starts_at_y_offset():
     layout = LegendLayout(x_offset=2, gap=2, column_spacing=5, vpad=5)
-    layout.reset_to(axes_height_mm=80.0)
-    assert layout.current_x == 2
-    assert layout.current_y == 80.0 - 5  # axes_height - vpad
+    layout.reset_to(edge_length_mm=80.0)
+    assert layout.current_outward == 2
+    assert layout.current_along == 80.0 - 5  # edge_length - vpad
 
 
 def test_fresh_layout_uses_explicit_y_offset():
     layout = LegendLayout(x_offset=2, y_offset=50.0, gap=2)
-    layout.reset_to(axes_height_mm=80.0)
-    # With explicit y_offset, reset_to should honor it rather than (height - vpad)
-    assert layout.current_y == 50.0
+    layout.reset_to(edge_length_mm=80.0)
+    # With explicit y_offset, reset_to should honor it rather than (length - vpad)
+    assert layout.current_along == 50.0
 
 
-def test_advance_y_subtracts_element_height_plus_gap():
+def test_advance_along_subtracts_element_size_plus_gap():
     layout = LegendLayout(gap=2)
-    layout.reset_to(axes_height_mm=80.0)
-    start_y = layout.current_y
-    layout.advance_y(element_height=10.0)
-    assert layout.current_y == start_y - 10.0 - 2
+    layout.reset_to(edge_length_mm=80.0)
+    start = layout.current_along
+    layout.advance_along(element_along=10.0)
+    assert layout.current_along == start - 10.0 - 2
 
 
 def test_update_width_is_monotonic_max():
     layout = LegendLayout()
-    layout.reset_to(axes_height_mm=80.0)
+    layout.reset_to(edge_length_mm=80.0)
     layout.update_width(15)
-    assert layout.current_column_width == 15
+    assert layout.current_band_width == 15
     layout.update_width(10)  # smaller - should NOT shrink
-    assert layout.current_column_width == 15
+    assert layout.current_band_width == 15
     layout.update_width(20)
-    assert layout.current_column_width == 20
+    assert layout.current_band_width == 20
 
 
-def test_check_overflow_returns_true_when_required_exceeds_current_y():
+def test_check_overflow_returns_true_when_required_exceeds_current_along():
     layout = LegendLayout(vpad=5)
-    layout.reset_to(axes_height_mm=20.0)
-    # current_y = 15, required = 20 -> overflow
-    assert layout.check_overflow(required_height=20.0) is True
+    layout.reset_to(edge_length_mm=20.0)
+    # current_along = 15, required = 20 -> overflow
+    assert layout.check_overflow(required_along=20.0) is True
     # required = 10 -> fits
-    assert layout.check_overflow(required_height=10.0) is False
+    assert layout.check_overflow(required_along=10.0) is False
 
 
-def test_start_new_column_records_width_and_shifts_x():
+def test_start_new_band_records_width_and_shifts_outward():
     layout = LegendLayout(x_offset=2, column_spacing=5)
-    layout.reset_to(axes_height_mm=80.0)
+    layout.reset_to(edge_length_mm=80.0)
     layout.update_width(12)
-    start_y = layout.current_y
-    layout.advance_y(10)  # move down
-    layout.start_new_column()
-    assert layout.columns == [12]
-    assert layout.current_x == 2 + 12 + 5  # x_offset + col_width + spacing
-    assert layout.current_y == start_y  # y reset to column top
-    assert layout.current_column_width == 0  # reset
+    start = layout.current_along
+    layout.advance_along(10)  # move down the edge
+    layout.start_new_band()
+    assert layout.bands == [12]
+    assert layout.current_outward == 2 + 12 + 5  # x_offset + band_width + spacing
+    assert layout.current_along == start  # along reset to band top
+    assert layout.current_band_width == 0  # reset
 
 
-def test_multiple_new_columns_accumulate():
+def test_multiple_new_bands_accumulate():
     layout = LegendLayout(x_offset=2, column_spacing=5)
-    layout.reset_to(axes_height_mm=80.0)
+    layout.reset_to(edge_length_mm=80.0)
     layout.update_width(10)
-    layout.start_new_column()
+    layout.start_new_band()
     layout.update_width(8)
-    layout.start_new_column()
-    assert layout.columns == [10, 8]
-    # Second column shifted by col1 width + spacing;
-    # third column shifted by col1 + col2 widths + 2*spacing.
-    assert layout.current_x == 2 + 10 + 5 + 8 + 5
+    layout.start_new_band()
+    assert layout.bands == [10, 8]
+    # Second band shifted by band1 width + spacing;
+    # third band shifted by band1 + band2 widths + 2*spacing.
+    assert layout.current_outward == 2 + 10 + 5 + 8 + 5
 
 
 def test_reset_to_clears_state():
     layout = LegendLayout(x_offset=2, vpad=5)
-    layout.reset_to(axes_height_mm=80.0)
+    layout.reset_to(edge_length_mm=80.0)
     layout.update_width(10)
-    layout.advance_y(5)
-    layout.start_new_column()
+    layout.advance_along(5)
+    layout.start_new_band()
     # Now reset
-    layout.reset_to(axes_height_mm=60.0)
-    assert layout.current_x == 2
-    assert layout.current_y == 60.0 - 5
-    assert layout.columns == []
-    assert layout.current_column_width == 0
+    layout.reset_to(edge_length_mm=60.0)
+    assert layout.current_outward == 2
+    assert layout.current_along == 60.0 - 5
+    assert layout.bands == []
+    assert layout.current_band_width == 0
 
 
-def test_zero_width_elements_do_not_corrupt_state():
+def test_zero_size_elements_do_not_corrupt_state():
     layout = LegendLayout()
-    layout.reset_to(axes_height_mm=80.0)
+    layout.reset_to(edge_length_mm=80.0)
     layout.update_width(0)
-    assert layout.current_column_width == 0
-    layout.advance_y(0)
-    layout.start_new_column()
-    assert layout.columns == [0]
+    assert layout.current_band_width == 0
+    layout.advance_along(0)
+    layout.start_new_band()
+    assert layout.bands == [0]
 
 
-def test_current_y_from_top_starts_at_vpad():
+def test_along_from_start_begins_at_vpad():
     layout = LegendLayout(vpad=5, gap=2)
-    layout.reset_to(axes_height_mm=80.0)
-    assert layout.current_y_from_top == 5
+    layout.reset_to(edge_length_mm=80.0)
+    assert layout.along_from_start == 5
 
 
-def test_current_y_from_top_advances_correctly():
+def test_along_from_start_advances_correctly():
     layout = LegendLayout(vpad=5, gap=2)
-    layout.reset_to(axes_height_mm=80.0)
-    layout.advance_y(10.0)
-    assert layout.current_y_from_top == 5 + 10 + 2  # vpad + height + gap
-    layout.advance_y(3.0)
-    assert layout.current_y_from_top == 5 + 10 + 2 + 3 + 2
+    layout.reset_to(edge_length_mm=80.0)
+    layout.advance_along(10.0)
+    assert layout.along_from_start == 5 + 10 + 2  # vpad + size + gap
+    layout.advance_along(3.0)
+    assert layout.along_from_start == 5 + 10 + 2 + 3 + 2
 
 
-def test_current_y_from_top_is_independent_of_axes_height():
-    """The bug fix: y_from_top must not change when axes height changes."""
+def test_along_from_start_is_independent_of_edge_length():
+    """y_from_top / along_from_start must not change when anchor size changes."""
     layout1 = LegendLayout(vpad=5)
-    layout1.reset_to(axes_height_mm=80.0)
-    layout1.advance_y(10.0)
-    y1 = layout1.current_y_from_top
+    layout1.reset_to(edge_length_mm=80.0)
+    layout1.advance_along(10.0)
+    y1 = layout1.along_from_start
 
     layout2 = LegendLayout(vpad=5)
-    layout2.reset_to(axes_height_mm=40.0)  # half the height
-    layout2.advance_y(10.0)
-    y2 = layout2.current_y_from_top
+    layout2.reset_to(edge_length_mm=40.0)  # half the length
+    layout2.advance_along(10.0)
+    y2 = layout2.along_from_start
     assert y1 == y2
 
 
-def test_current_y_from_top_resets_on_new_column():
+def test_along_from_start_resets_on_new_band():
     layout = LegendLayout(vpad=5, gap=2)
-    layout.reset_to(axes_height_mm=80.0)
-    layout.advance_y(10.0)
-    assert layout.current_y_from_top > 5
-    layout.start_new_column()
-    assert layout.current_y_from_top == 5
+    layout.reset_to(edge_length_mm=80.0)
+    layout.advance_along(10.0)
+    assert layout.along_from_start > 5
+    layout.start_new_band()
+    assert layout.along_from_start == 5

--- a/tests/test_subplots.py
+++ b/tests/test_subplots.py
@@ -540,14 +540,15 @@ def test_subplots_negative_tuple_element_raises():
         pp.subplots(2, 1, axes_size=(50, 30), title_space=(5, -1))
 
 
-def test_auto_layout_excludes_legend_group_from_tightbbox():
-    """pp.legend_group anchors a legend external to the axes — its width
-    is handled by legend_column, not the column's `right` reservation."""
+def test_auto_layout_figure_anchored_legend_group_uses_legend_column():
+    """Figure-anchored ``pp.legend_group()`` writes overhang into
+    ``legend_column`` (the far-right scalar reservation), leaving every
+    per-column ``right[]`` at baseline."""
     from publiplots.utils.legend import create_legend_handles
     fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
     for ax in axes:
         ax.plot([0, 1, 2], [0, 1, 0])
-    group = pp.legend_group(anchor=axes[-1])
+    group = pp.legend_group()  # figure-anchored (no explicit anchor)
     group.add_legend(
         handles=create_legend_handles(
             labels=["A", "B", "C"],
@@ -558,11 +559,48 @@ def test_auto_layout_excludes_legend_group_from_tightbbox():
     )
     fig.canvas.draw()
     layout = fig._publiplots_layout
-    # The rightmost column's `right` should be close to baseline (< 5 mm),
-    # NOT inflated to the legend's width.
-    assert layout.right[-1] < 5.0, (
-        f"right[-1] should be ~ baseline (legend excluded from tightbbox); "
+    # Every column's right-side reservation stays at baseline — the
+    # legend lives in the separate legend_column scalar.
+    for c in range(len(axes)):
+        assert layout.right[c] < 5.0, (
+            f"right[{c}] should be ~ baseline (legend in legend_column); "
+            f"got {layout.right[c]:.1f} mm"
+        )
+    assert layout.legend_column > 10.0, (
+        f"legend_column should absorb the legend width; got {layout.legend_column:.1f} mm"
+    )
+
+
+def test_auto_layout_axes_anchored_legend_group_grows_per_cell_right():
+    """Axes-anchored ``pp.legend_group(anchor=axes[r, c])`` grows the
+    anchor column's per-cell ``right[c]``, not the figure-level
+    ``legend_column``."""
+    from publiplots.utils.legend import create_legend_handles
+    fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
+    for ax in axes:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend_group(anchor=axes[-1])  # axes-anchored, last column
+    group.add_legend(
+        handles=create_legend_handles(
+            labels=["A", "B", "C"],
+            colors=list(pp.color_palette("pastel", 3)),
+            alpha=0.2, linewidth=1.0,
+        ),
+        label="group",
+    )
+    fig.canvas.draw()
+    layout = fig._publiplots_layout
+    assert layout.right[-1] > 10.0, (
+        f"right[-1] should absorb the legend width (axes-anchored); "
         f"got {layout.right[-1]:.1f} mm"
+    )
+    assert layout.right[0] < 5.0 and layout.right[1] < 5.0, (
+        f"other columns should stay at baseline; "
+        f"got right[0]={layout.right[0]:.1f}, right[1]={layout.right[1]:.1f}"
+    )
+    assert layout.legend_column < 0.5, (
+        f"legend_column should not absorb axes-anchored width; "
+        f"got {layout.legend_column:.1f} mm"
     )
 
 
@@ -632,9 +670,11 @@ def test_legend_column_is_zero_without_group():
 
 
 def test_legend_column_auto_grows_with_group():
+    """Figure-anchored legend_group auto-grows the figure's legend_column."""
     from publiplots.utils.legend import create_legend_handles
     fig, axes = pp.subplots(1, 2, axes_size=(40, 30))
-    # Stash so auto-collect picks something up
+    # Stash so auto-collect picks something up on the first axes (doesn't
+    # matter which — the group walks every axes in the grid).
     stash_entry(
         axes[0],
         LegendEntry.build(
@@ -644,7 +684,7 @@ def test_legend_column_auto_grows_with_group():
             labels=("A", "B"),
         ),
     )
-    pp.legend_group(anchor=axes[-1])
+    pp.legend_group()  # figure-anchored (no anchor=)
     fig.savefig("/tmp/test_legend_column_auto.png")
     layout = fig._publiplots_layout
     assert layout.legend_column > 5.0, (

--- a/tests/test_subplots.py
+++ b/tests/test_subplots.py
@@ -289,8 +289,8 @@ def test_auto_layout_locked_side_not_remeasured():
 def test_auto_layout_no_hook_when_all_sides_locked():
     layout = _make_layout()
     fig, _ = _make_fig_with_layout(layout)
-    all_sides = {"title_space", "xlabel_space", "ylabel_space", "right", "legend_column"}
-    reactor = SubplotsAutoLayout(fig, layout, locked=all_sides)
+    from publiplots.layout.auto_layout import _ALL_SIDES
+    reactor = SubplotsAutoLayout(fig, layout, locked=_ALL_SIDES)
     # No draw-event callback should be connected
     assert reactor._cid is None
 


### PR DESCRIPTION
## Summary

Second half of the legend placement work (first half was PR #112 — inside-axes per-plot). `pp.legend_group` now supports:

- **4 sides**: `side='right'` (default, unchanged) | `'bottom'` | `'left'` | `'top'`.
- **2 anchor modes**: **figure-anchored** (`anchor=None`, default) spans the full subplot grid on the chosen side; **axes-anchored** (`anchor=axes[r,c]`) pins the band to that single cell.

Completes the plan on file, ready for 0.9.0 cut.

## Why

Today `pp.legend_group(anchor=axes[-1])` on a 2×2 grid pins the band to just `axes[1,1]` — the legend sits next to that one cell instead of spanning the figure's right side. And `side='bottom'` / `'top'` / `'left'` weren't supported at all; `_measure_legend_column` only knew how to reserve space on the right.

## What

1. **`_GridAnchor` proxy** (`utils/legend_group.py`) duck-types `Axes.get_position()` to return the union of all `fig._publiplots_axes` positions. Figure-anchored groups use this proxy as their anchor, so `LegendBuilder` and `LayoutReactor` treat them identically to axes-anchored ones — no branching in position math.

2. **`LegendBuilder.side`** (`utils/legend.py`) — added to `__init__`, passed through to the reactor. `_mm_to_figure_coords` picks the right corner + rotates cursor math for top/bottom. matplotlib `loc` defaults per side so the legend grows outward from the edge.

3. **`LayoutReactor._update_artist_anchor`** dispatches on a new `side` field in `_Registration`; 4 branches for right/left/bottom/top. Colorbar bottom-left computation flips per side.

4. **`SubplotsAutoLayout._apply_legend_band_measurement`** replaces the old `_measure_legend_column`. It branches on `(side, anchor_kind)` → the right `FigureLayout` field:

   | side | figure-anchored | axes-anchored |
   |------|-----------------|---------------|
   | right | `legend_column` | `right[anchor_col]` |
   | bottom | `legend_band_bottom` | `xlabel_space[anchor_row]` |
   | left | `legend_band_left` | `ylabel_space[anchor_col]` |
   | top | `legend_band_top` | `title_space[anchor_row]` |

5. **`FigureLayout`** gains three new scalar fields (`legend_band_bottom`, `_top`, `_left`) alongside the existing `legend_column`. `figure_size()` + `axes_position()` fold them into the W/H totals.

6. **Back-compat**: `pp.legend_group(anchor=axes[-1])` still works — now formally "axes-anchored `side='right'`" and grows `right[-1]` rather than `legend_column`. Visually identical on 1×N, cleaner on 2×2+.

## Test plan

- [x] `tests/test_legend_group_sides.py` — 9 tests covering the 4×2 matrix + validation + back-compat.
- [x] Two new tests in `tests/test_subplots.py` covering figure-anchored (grows `legend_column`) vs axes-anchored (grows `right[c]`) correctly.
- [x] `pytest tests/` — 498 pass (488 baseline + 10 new, net after replacing the old single-anchor exclusion test).
- [x] New `examples/plots/plot_17_legend_placement.py` — 7 sections walking through every placement.
- [x] All 17 gallery examples render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)