### PR TITLE
chore(release): v0.10.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.4] - 2026-05-08
 
 ### Added
 
-- feat(suptitle): `pp.suptitle` now reserves space via the auto-layout engine — no more overlap with top-row axes.
+- `pp.suptitle` now reserves vertical space via the auto-layout engine:
+  the figure grows to fit the title instead of overlapping the top row
+  of axes. New `FigureLayout.suptitle_space` scalar sits between
+  `outer_pad` and `legend_band_top` in the figure H formula; auto-measured
+  from the Text's tight bbox on `draw_event`. Repeated `pp.suptitle`
+  calls replace the prior title rather than stacking. A `side="top"`
+  figure-anchored `pp.legend` band now sits below the reserved suptitle
+  band — both coexist cleanly (PR #128).
 
 ### Changed
 
-- `figure.titlesize` default is now `11` (was matplotlib's `"large"`, which resolves to 9.6pt at publiplots' 8pt base — smaller than the 10pt panel titles, a flipped hierarchy). `figure.titleweight` stays `"normal"`. The figure-level suptitle now reads as the outermost heading.
+- `figure.titlesize` default bumped to `11` (was matplotlib's `"large"`,
+  which resolves to 9.6pt at publiplots' 8pt base — smaller than the
+  10pt panel titles, a flipped hierarchy). `figure.titleweight` stays
+  `"normal"`. The figure-level suptitle now reads as the outermost
+  heading in the type stack (PR #128).
+- Dropped the now-stale `y=1.02` nudge from the three `pp.suptitle`
+  calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
+  the title correctly regardless (PR #128).
+
+[0.10.4]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.4
 
 ## [0.10.3] - 2026-05-08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.3"
+version = "0.10.4"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Release PR for v0.10.4 — ships the auto-sized `pp.suptitle` feature from #128.

Bumps version in the three usual spots:
- `pyproject.toml`: 0.10.3 → 0.10.4
- `src/publiplots/__init__.py`: `__version__` 0.10.3 → 0.10.4
- `.claude-plugin/plugin.json`: 0.10.3 → 0.10.4

Promotes `[Unreleased]` → `[0.10.4] - 2026-05-08` in `CHANGELOG.md` with expanded entries summarizing the suptitle auto-layout + figure.titlesize default bump.

Merge and tag v0.10.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)