### PR TITLE
chore(release): v0.10.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
   the title correctly regardless (PR #128).
 
+[0.10.7]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.7
+[0.10.6]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.6
+[0.10.5]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.5
 [0.10.4]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.4
 
 ## [0.10.3] - 2026-05-08


### PR DESCRIPTION
## Summary

Catches up PyPI (currently at 0.10.4) with the three unreleased versions on main.

- **0.10.5** — `pp.barplot(border_radius=...)` + `bar.border_radius` rcParam + `utils.rounding`
- **0.10.6** — `pp.boxplot(border_radius=...)` + auto-propagation through `pp.raincloudplot`; `apply_border_radius` gained `PathPatch` support for seaborn 0.13 IQR boxes
- **0.10.7** — `pp.histplot` with seaborn-parity API, full legend stash, hatch support, annotate pipeline, and a 9-panel gallery

## Changes in this PR

- `.claude-plugin/plugin.json`: `0.10.6` → `0.10.7`
- `CHANGELOG.md`: adds release-URL footers for `[0.10.5]`, `[0.10.6]`, `[0.10.7]`

`pyproject.toml`, `src/publiplots/__init__.py`, and `uv.lock` are already at 0.10.7 (set in #132). After merge, tag `v0.10.7` on main → triggers `publish.yml` → TestPyPI → PyPI.

## Test plan

- [x] Version consistency across pyproject / `__version__` / plugin.json / uv.lock — all `0.10.7`
- [ ] CI green (docs + gitguardian)
- [ ] Post-merge: tag + release triggers TestPyPI → PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)