### PR TITLE
chore(release): v0.10.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2026-05-08
+
+### Changed
+
+- Docstring overhaul across every public `pp.*` function and the
+  Sphinx API reference:
+  - Completed the API-reference toctrees — every name in
+    `publiplots.__all__` now has an entry (previously missing:
+    `lineplot`, `pointplot`, `violinplot`, `raincloudplot`, `heatmap`,
+    `complex_heatmap`, `dendrogram`, `subplots`, `show`, `suptitle`,
+    `rotate`, `invert_axis`, `MultiAxesLegendGroup`,
+    `HandlerLineMarker`, `LineMarkerPatch`, `STANDARD_MARKERS`,
+    `HATCH_PATTERNS`).
+  - Documented publiplots-specific features that differentiate from
+    seaborn: `errorbar=('custom', (lo, hi))` on `pp.lineplot` /
+    `pp.pointplot`, `pp.subplots` mm-units + `reject_figsize`,
+    `pp.savefig` `bbox_inches=None` default (0.9.3+),
+    `pp.scatterplot` `background_marker`, `pp.raincloudplot`
+    composite (half-violin + box + strip), `pp.heatmap` /
+    `pp.complex_heatmap` clustering + dot-heatmap mode.
+  - Added a **Notes** section to `pp.legend` documenting the
+    flagship 0.10 asymmetry: `pp.legend(ax)` positional (internal
+    per-axes legend) vs `pp.legend(anchor=ax)` keyword (external
+    band overhang).
+  - Rewrote `pp.barplot` `hatch` / `hatch_map` params with the
+    "second categorical via texture" mental model; cross-references
+    to `pp.set_hatch_mode`, `pp.list_hatch_patterns`,
+    `pp.HATCH_PATTERNS`.
+  - Aligned docstring defaults with actual signatures (drift fixes
+    in `pp.raincloudplot`, `pp.venn`, `pp.scatterplot`, `pp.savefig`
+    `transparent`, DPI).
+  - Fixed broken `See Also` blocks (e.g. removed phantom
+    `barplot_enrichment` reference).
+  - Removed stale references to 0.10-removed API (`pp.legend_group`,
+    `pp.legend(ax, auto=False)`).
+
+### Fixed
+
+- Several Sphinx-rendering issues in docstrings:
+  `pp.pointplot` `errorbar` nested-bullet indentation,
+  `pp.barplot` `hatch_map` malformed escape example, single-backtick
+  inline literals throughout.
+
 ## [0.10.2] - 2026-05-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.2"
+version = "0.10.3"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"


### PR DESCRIPTION
Release PR for v0.10.3 — ships the docstring overhaul from #126.

Bumps version in the three usual spots:
- `pyproject.toml`: 0.10.2 → 0.10.3
- `src/publiplots/__init__.py`: `__version__` 0.10.2 → 0.10.3
- `.claude-plugin/plugin.json`: 0.10.2 → 0.10.3

Prepends `[0.10.3] - 2026-05-08` section to `CHANGELOG.md` summarizing the documentation changes.

Merge and tag v0.10.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)