### PR TITLE
feat(suptitle): auto-reserve vertical space via SubplotsAutoLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat(suptitle): `pp.suptitle` now reserves space via the auto-layout engine — no more overlap with top-row axes.
 
+### Changed
+
+- `figure.titlesize` default is now `11` (was matplotlib's `"large"`, which resolves to 9.6pt at publiplots' 8pt base — smaller than the 10pt panel titles, a flipped hierarchy). `figure.titleweight` stays `"normal"`. The figure-level suptitle now reads as the outermost heading.
+
 ## [0.10.3] - 2026-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- feat(suptitle): `pp.suptitle` now reserves space via the auto-layout engine — no more overlap with top-row axes.
+
 ## [0.10.3] - 2026-05-08
 
 ### Changed

--- a/examples/plots/plot_12_heatmap.py
+++ b/examples/plots/plot_12_heatmap.py
@@ -152,7 +152,7 @@ axes = (
     )
     .build()
 )
-pp.suptitle('Clustered Heatmap with Dendrograms', y=1.02)
+pp.suptitle('Clustered Heatmap with Dendrograms')
 pp.show()
 
 # %%
@@ -202,7 +202,7 @@ axes = (
     )
     .build()
 )
-pp.suptitle('Complex Heatmap with Summary Bar Plot', y=1.02)
+pp.suptitle('Complex Heatmap with Summary Bar Plot')
 pp.show()
 
 # %%
@@ -292,5 +292,5 @@ axes = (
     )
     .build()
 )
-pp.suptitle('Clustered Heatmap (Dendrograms Hidden)', y=1.02)
+pp.suptitle('Clustered Heatmap (Dendrograms Hidden)')
 pp.show()

--- a/examples/plots/plot_17_legend_placement.py
+++ b/examples/plots/plot_17_legend_placement.py
@@ -153,6 +153,27 @@ for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
 pp.show()
 
 # %%
+# 5b. Figure title (``pp.suptitle``) above a ``side='top'`` band
+# --------------------------------------------------------------
+# ``pp.suptitle`` hooks into the same auto-layout engine as the legend
+# bands: it measures the text's height and grows the figure to reserve
+# a dedicated ``suptitle_space`` band above everything else. No
+# manual ``y=...`` nudge, no overlap with the top row of axis titles —
+# and a ``side='top'`` legend band slots in cleanly between the
+# suptitle and the axes.
+
+fig, axes = pp.subplots(2, 2, axes_size=(35, 30))
+pp.legend(side="top")
+for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
+    pp.scatterplot(
+        data=_df[_df["panel"] == panel], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f"Panel {panel}", ax=axes[r, c],
+    )
+pp.suptitle("Experiment 42")
+pp.show()
+
+# %%
 # 6. Axes-anchored: pin the band to a single cell
 # -----------------------------------------------
 # Pass ``anchor=axes[r, c]`` to pin the band to one cell. The

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -24,6 +24,7 @@ _UPDATE_THRESHOLD_MM = 0.1
 _ALL_SIDES = {
     "title_space", "xlabel_space", "ylabel_space", "right",
     "legend_column", "legend_band_bottom", "legend_band_top", "legend_band_left",
+    "suptitle_space",
 }
 # Cap on settle() draws; 1-3 is typical.
 _MAX_CONVERGENCE_ITERS = 5
@@ -143,6 +144,11 @@ class SubplotsAutoLayout:
         # its overhang to the right reservation field based on (side,
         # anchor_kind).
         self._apply_legend_band_measurement(measured, axes_matrix)
+        # Measure pp.suptitle (if any) and write its mm height into
+        # ``measured["suptitle_space"]``. Ordering is irrelevant —
+        # suptitle_space is a dedicated scalar, independent of legend
+        # bands.
+        self._apply_suptitle_measurement(measured, dpi)
         return measured
 
     def _side_extent(self, ax, calc, managed_artist_ids) -> float:
@@ -217,6 +223,7 @@ class SubplotsAutoLayout:
 
     _SCALAR_SIDES = {
         "legend_column", "legend_band_bottom", "legend_band_top", "legend_band_left",
+        "suptitle_space",
     }
 
     def _needs_update(self, measured: Dict[str, Tuple[float, ...]]) -> bool:
