### PR TITLE
feat(lineplot): errorbar=('custom', (lo, hi)) for precomputed CI bands [v0.10.2]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-05-07
+
+### Added
+
+- `pp.lineplot` now accepts `errorbar=('custom', (lower_col,
+  upper_col))` for rendering precomputed CI bands (e.g. from a LOESS
+  bootstrap, a GAM fit, or a Bayesian posterior) directly as
+  `err_style='band'` — no manual `fill_between` loop per group
+  required. Matches the existing `pp.pointplot` API. See
+  `examples/plots/plot_04_lineplot.py` for a full "raw scatter +
+  smooth + CI band" composition.
+- Shared `publiplots.utils.errorbar.format_for_custom_errorbar`
+  helper backing both `pp.lineplot` and `pp.pointplot`.
+
+### Fixed
+
+- `pp.pointplot` with `errorbar=('custom', ...)` no longer crashes
+  when both x and y are numeric and `orient` is left at the default
+  `None`. Previously the internal `_format_for_custom_errorbar`
+  helper called `orient.isin(...)` on a `str`/`None`, which only
+  avoided an `AttributeError` when one of the axes happened to be
+  categorical.
+
+[0.10.2]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.2
+
 ## [0.10.1] - 2026-05-07
 
 ### Added

--- a/examples/plots/plot_04_lineplot.py
+++ b/examples/plots/plot_04_lineplot.py
@@ -249,3 +249,47 @@ for ax, panel in zip(axes, ["Replicate A", "Replicate B", "Replicate C"]):
         ax=ax,
     )
 pp.show()
