### PR TITLE
chore(release): 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-05-05
+
+### Fixed
+- `pp.lineplot` and `pp.pointplot` legend markers now honor the
+  `edgecolor` override (both the explicit argument and
+  `pp.rcParams['edgecolor']`). `HandlerLineMarker.create_artists`
+  extracted the handle's edgecolor but reused the face color for the
+  marker ring, so `edgecolor='black'` had no visible effect on the
+  legend swatch. `pp.scatterplot` was unaffected (it goes through
+  `HandlerMarker`, which already routed `edgecolor` correctly)
+  (PR #118).
+
+[0.9.2]: https://github.com/jorgebotas/publiplots/releases/tag/v0.9.2
+
 ## [0.9.1] - 2026-05-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.9.1"
+version = "0.9.2"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
## Summary

- Bump version to 0.9.2
- Changelog entry for PR #118 (line+marker legend edgecolor fix)

## Test plan

- [x] Full pytest suite green on the fix branch (528 passed)
- [x] All 17 gallery scripts render

🤖 Generated with [Claude Code](https://claude.com/claude-code)