@@ -251,6 +258,32 @@ class SubplotsAutoLayout:
         "bottom": ("legend_band_bottom",  "xlabel_space", "row"),
         "top":    ("legend_band_top",     "title_space",  "row"),
     }
+
+    def _apply_suptitle_measurement(self, measured: dict, dpi: float) -> None:
+        """Measure the pixel height of ``fig._publiplots_suptitle`` (if any)
+        and write it into ``measured["suptitle_space"]`` in mm.
+
+        A ``+1 mm`` safety margin is added (same convention as
+        :meth:`_measure_one_group` below at the
+        ``overhang_mm = max_overhang_px / dpi * 25.4 + 1.0`` line).
+        When there is no suptitle, writes ``0.0`` so the reservation
+        collapses back to zero.
+        """
+        if "suptitle_space" in self._locked:
+            return
+        artist = getattr(self._fig, "_publiplots_suptitle", None)
+        if artist is None:
+            measured["suptitle_space"] = 0.0
+            return
+        try:
+            extent = artist.get_window_extent()
+        except Exception:
+            measured["suptitle_space"] = 0.0
+            return
+        if extent is None or extent.height <= 0:
+            measured["suptitle_space"] = 0.0
+            return
+        measured["suptitle_space"] = extent.height / dpi * 25.4 + 1.0
 
     def _apply_legend_band_measurement(self, measured: dict, axes_matrix) -> None:
         """Measure every pp.legend_group's overhang and write it into
@@ -434,6 +467,17 @@ class SubplotsAutoLayout:
         for r, row in enumerate(self._axes_matrix()):
             for c, ax in enumerate(row):
                 ax.set_position(new_layout.axes_position(r, c))
+
+        # Reposition pp.suptitle (if any) to the vertical midpoint of
+        # its reserved band. Runs after set_size_inches so the figure's
+        # final height is known; the next draw renders the title at
+        # the fixed fraction inside the grown canvas.
+        suptitle = getattr(self._fig, "_publiplots_suptitle", None)
+        if suptitle is not None and new_layout.suptitle_space > 0:
+            y_mm = H - new_layout.outer_pad - new_layout.suptitle_space / 2
+            suptitle.set_position((0.5, y_mm / H))
+            suptitle.set_verticalalignment("center")
+            suptitle.set_horizontalalignment("center")
 
     def _axes_matrix(self):
         stored = getattr(self._fig, "_publiplots_axes", None)

--- a/src/publiplots/layout/figure_layout.py
+++ b/src/publiplots/layout/figure_layout.py
@@ -44,6 +44,10 @@ class FigureLayout:
         grid. Used by figure-anchored ``pp.legend_group(side=...)``.
         Default ``0.0``. All four scalars only kick in when a
         figure-anchored legend group asks for space on that side.
+    suptitle_space : float
+        Extra mm above ``legend_band_top`` reserved for a figure-level
+        ``pp.suptitle``. Default ``0.0``; auto-measured by
+        :class:`SubplotsAutoLayout` when a suptitle is present.
     """
 
     nrows: int
@@ -60,6 +64,7 @@ class FigureLayout:
     legend_band_bottom: float = 0.0
     legend_band_top: float = 0.0
     legend_band_left: float = 0.0
+    suptitle_space: float = 0.0
 
     def __post_init__(self) -> None:
         for side in ("title_space", "xlabel_space", "ylabel_space", "right"):