+
+# %%
+# Smooth Line with Precomputed CI Band
+# -------------------------------------
+# ``errorbar=('custom', (lo_col, hi_col))`` accepts precomputed lower
+# and upper bounds — e.g. from a LOESS bootstrap, a GAM fit, or a
+# Bayesian posterior — and renders them as a shaded band. No manual
+# ``ax.fill_between`` call per group needed. A full "raw scatter +
+# smooth line + CI band" panel now composes as two native ``pp.*``
+# calls.
+#
+# Here we synthesize a noisy sine wave, fit a rolling-mean smoother,
+# and take a rolling 2.5%/97.5% percentile envelope as a stand-in for
+# a bootstrap CI (keeping the example dependency-free — numpy only).
+
+np.random.seed(31)
+x = np.linspace(0, 10, 200)
+y_raw = np.sin(x) + np.random.normal(0, 0.35, size=x.size)
+raw_df = pd.DataFrame({"time": x, "value": y_raw})
+
+window = 25
+rolled = raw_df["value"].rolling(window, center=True, min_periods=1)
+smooth_df = pd.DataFrame({
+    "time": x,
+    "value": rolled.mean().to_numpy(),
+    "lo": rolled.quantile(0.025).to_numpy(),
+    "hi": rolled.quantile(0.975).to_numpy(),
+})
+
+fig, ax = pp.subplots(axes_size=(90, 45))
+pp.scatterplot(
+    data=raw_df, x="time", y="value",
+    color="#6565eb", alpha=0.35, ax=ax,
+)
+pp.lineplot(
+    data=smooth_df, x="time", y="value",
+    errorbar=("custom", ("lo", "hi")),
+    err_style="band", color="#1d1d8a",
+    title="Raw observations + smooth + 95% CI band",
+    xlabel="Time",
+    ylabel="Signal",
+    ax=ax,
+)
+pp.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.1"
+version = "0.10.2"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/src/publiplots/plot/line.py
+++ b/src/publiplots/plot/line.py
@@ -18,6 +18,7 @@ from matplotlib.colors import Normalize
 from publiplots.themes.rcparams import resolve_param
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.utils import is_categorical, is_numeric, create_legend_handles
+from publiplots.utils.errorbar import format_for_custom_errorbar
 from publiplots.utils.legend_entries import (
     LegendEntry,
     stash_entry,
@@ -277,6 +278,17 @@ def lineplot(
         size_map = resolve_size_map(
             size=size, data=data, size_order=size_order, sizes=sizes,
         )
+
+    # Support ``errorbar=('custom', (lo, hi))`` for precomputed CI bands.
+    # The shared helper triplicates rows so seaborn's 100% percentile
+    # interval over the expanded frame spans exactly ``[lo, hi]``; this
+    # lets callers pass LOESS / GAM / Bayesian posterior bounds directly
+    # without running a fresh bootstrap. ``lineplot`` already uses modern
+    # seaborn ``orient`` values ({'x','y'}), so pass through untranslated.
+    if isinstance(errorbar, tuple) and errorbar[0] == "custom":
+        data = format_for_custom_errorbar(data, x, y, errorbar[1], orient)
+        estimator = "median"
+        errorbar = ("pi", 100)
 
     # Prepare seaborn kwargs. publiplots handles the legend itself.
     sns_kwargs = {

--- a/src/publiplots/plot/point.py
+++ b/src/publiplots/plot/point.py
@@ -18,6 +18,7 @@ from typing import Optional, Tuple, Union, Dict, List
 from publiplots.themes.rcparams import resolve_param
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.utils import create_legend_handles
+from publiplots.utils.errorbar import format_for_custom_errorbar
 from publiplots.utils.legend_entries import (
     LegendEntry,
     stash_entry,
@@ -27,6 +28,18 @@ from publiplots.utils.legend_entries import (
     is_continuous_hue,
 )
 from publiplots.utils.plot_legend import render_entries, resolve_style_maps
+
+
+# Map seaborn's legacy orient tokens onto the modern {'x', 'y'} set used
+# by :func:`publiplots.utils.errorbar.format_for_custom_errorbar`.
+_MODERN_ORIENT = {
+    "h": "y",
+    "horizontal": "y",
+    "v": "x",
+    "vertical": "x",
+    "x": "x",
+    "y": "y",
+}
 
 
 def pointplot(
@@ -258,9 +271,13 @@ def pointplot(
     if 'linewidth' not in err_kws:
         err_kws['linewidth'] = linewidth
 
-    # Resolve errorbar if custom error values are provided
+    # Resolve errorbar if custom error values are provided. Translate
+    # seaborn's legacy orient tokens ('h'/'v') to the modern {'x','y'}
+    # set that the shared helper expects; pass None through so the
+    # helper can auto-detect from which axis is categorical.
     if isinstance(errorbar, tuple) and errorbar[0] == "custom":
-        data = _format_for_custom_errorbar(data, x, y, errorbar[1], orient)
+        modern_orient = _MODERN_ORIENT.get(orient) if orient is not None else None
+        data = format_for_custom_errorbar(data, x, y, errorbar[1], modern_orient)
         estimator = "median"   # middle value for estimator
         errorbar = ("pi", 100) # Use full range
 
@@ -354,42 +371,6 @@ def pointplot(
         _annotate_fn(ax, kind="point_values", **opts)
 
     return ax
-
-def _format_for_custom_errorbar(
-    data: pd.DataFrame,
-    x: str,
-    y: str,
-    custom_errorbar: Tuple[str, str],
-    orient: Optional[str] = None,
-) -> pd.DataFrame:
-    """"
-    Format data for custom errorbar.
-    """
-    # Figure out categorical variable
-    value_col = None
-    if is_categorical(data[y]) or orient.isin(["horizontal", "h", "x"]):
-        value_col = x
-    elif is_categorical(data[x]) or orient.isin(["vertical", "v", "y"]):
-        value_col = y
-    else:
-        raise ValueError(
-            "One of x or y must be categorical. "
-            "Or orient must be specified."
-        )
-
-    lower, upper = custom_errorbar
-    assert lower in data.columns and upper in data.columns, \
-        "Custom errorbar must be a tuple of column names."
-    
-    data = pd.concat([
-        data.assign(__value=data[lower]),
-        data.assign(__value=data[value_col]),
-        data.assign(__value=data[upper]),
-    ], ignore_index=True)
-    data[value_col] = data["__value"]
-    data.drop(columns=["__value"], inplace=True)
-    return data
-
 
 def _legend(
     ax: Axes,

--- a/src/publiplots/utils/errorbar.py
+++ b/src/publiplots/utils/errorbar.py
@@ -1,0 +1,103 @@
+"""Utilities for custom error-bar / error-band rendering.
+
+When callers already have precomputed confidence bounds (e.g. from a
+LOESS bootstrap, a GAM fit, or a Bayesian posterior), they can pass
+``errorbar=('custom', (lower_col, upper_col))`` to
+:func:`publiplots.pointplot` or :func:`publiplots.lineplot` and have
+the bounds rendered as error bars / shaded bands without running
+seaborn's own bootstrap.
+
+The plot functions convert that request into a seaborn-native
+``estimator='median'`` + ``errorbar=('pi', 100)`` call by triplicating
+each row of the data so the 100% percentile interval spans exactly the
+requested ``(lo, hi)`` bounds. :func:`format_for_custom_errorbar`
+performs that triplication.
+"""
+
+from typing import Optional, Tuple
+
+import pandas as pd
+
+from publiplots.utils.validation import is_categorical
+
+
+def format_for_custom_errorbar(
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    cols: Tuple[str, str],
+    orient: Optional[str] = None,
+) -> pd.DataFrame:
+    """Triplicate rows so a 100% percentile interval spans ``(lo, hi)``.
+
+    Returns a long-format DataFrame with 3x the input row count: one
+    copy with the value column overwritten by the lower bound, one
+    unchanged copy, and one copy with the value column overwritten by
+    the upper bound. When passed to seaborn with
+    ``estimator='median'`` + ``errorbar=('pi', 100)``, the resulting
+    interval spans exactly ``[lo, hi]``.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Input data containing ``x``, ``y`` and both bound columns.
+    x, y : str
+        Column names for the x- and y-axis variables.
+    cols : (str, str)
+        Column names ``(lower, upper)`` holding the precomputed bounds.
+    orient : {'x', 'y', None}, optional
+        Which axis carries the aggregated numeric value.
+
+        - ``'x'`` (seaborn's default) means the aggregation happens
+          within each x group; ``y`` is the value axis and ``(lo, hi)``
+          are y-bounds.
+        - ``'y'`` swaps that: ``x`` is the value axis.
+        - ``None`` auto-detects from which of ``x`` / ``y`` is
+          categorical. If both are numeric, falls back to ``y`` as the
+          value axis (matching seaborn's ``orient='x'`` default).
+
+    Returns
+    -------
+    pd.DataFrame
+        Long-format frame with 3x the row count of ``data``. The value
+        column is overwritten with ``lo`` in the first third and
+        ``hi`` in the last third; all other columns are unchanged
+        (rows repeated).
+
+    Raises
+    ------
+    KeyError
+        If either ``cols[0]`` or ``cols[1]`` is not a column of
+        ``data``.
+    """
+    lower, upper = cols
+    if lower not in data.columns or upper not in data.columns:
+        missing = [c for c in cols if c not in data.columns]
+        raise KeyError(
+            f"Custom errorbar columns not found in data: {missing}. "
+            f"Available columns: {list(data.columns)}"
+        )
+
+    # Decide which column carries the aggregated numeric value.
+    if orient == "x":
+        value_col = y
+    elif orient == "y":
+        value_col = x
+    elif orient is None and is_categorical(data[x]):
+        value_col = y
+    elif orient is None and is_categorical(data[y]):
+        value_col = x
+    else:
+        # Both numeric and no orient given: default to y as the value
+        # axis, matching seaborn's ``orient='x'`` default (aggregation
+        # happens within x groups, so y carries the numeric value).
+        value_col = y
+
+    return pd.concat(
+        [
+            data.assign(**{value_col: data[lower]}),
+            data,
+            data.assign(**{value_col: data[upper]}),
+        ],
+        ignore_index=True,
+    )

--- a/tests/test_errorbar.py
+++ b/tests/test_errorbar.py
@@ -105,3 +105,79 @@ def test_pointplot_custom_errorbar_categorical_y_still_works():
         errorbar=("custom", ("log2_lower", "log2_upper")),
         ax=ax,
     )
+
+
+# ---- Lineplot integration ----
+
+
+def test_lineplot_custom_errorbar_renders_band():
+    """A single-series lineplot with ``errorbar=('custom', ...)`` and
+    ``err_style='band'`` must render a shaded band.
+
+    Matplotlib 3.8+ represents the band as a ``FillBetweenPolyCollection``
+    (a ``PolyCollection`` subclass); older versions use a plain
+    ``PolyCollection``. ``isinstance`` covers both.
+    """
+    from matplotlib.collections import PolyCollection
+
+    df = pd.DataFrame(
+        {
+            "day": list(range(10)),
+            "y": list(range(10, 20)),
+            "lo": list(range(8, 18)),
+            "hi": list(range(12, 22)),
+        }
+    )
+    fig, ax = plt.subplots()
+    pp.lineplot(
+        data=df,
+        x="day",
+        y="y",
+        errorbar=("custom", ("lo", "hi")),
+        err_style="band",
+        ax=ax,
+    )
+    assert any(isinstance(coll, PolyCollection) for coll in ax.collections)
+
+
+def test_lineplot_custom_errorbar_with_hue():
+    """Custom errorbars must compose with ``hue`` — one band per group."""
+    from matplotlib.collections import PolyCollection
+
+    df = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "day": list(range(5)),
+                    "y": [1, 2, 3, 4, 5],
+                    "lo": [0.5] * 5,
+                    "hi": [1.5] * 5,
+                    "g": "a",
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "day": list(range(5)),
+                    "y": [2, 3, 4, 5, 6],
+                    "lo": [1.5] * 5,
+                    "hi": [2.5] * 5,
+                    "g": "b",
+                }
+            ),
+        ]
+    )
+    fig, ax = plt.subplots()
+    pp.lineplot(
+        data=df,
+        x="day",
+        y="y",
+        hue="g",
+        errorbar=("custom", ("lo", "hi")),
+        err_style="band",
+        ax=ax,
+    )
+    # One band per hue level.
+    bands = [
+        coll for coll in ax.collections if isinstance(coll, PolyCollection)
+    ]
+    assert len(bands) == 2

--- a/tests/test_errorbar.py
+++ b/tests/test_errorbar.py
@@ -1,0 +1,107 @@
+"""Tests for the shared custom-errorbar helper and its plot-function
+integrations."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.utils.errorbar import format_for_custom_errorbar
+
+
+@pytest.fixture(autouse=True)
+def _close():
+    yield
+    plt.close("all")
+
+
+# ---- Helper unit tests ----
+
+
+def test_helper_triplicates_rows():
+    df = pd.DataFrame(
+        {"day": [1, 2, 3], "y": [10, 20, 30], "lo": [8, 18, 28], "hi": [12, 22, 32]}
+    )
+    out = format_for_custom_errorbar(df, "day", "y", ("lo", "hi"), "x")
+    assert len(out) == 9  # 3x original
+    # Value column must cycle lo / original / hi.
+    assert list(out["y"]) == [8, 18, 28, 10, 20, 30, 12, 22, 32]
+    # Other columns repeat three times unchanged.
+    assert list(out["day"]) == [1, 2, 3] * 3
+
+
+def test_helper_auto_orient_categorical_x():
+    df = pd.DataFrame(
+        {"gene": ["A", "B"], "val": [1.0, 2.0], "lo": [0.5, 1.5], "hi": [1.5, 2.5]}
+    )
+    # orient=None + x categorical -> value_col = y.
+    out = format_for_custom_errorbar(df, "gene", "val", ("lo", "hi"), None)
+    assert list(out["val"]) == [0.5, 1.5, 1.0, 2.0, 1.5, 2.5]
+
+
+def test_helper_explicit_orient_y_aggregates_on_x():
+    df = pd.DataFrame(
+        {"val": [1.0, 2.0], "gene": ["A", "B"], "lo": [0.5, 1.5], "hi": [1.5, 2.5]}
+    )
+    # orient='y' means the categorical axis is y; x carries the value.
+    out = format_for_custom_errorbar(df, "val", "gene", ("lo", "hi"), "y")
+    assert list(out["val"]) == [0.5, 1.5, 1.0, 2.0, 1.5, 2.5]
+
+
+def test_helper_both_numeric_no_orient_defaults_to_y():
+    """Both axes numeric and orient=None -> value_col falls back to y
+    (matching seaborn's ``orient='x'`` default)."""
+    df = pd.DataFrame(
+        {"x": [1, 2, 3], "y": [10, 20, 30], "lo": [8, 18, 28], "hi": [12, 22, 32]}
+    )
+    out = format_for_custom_errorbar(df, "x", "y", ("lo", "hi"), None)
+    assert list(out["y"]) == [8, 18, 28, 10, 20, 30, 12, 22, 32]
+
+
+def test_helper_missing_cols_raises_keyerror():
+    df = pd.DataFrame({"x": [1, 2], "y": [10, 20]})
+    with pytest.raises(KeyError):
+        format_for_custom_errorbar(df, "x", "y", ("nope", "also_nope"), "x")
+
+
+# ---- Pointplot integration / regression ----
+
+
+def test_pointplot_custom_errorbar_non_categorical_axes_no_crash():
+    """Regression for the ``orient.isin(...)`` bug in v0.10.1: when both
+    x and y are numeric and ``orient`` is the default ``None``, the old
+    local helper called ``None.isin(...)`` and raised. After the move
+    to the shared helper the call resolves cleanly (defaulting to y as
+    the value axis)."""
+    df = pd.DataFrame(
+        {"x": [1, 2, 3], "y": [10, 20, 30], "lo": [8, 18, 28], "hi": [12, 22, 32]}
+    )
+    fig, ax = plt.subplots()
+    pp.pointplot(
+        data=df, x="x", y="y", errorbar=("custom", ("lo", "hi")), ax=ax
+    )
+
+
+def test_pointplot_custom_errorbar_categorical_y_still_works():
+    """Pre-existing gallery use case (forest plot: numeric x, categorical y)
+    must keep working after the refactor."""
+    df = pd.DataFrame(
+        {
+            "log2_or": [0.85, 0.45, -0.25],
+            "gene": ["APOE", "TREM2", "CLU"],
+            "log2_lower": [0.65, 0.25, -0.45],
+            "log2_upper": [1.05, 0.65, -0.05],
+        }
+    )
+    fig, ax = plt.subplots()
+    pp.pointplot(
+        data=df,
+        x="log2_or",
+        y="gene",
+        errorbar=("custom", ("log2_lower", "log2_upper")),
+        ax=ax,
+    )


### PR DESCRIPTION
Closes #124.

## Summary

Extends the `errorbar=('custom', (lower_col, upper_col))` pattern from `pp.pointplot` to `pp.lineplot`, so precomputed CI bands (LOESS bootstrap, GAMs, Bayesian posteriors) render as shaded `err_style='band'` regions without manual `fill_between` calls.

```python
# The full "raw scatter + smooth + CI" panel now reduces to two native calls:
pp.scatterplot(data=raw_df, x='day', y='obs', hue='group', alpha=0.35, ax=ax, legend=False)
pp.lineplot(data=smooth_df, x='day', y='y', hue='group',
            errorbar=('custom', ('ci_lo', 'ci_hi')), err_style='band', ax=ax)
```

## Changes

- **New shared helper** at `src/publiplots/utils/errorbar.py::format_for_custom_errorbar`. Triplicates input rows so seaborn's `(errorbar='pi', estimator='median')` spans the precomputed bounds exactly.
- **`pp.pointplot` now uses the shared helper**. Also fixes a real bug along the way: the old `_format_for_custom_errorbar` called `orient.isin([...])` on a `str`, which AttributeError'd for non-categorical data. Worked before only because the one gallery example had a categorical x that short-circuited the `or`. Zero existing tests covered this path.
- **`pp.lineplot`** gets the same 4-line branch before its `sns_kwargs` assembly.
- **Gallery**: new section in `examples/plots/plot_04_lineplot.py` demonstrating the combined scatter + smooth + CI pattern with self-contained synthesized data (sine + noise + rolling-percentile CI — no scipy dependency).

## Commits

1. `refactor(errorbar): extract format_for_custom_errorbar to shared utility` — new utility, point.py migrated, orient bug fixed at the call site, 7 tests (5 helper unit + 2 pointplot regression).
2. `feat(lineplot): support errorbar=('custom', (lo, hi)) for precomputed CI bands` — line.py branch + 2 integration tests.
3. `docs(examples): smooth line + CI band gallery section in plot_04`
4. `chore(release): v0.10.2`

## Test plan

- [x] Full suite: **560 pass** (551 baseline + 9 new in `test_errorbar.py`)
- [x] Gallery: 17/17 render clean
- [x] Regression test for the pre-existing `pp.pointplot` orient bug (non-categorical data path)
- [x] Integration tests for `pp.lineplot` (with and without `hue`)
- [x] `isinstance(coll, PolyCollection)` assertion handles both matplotlib 3.7 (`PolyCollection`) and 3.8+ (`FillBetweenPolyCollection` subclass)
- [x] Version bumped: `pp.__version__ == '0.10.2'`, pyproject + plugin.json consistent

## Out of scope

- Auto-computing CI from a `n_boot` kwarg — users still run their own smoother.
- Extending custom errorbar to `pp.scatterplot` / `pp.barplot` — separate feature if requested.
- Public `pp.format_for_custom_errorbar` in the top-level namespace — helper stays in `utils/`; users shouldn't call it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)