@@ -101,6 +106,7 @@ class FigureLayout:
         )
         H = (
             self.outer_pad
+            + self.suptitle_space
             + self.legend_band_top
             + sum(self.title_space)
             + self.nrows * h_ax

--- a/src/publiplots/layout/subplots.py
+++ b/src/publiplots/layout/subplots.py
@@ -272,6 +272,7 @@ def subplots(
         nrows=nrows, ncols=ncols,
         axes_size=axes_size_t,
         legend_column=0.0,
+        suptitle_space=0.0,
         **resolved,
     )
     W, H = layout.figure_size()

--- a/src/publiplots/themes/rcparams.py
+++ b/src/publiplots/themes/rcparams.py
@@ -52,6 +52,12 @@ MATPLOTLIB_RCPARAMS: Dict[str, Any] = {
     "figure.edgecolor": "none",
     "figure.subplot.hspace": 0.05,
     "figure.subplot.wspace": 0.05,
+    # Figure-level suptitle: one notch above axes.titlesize (10) so the
+    # figure title reads as the outermost heading in the type hierarchy
+    # (matplotlib's default 'large' resolves to 9.6pt, which is smaller
+    # than the panel titles — flipped hierarchy).
+    "figure.titlesize": 11,
+    "figure.titleweight": "normal",
 
     # Font settings - optimized for readability
     "font.size": 8,

--- a/src/publiplots/utils/display.py
+++ b/src/publiplots/utils/display.py
@@ -37,8 +37,12 @@ def show(*args: Any, **kwargs: Any) -> None:
 def suptitle(text: str, **kwargs: Any) -> Text:
     """Add a figure-level title to the current figure.
 
-    Thin wrapper around :func:`matplotlib.pyplot.suptitle`. Returns the
-    created :class:`~matplotlib.text.Text` artist. Uses
+    Thin wrapper around :func:`matplotlib.pyplot.suptitle` that also
+    hooks into publiplots' auto-layout engine: the figure grows
+    vertically to reserve room for the title (no overlap with top-row
+    axis titles), and repeated calls replace the prior suptitle rather
+    than accumulating texts on the figure. Returns the created
+    :class:`~matplotlib.text.Text` artist. Uses
     ``matplotlib.pyplot.gcf()`` to locate the target figure.
 
     Parameters
@@ -62,4 +66,26 @@ def suptitle(text: str, **kwargs: Any) -> Text:
     >>> pp.barplot(data=df2, x='x', y='y', ax=axes[1])
     >>> pp.suptitle('Comparison of two experiments')
     """
-    return plt.suptitle(text, **kwargs)
+    fig = plt.gcf()
+    prior = getattr(fig, "_publiplots_suptitle", None)
+    if prior is not None:
+        try:
+            prior.remove()
+        except (NotImplementedError, ValueError):
+            # Already detached from the figure, or remove unsupported;
+            # proceed — the important invariant is that only the new
+            # artist ends up in fig._publiplots_suptitle.
+            pass
+        # Matplotlib caches the suptitle on ``fig._suptitle`` and
+        # re-uses it on subsequent ``plt.suptitle`` calls. After we
+        # remove the prior Text from ``fig.texts``, null the cache so
+        # the next ``plt.suptitle`` creates a fresh, attached artist
+        # rather than silently updating the detached one.
+        fig._suptitle = None
+    artist = plt.suptitle(text, **kwargs)
+    fig._publiplots_suptitle = artist
+    # Trigger a re-measure so the figure grows before the user sees it.
+    al = getattr(fig, "_publiplots_auto_layout", None)
+    if al is not None:
+        al.settle()
+    return artist

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -206,7 +206,12 @@ class _GridAnchor:
                 x0 = (layout.outer_pad + layout.legend_band_left) / W
                 x1 = (W - layout.outer_pad - layout.legend_column) / W
                 y0 = (layout.outer_pad + layout.legend_band_bottom) / H
-                y1 = (H - layout.outer_pad - layout.legend_band_top) / H
+                y1 = (
+                    H
+                    - layout.outer_pad
+                    - layout.suptitle_space
+                    - layout.legend_band_top
+                ) / H
                 return Bbox.from_extents(x0, y0, x1, y1)
         # Fallback when no publiplots layout is installed (figure built
         # by raw matplotlib): union the axes rectangles only.

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -43,3 +43,80 @@ def test_suptitle_forwards_kwargs():
     result = pp.suptitle("Title", fontsize=14, fontweight="bold")
     assert result.get_fontsize() == 14
     assert result.get_fontweight() == "bold"
+
+
+def test_suptitle_grows_figure_height():
+    """pp.suptitle reserves vertical space, so the figure grows."""
+    fig, ax = pp.subplots(axes_size=(60, 40))
+    # Settle so the first draw-event has passed.
+    fig.canvas.draw()
+    h_before_in = fig.get_size_inches()[1]
+    pp.suptitle("Figure-level title", fontsize=16)
+    h_after_in = fig.get_size_inches()[1]
+    assert h_after_in > h_before_in + 0.1, (
+        f"Figure height should grow to accommodate suptitle; "
+        f"got before={h_before_in:.3f} in, after={h_after_in:.3f} in"
+    )
+
+
+def test_suptitle_second_call_replaces_first():
+    """Calling pp.suptitle twice should leave exactly one publiplots
+    suptitle attached; the new text is reflected in the stashed
+    artist (matplotlib reuses ``fig._suptitle``) and the figure still
+    has at most one suptitle-style Text attached."""
+    fig, ax = pp.subplots(axes_size=(60, 40))
+    first = pp.suptitle("First title")
+    second = pp.suptitle("Second title")
+    # The latest artist is stashed.
+    assert fig._publiplots_suptitle is second
+    # The title text reflects the latest call — prior "First title" is
+    # gone regardless of whether matplotlib reused the Text instance.
+    assert second.get_text() == "Second title"
+    # Only one publiplots-managed suptitle on the figure: whatever
+    # artist is in fig._publiplots_suptitle must be the one currently
+    # attached. No stale "First title" Text should coexist.
+    suptitle_like = [t for t in fig.texts if t.get_text() == "First title"]
+    assert suptitle_like == [], (
+        f"Stale first-call suptitle should be removed from fig.texts, "
+        f"found: {suptitle_like}"
+    )
+    # The stashed artist is actually on the figure.
+    assert fig._publiplots_suptitle in fig.texts
+
+
+def test_suptitle_does_not_overlap_top_row_axes():
+    """After settle(), the suptitle's y0 (pixel space) sits above the
+    top-row axes' y1 — no overlap."""
+    fig, ax = pp.subplots(axes_size=(60, 40))
+    ax.set_title("axis title")  # a decoration that lives in title_space
+    artist = pp.suptitle("Big figure title", fontsize=18)
+    # settle has already been called inside pp.suptitle; one more draw
+    # to ensure renderer is populated for window extent reads.
+    fig.canvas.draw()
+    ax_ext = ax.get_window_extent()
+    su_ext = artist.get_window_extent()
+    # Top-row axes' top edge (y1) must be strictly below suptitle's bottom (y0).
+    assert ax_ext.y1 < su_ext.y0, (
+        f"Top-row axes should sit entirely below suptitle; "
+        f"got ax.y1={ax_ext.y1:.1f}, suptitle.y0={su_ext.y0:.1f}"
+    )
+
+
+def test_suptitle_lands_inside_reserved_band():
+    """Suptitle y fraction lands inside the reserved band:
+    between 1 - (outer_pad + suptitle_space)/H and 1 - outer_pad/H."""
+    fig, ax = pp.subplots(axes_size=(60, 40))
+    artist = pp.suptitle("Banded title", fontsize=16)
+    layout = fig._publiplots_layout
+    _, H = layout.figure_size()
+    outer_pad = layout.outer_pad
+    suptitle_space = layout.suptitle_space
+    # y is in figure fractions.
+    _, y = artist.get_position()
+    lower = 1.0 - (outer_pad + suptitle_space) / H
+    upper = 1.0 - outer_pad / H
+    assert lower <= y <= upper, (
+        f"suptitle y={y:.4f} should sit in the reserved band "
+        f"[{lower:.4f}, {upper:.4f}]; "
+        f"H={H:.2f}, outer_pad={outer_pad:.2f}, suptitle_space={suptitle_space:.2f}"
+    )

--- a/tests/test_subplots.py
+++ b/tests/test_subplots.py
@@ -703,3 +703,71 @@ def test_legend_column_stays_small_with_empty_group():
     assert layout.legend_column < 2.0, (
         f"legend_column should stay near 0; got {layout.legend_column}"
     )
+
+
+# ---------------------------------------------------------------------------
+# suptitle_space auto-measurement
+# ---------------------------------------------------------------------------
+
+
+def test_auto_layout_suptitle_space_is_zero_without_title():
+    """With no pp.suptitle attached, suptitle_space stays at 0 after draw."""
+    fig, ax = pp.subplots(axes_size=(50, 30))
+    fig.canvas.draw()
+    assert fig._publiplots_layout.suptitle_space == 0.0
+
+
+def test_auto_layout_grows_suptitle_space_for_title():
+    """A tall suptitle grows suptitle_space past a few mm."""
+    fig, ax = pp.subplots(axes_size=(50, 30))
+    pp.suptitle("A bold figure title", fontsize=40)
+    # pp.suptitle calls settle internally; one more draw for good measure.
+    fig.canvas.draw()
+    assert fig._publiplots_layout.suptitle_space > 5.0, (
+        f"suptitle_space should have grown past 5 mm with fontsize=40; "
+        f"got {fig._publiplots_layout.suptitle_space:.2f} mm"
+    )
+
+
+def test_auto_layout_suptitle_coexists_with_top_legend_band():
+    """Figure-anchored top legend group + pp.suptitle: suptitle must sit
+    above the top legend band (higher pixel y)."""
+    from publiplots.utils.legend import create_legend_handles
+    fig, axes = pp.subplots(1, 3, axes_size=(45, 30))
+    for ax in axes:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend(side="top")
+    group.add_legend(
+        handles=create_legend_handles(
+            labels=["A", "B", "C"],
+            colors=list(pp.color_palette("pastel", 3)),
+            alpha=0.2, linewidth=1.0,
+        ),
+        label="group",
+    )
+    artist = pp.suptitle("Figure-wide title", fontsize=16)
+    fig.canvas.draw()
+
+    # Collect every managed legend artist and find its window extent.
+    reactor = getattr(fig, "_publiplots_layout_reactor", None)
+    assert reactor is not None, "layout reactor should be attached"
+    legend_y1 = 0.0
+    saw_legend = False
+    for reg in reactor._registrations:
+        obj = reg.artist
+        extent = None
+        if hasattr(obj, "get_window_extent"):
+            try:
+                extent = obj.get_window_extent()
+            except TypeError:
+                extent = None
+        if extent is None:
+            continue
+        saw_legend = True
+        legend_y1 = max(legend_y1, extent.y1)
+    assert saw_legend, "expected at least one registered legend artist"
+    su_ext = artist.get_window_extent()
+    assert su_ext.y0 > legend_y1, (
+        f"suptitle should sit above top legend band; "
+        f"got suptitle.y0={su_ext.y0:.1f}, legend_top.y1={legend_y1:.1f}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.0"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- `pp.suptitle` now hooks into the `SubplotsAutoLayout` dimension system: the figure grows vertically so the title never overlaps top-row axes, and repeated calls replace the prior title instead of accumulating on the figure.
- New `FigureLayout.suptitle_space` scalar sits between `outer_pad` and `legend_band_top` in the H formula; starts at 0 mm and is auto-measured from the Text's tight bbox (+1 mm safety, same pattern as the legend-band reservations).
- `_GridAnchor.get_position()` subtracts `suptitle_space` so `side="top"` figure-anchored legend bands coexist cleanly below the suptitle band.

## Design notes
- No new rcParam, no user-facing `space=` lock kwarg — matches the `legend_band_*` auto-only pattern. Can be added later if demand appears.
- Default `suptitle_space=0.0` keeps every pre-existing test byte-identical; no recalibration of hard-coded geometry expectations was needed across the 560-test baseline.
- `pp.suptitle` calls `auto_layout.settle()` before returning, so callers that immediately `fig.savefig(...)` pick up the grown canvas without relying on the savefig wrapper.
- Matplotlib caches the suptitle at `fig._suptitle`; we null the cache after `.remove()` on replace so the next `plt.suptitle` creates a fresh, attached artist instead of silently mutating the detached one.

## Test plan
- [x] 7 new tests in `tests/test_display.py` and `tests/test_subplots.py` covering: figure grows for tall title, `_needs_update` threshold respected when no title, replace-on-recall invariant, coexistence with `side="top"` figure legend band, axis top-row non-overlap, suptitle position inside reserved band.
- [x] Full suite: 567 passed, 0 failed (173s).
- [x] Rebased onto `origin/main` (v0.10.3); resolved conflicts in `CHANGELOG.md` (new `## [Unreleased]` section) and `display.py` docstring (merged wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)