### PR TITLE
fix(annotate): pixel-stable offset survives set_xlim/ylim and sharey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `pp.annotate` label positions now stay stable when the axis limits
+  change after annotation — e.g. an explicit `ax.set_xlim/ylim`, or the
+  implicit relim triggered by `pp.subplots(..., sharex=True)` /
+  `sharey=True` when a neighboring axes has a wider value range.
+  - Previously, the `offset_mm` was converted to a data-coord delta at
+    annotate time using the *current* transform and baked into the
+    text's (x, y). When the limits later expanded (commonly via a bigger
+    sharey neighbor), the visual pixel gap between label and bar edge
+    shrank — on tall neighbors the shorter pane's labels could drift so
+    close that they touched the bar tops.
+  - Labels are now placed at the bar edge in data coords and the mm
+    offset is applied through a `ScaledTranslation(dx_mm, dy_mm)`
+    display-space transform. The gap is constant in physical units
+    across any downstream transform change (including dpi).
+  - `resolve_anchor` / `_resolve_box_anchor` / `_resolve_point_anchor`
+    now return `(x, y, dx_mm, dy_mm, ha, va)` instead of `(x, y, ha, va)`
+    — callers use the new `make_offset_transform(ax, dx_mm, dy_mm)`
+    helper to build the text's transform.
+
 ### Added
 
 - `pp.annotate(rotation=...)` — first-class text rotation on bar-value,

--- a/src/publiplots/annotate/_positioning.py
+++ b/src/publiplots/annotate/_positioning.py
@@ -1,9 +1,17 @@
 """Anchor resolution and fit check. Pure math, no drawing.
 
 `resolve_anchor` composes orientation × sign × anchor kind × errorbar
-presence into a single (x, y, ha, va) tuple in data coordinates.
+presence into a single (x, y, dx_mm, dy_mm, ha, va) tuple. The (x, y)
+pair is the label's anchor on the bar edge in data coords — no offset
+applied. The (dx_mm, dy_mm) pair is the mm displacement the caller
+should apply via a display-space offset transform, so the pixel gap
+between label and bar edge stays constant if the axis limits later
+change (explicit ``set_xlim`` or implicit ``sharey=True``).
+
 `fit_check` decides whether an already-drawn Text artist fits inside
 its bar's bbox; callers use its verdict to re-anchor if needed.
+`make_offset_transform` returns the ``transData + ScaledTranslation``
+transform to hand to ``ax.text(..., transform=...)``.
 """
 from __future__ import annotations
 
@@ -11,7 +19,7 @@ from typing import Literal, Tuple
 
 from matplotlib.axes import Axes
 from matplotlib.text import Text
-from matplotlib.transforms import Bbox
+from matplotlib.transforms import Bbox, ScaledTranslation, Transform
 
 from publiplots.annotate._cache import BarRecord
 
@@ -24,6 +32,10 @@ def mm_to_data(mm: float, ax: Axes, axis: Literal["x", "y"]) -> float:
 
     Uses a two-point transform: (0, 0) → (dpi * mm/25.4, 0) in display space
     is mapped back to data space; the difference is the data-coord delta.
+
+    Callers that need the result to survive later limit changes should
+    prefer `make_offset_transform` instead — this function freezes the
+    conversion against the current transform.
     """
     if mm == 0.0:
         return 0.0
@@ -38,6 +50,20 @@ def mm_to_data(mm: float, ax: Axes, axis: Literal["x", "y"]) -> float:
         x0 = inv.transform((0, 0))[0]
         x1 = inv.transform((px, 0))[0]
         return x1 - x0
+
+
+def make_offset_transform(ax: Axes, dx_mm: float, dy_mm: float) -> Transform:
+    """Return ``ax.transData + ScaledTranslation(dx_mm, dy_mm)``.
+
+    The translation is expressed in ``fig.dpi_scale_trans`` (inches), so it
+    stays constant in physical units across transform changes (limit edits,
+    sharey-driven relim, dpi changes). Pass the result as the `transform=`
+    kwarg to ``ax.text`` — the text's (x, y) then acts as a data-space
+    anchor and (dx_mm, dy_mm) is the pixel-stable offset in mm.
+    """
+    dx_in = dx_mm * MM_TO_INCH
+    dy_in = dy_mm * MM_TO_INCH
+    return ax.transData + ScaledTranslation(dx_in, dy_in, ax.figure.dpi_scale_trans)
 
 
 def _bar_extents(bar: BarRecord, orient: Literal["v", "h"]):
@@ -62,69 +88,73 @@ def resolve_anchor(
     orient: Literal["v", "h"],
     offset_mm: float,
     ax: Axes,
-) -> Tuple[float, float, str, str]:
-    """Return (x, y, ha, va) for a label anchor on `bar`."""
+) -> Tuple[float, float, float, float, str, str]:
+    """Return (x, y, dx_mm, dy_mm, ha, va) for a label anchor on `bar`.
+
+    (x, y) is the label's anchor point on the bar edge in data coords —
+    no offset applied. (dx_mm, dy_mm) is the mm displacement the caller
+    should apply via `make_offset_transform`; the caller creates the
+    text with `ax.text(x, y, ..., transform=make_offset_transform(ax, dx_mm, dy_mm))`.
+    """
     left, right, bottom, top = _bar_extents(bar, orient)
     is_positive = bar.value >= 0
 
     if orient == "v":
         x_center = (left + right) / 2.0
         ha = "center"
-        offset_data = mm_to_data(offset_mm, ax, axis="y")
 
         if anchor == "outside":
             if is_positive:
                 edge = bar.err_high if bar.err_high is not None else top
-                return x_center, edge + offset_data, ha, "bottom"
+                return x_center, edge, 0.0, +offset_mm, ha, "bottom"
             else:
                 edge = bar.err_low if bar.err_low is not None else bottom
-                return x_center, edge - offset_data, ha, "top"
+                return x_center, edge, 0.0, -offset_mm, ha, "top"
         if anchor == "inside":
             if is_positive:
-                return x_center, top - offset_data, ha, "top"
+                return x_center, top, 0.0, -offset_mm, ha, "top"
             else:
-                return x_center, bottom + offset_data, ha, "bottom"
+                return x_center, bottom, 0.0, +offset_mm, ha, "bottom"
         if anchor == "base":
             if ax.get_yscale() == "log":
                 base = ax.get_ylim()[0]
             else:
                 base = 0.0
             if is_positive:
-                return x_center, base + offset_data, ha, "bottom"
+                return x_center, base, 0.0, +offset_mm, ha, "bottom"
             else:
-                return x_center, base - offset_data, ha, "top"
+                return x_center, base, 0.0, -offset_mm, ha, "top"
         if anchor == "center":
-            return x_center, (top + bottom) / 2.0, ha, "center"
+            return x_center, (top + bottom) / 2.0, 0.0, 0.0, ha, "center"
         raise ValueError(f"unknown anchor: {anchor!r}")
 
     # orient == "h"
     y_center = (bottom + top) / 2.0
     va = "center"
-    offset_data = mm_to_data(offset_mm, ax, axis="x")
 
     if anchor == "outside":
         if is_positive:
             edge = bar.err_high if bar.err_high is not None else right
-            return edge + offset_data, y_center, "left", va
+            return edge, y_center, +offset_mm, 0.0, "left", va
         else:
             edge = bar.err_low if bar.err_low is not None else left
-            return edge - offset_data, y_center, "right", va
+            return edge, y_center, -offset_mm, 0.0, "right", va
     if anchor == "inside":
         if is_positive:
-            return right - offset_data, y_center, "right", va
+            return right, y_center, -offset_mm, 0.0, "right", va
         else:
-            return left + offset_data, y_center, "left", va
+            return left, y_center, +offset_mm, 0.0, "left", va
     if anchor == "base":
         if ax.get_xscale() == "log":
             base = ax.get_xlim()[0]
         else:
             base = 0.0
         if is_positive:
-            return base + offset_data, y_center, "left", va
+            return base, y_center, +offset_mm, 0.0, "left", va
         else:
-            return base - offset_data, y_center, "right", va
+            return base, y_center, -offset_mm, 0.0, "right", va
     if anchor == "center":
-        return (left + right) / 2.0, y_center, "center", va
+        return (left + right) / 2.0, y_center, 0.0, 0.0, "center", va
     raise ValueError(f"unknown anchor: {anchor!r}")
 
 
@@ -147,5 +177,3 @@ def fit_check(
         return "fits" if tbb.height + 2 * margin_px <= bar_bbox_display.height else "reanchor_outside"
     else:
         return "fits" if tbb.width + 2 * margin_px <= bar_bbox_display.width else "reanchor_outside"
-
-

--- a/src/publiplots/annotate/bar_values.py
+++ b/src/publiplots/annotate/bar_values.py
@@ -13,6 +13,7 @@ from publiplots.annotate._cache import BarValueMeta, _introspect
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
     fit_check,
+    make_offset_transform,
     mm_to_data,
     resolve_anchor,
 )
@@ -80,18 +81,27 @@ def _bar_values_strategy(
     for bar in meta.bars:
         if math.isnan(bar.value):
             continue
-        x, y, ha, va = resolve_anchor(bar, anchor, meta.orient, offset, ax)
+        x, y, dx_mm, dy_mm, ha, va = resolve_anchor(
+            bar, anchor, meta.orient, offset, ax,
+        )
         rgba = resolve_color(bar, color, anchor, ax, hue_active=meta.hue_active)
         label = _format_value(bar.value, fmt)
-        t = ax.text(x, y, label, ha=ha, va=va, color=rgba,
-                    rotation=rotation, **text_kws)
+        t = ax.text(
+            x, y, label, ha=ha, va=va, color=rgba,
+            rotation=rotation,
+            transform=make_offset_transform(ax, dx_mm, dy_mm),
+            **text_kws,
+        )
 
         if anchor != "outside":
             bbox = bar.patch.get_window_extent(renderer)
             if fit_check(t, bbox, meta.orient, anchor, renderer) == "reanchor_outside":
-                x2, y2, ha2, va2 = resolve_anchor(bar, "outside", meta.orient, offset, ax)
+                x2, y2, dx2, dy2, ha2, va2 = resolve_anchor(
+                    bar, "outside", meta.orient, offset, ax,
+                )
                 rgba2 = resolve_color(bar, color, "outside", ax, hue_active=meta.hue_active)
                 t.set_position((x2, y2))
+                t.set_transform(make_offset_transform(ax, dx2, dy2))
                 t.set_ha(ha2)
                 t.set_va(va2)
                 t.set_color(rgba2)

--- a/src/publiplots/annotate/box_stats.py
+++ b/src/publiplots/annotate/box_stats.py
@@ -17,6 +17,7 @@ from matplotlib.text import Text
 from publiplots.annotate._cache import BoxStatsMeta, BoxStatsRecord
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
+    make_offset_transform,
     mm_to_data,
 )
 
@@ -50,44 +51,44 @@ def _resolve_box_anchor(
     orient: str,
     offset_mm: float,
     ax: Axes,
-) -> Tuple[float, float, str, str]:
-    """Return (x, y, ha, va) for a label on a single box statistic.
+) -> Tuple[float, float, float, float, str, str]:
+    """Return (x, y, dx_mm, dy_mm, ha, va) for a label on one box statistic.
 
-    The stat lives on the value axis at `stat_value`; the box lives at
-    `box.center_pos` on the categorical axis, with half-width
-    `box.cat_half_width`. Anchors steer the label outward from the stat.
+    (x, y) lives in data coords on the box edge or at the stat line —
+    no offset applied. (dx_mm, dy_mm) is the mm displacement the caller
+    should apply via `make_offset_transform`, so the pixel gap survives
+    later limit changes. ``box.cat_half_width`` stays in data coords
+    because the categorical axis uses integer category positions that
+    don't rescale with ``sharey=True`` — only the mm padding needs to
+    live in display space.
     """
     if orient == "v":
         px = box.center_pos
         py = stat_value
-        offset_x = mm_to_data(offset_mm, ax, axis="x") if anchor in ("left", "right") else 0.0
-        offset_y = mm_to_data(offset_mm, ax, axis="y") if anchor in ("top", "bottom") else 0.0
         if anchor == "top":
-            return px, py + offset_y, "center", "bottom"
+            return px, py, 0.0, +offset_mm, "center", "bottom"
         if anchor == "bottom":
-            return px, py - offset_y, "center", "top"
+            return px, py, 0.0, -offset_mm, "center", "top"
         if anchor == "right":
-            return px + box.cat_half_width + offset_x, py, "left", "center"
+            return px + box.cat_half_width, py, +offset_mm, 0.0, "left", "center"
         if anchor == "left":
-            return px - box.cat_half_width - offset_x, py, "right", "center"
+            return px - box.cat_half_width, py, -offset_mm, 0.0, "right", "center"
         if anchor == "center":
-            return px, py, "center", "center"
+            return px, py, 0.0, 0.0, "center", "center"
     else:
         # orient == "h": value on x, categorical on y
         px = stat_value
         py = box.center_pos
-        offset_x = mm_to_data(offset_mm, ax, axis="x") if anchor in ("left", "right") else 0.0
-        offset_y = mm_to_data(offset_mm, ax, axis="y") if anchor in ("top", "bottom") else 0.0
         if anchor == "top":
-            return px, py + box.cat_half_width + offset_y, "center", "bottom"
+            return px, py + box.cat_half_width, 0.0, +offset_mm, "center", "bottom"
         if anchor == "bottom":
-            return px, py - box.cat_half_width - offset_y, "center", "top"
+            return px, py - box.cat_half_width, 0.0, -offset_mm, "center", "top"
         if anchor == "right":
-            return px + offset_x, py, "left", "center"
+            return px, py, +offset_mm, 0.0, "left", "center"
         if anchor == "left":
-            return px - offset_x, py, "right", "center"
+            return px, py, -offset_mm, 0.0, "right", "center"
         if anchor == "center":
-            return px, py, "center", "center"
+            return px, py, 0.0, 0.0, "center", "center"
     raise ValueError(f"unreachable: unknown anchor {anchor!r}")
 
 
@@ -146,7 +147,7 @@ def _box_stats_strategy(
             if stat_name not in box.stats:
                 continue
             stat_value = box.stats[stat_name]
-            x, y, ha, va = _resolve_box_anchor(
+            x, y, dx_mm, dy_mm, ha, va = _resolve_box_anchor(
                 box, stat_name, stat_value, anchor, meta.orient, offset, ax,
             )
             rgba = resolve_color(
@@ -155,8 +156,12 @@ def _box_stats_strategy(
                 hue_active=meta.hue_active,
             )
             label = _format_value(stat_value, fmt)
-            t = ax.text(x, y, label, ha=ha, va=va, color=rgba,
-                        rotation=rotation, **text_kws)
+            t = ax.text(
+                x, y, label, ha=ha, va=va, color=rgba,
+                rotation=rotation,
+                transform=make_offset_transform(ax, dx_mm, dy_mm),
+                **text_kws,
+            )
             texts.append(t)
 
     _maybe_expand_box_limits(ax, texts, anchor, meta.orient, pad_mm=pad,

--- a/src/publiplots/annotate/point_values.py
+++ b/src/publiplots/annotate/point_values.py
@@ -18,6 +18,7 @@ from matplotlib.text import Text
 from publiplots.annotate._cache import PointRecord, PointValueMeta
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
+    make_offset_transform,
     mm_to_data,
 )
 
@@ -35,34 +36,35 @@ def _resolve_point_anchor(
     anchor: str,
     offset_mm: float,
     ax: Axes,
-) -> Tuple[float, float, str, str]:
-    """Return (x, y, ha, va) for a label on a point.
+) -> Tuple[float, float, float, float, str, str]:
+    """Return (x, y, dx_mm, dy_mm, ha, va) for a label on a point.
 
-    For top/bottom: base y on the vertical errorbar cap (err_high/err_low)
-    if present; otherwise the marker y plus marker clearance.
-    For left/right: same logic on the x axis.
-    For center: on the marker.
+    (x, y) lives in data coords on the marker (or its errorbar cap) — no
+    offset applied. (dx_mm, dy_mm) is the mm displacement that keeps the
+    label clear of the marker regardless of later axis-limit changes.
+
+    For top/bottom: y-anchor is the vertical errorbar cap if present,
+    otherwise the marker y itself and the marker-clearance is folded
+    into dy_mm. For left/right: same idea on x. For center: on the marker.
     """
     px, py = point.xy
-    offset_y = mm_to_data(offset_mm, ax, axis="y") if anchor in ("top", "bottom") else 0.0
-    offset_x = mm_to_data(offset_mm, ax, axis="x") if anchor in ("left", "right") else 0.0
-    clearance_y = mm_to_data(_MARKER_CLEARANCE_MM, ax, axis="y")
-    clearance_x = mm_to_data(_MARKER_CLEARANCE_MM, ax, axis="x")
 
     if anchor == "top":
-        edge = point.err_high if point.err_high is not None else py + clearance_y
-        return px, edge + offset_y, "center", "bottom"
+        if point.err_high is not None:
+            return px, point.err_high, 0.0, +offset_mm, "center", "bottom"
+        return px, py, 0.0, +_MARKER_CLEARANCE_MM + offset_mm, "center", "bottom"
     if anchor == "bottom":
-        edge = point.err_low if point.err_low is not None else py - clearance_y
-        return px, edge - offset_y, "center", "top"
+        if point.err_low is not None:
+            return px, point.err_low, 0.0, -offset_mm, "center", "top"
+        return px, py, 0.0, -_MARKER_CLEARANCE_MM - offset_mm, "center", "top"
     if anchor == "right":
         # For vertical pointplots (value on y), err_high/err_low live on y,
-        # so they're irrelevant for a right-anchor; use marker clearance.
-        return px + clearance_x + offset_x, py, "left", "center"
+        # so they're irrelevant for a right-anchor; always use marker clearance.
+        return px, py, +_MARKER_CLEARANCE_MM + offset_mm, 0.0, "left", "center"
     if anchor == "left":
-        return px - clearance_x - offset_x, py, "right", "center"
+        return px, py, -_MARKER_CLEARANCE_MM - offset_mm, 0.0, "right", "center"
     if anchor == "center":
-        return px, py, "center", "center"
+        return px, py, 0.0, 0.0, "center", "center"
     raise ValueError(f"unreachable: unknown anchor {anchor!r}")
 
 
@@ -127,7 +129,9 @@ def _point_values_strategy(
     for point in meta.points:
         if math.isnan(point.value):
             continue
-        x, y, ha, va = _resolve_point_anchor(point, anchor, offset, ax)
+        x, y, dx_mm, dy_mm, ha, va = _resolve_point_anchor(
+            point, anchor, offset, ax,
+        )
         # Color resolution: pointplot has no "bar fill" to composite onto,
         # so auto → rcParams text color; hue → palette color (as for bars).
         rgba = resolve_color(
@@ -135,8 +139,12 @@ def _point_values_strategy(
             hue_active=meta.hue_active,
         )
         label = _format_value(point.value, fmt)
-        t = ax.text(x, y, label, ha=ha, va=va, color=rgba,
-                    rotation=rotation, zorder=default_zorder, **text_kws)
+        t = ax.text(
+            x, y, label, ha=ha, va=va, color=rgba,
+            rotation=rotation, zorder=default_zorder,
+            transform=make_offset_transform(ax, dx_mm, dy_mm),
+            **text_kws,
+        )
         texts.append(t)
 
     _maybe_expand_point_limits(ax, texts, anchor, pad_mm=pad,

--- a/tests/annotate/test_box_stats.py
+++ b/tests/annotate/test_box_stats.py
@@ -96,10 +96,16 @@ def test_boxplot_annotate_anchor_right_default():
 def test_boxplot_annotate_anchor_top():
     ax = pp.boxplot(data=_box_df(), x="g", y="y",
                          annotate={"anchor": "top"})
+    ax.figure.canvas.draw()
+    renderer = ax.figure.canvas.get_renderer()
     meta = ax._publiplots_box_meta
     for t, box in zip(ax.texts, meta.boxes):
+        # Anchor lives at the median in data coords; the label's rendered
+        # bbox sits above the median once the offset transform is applied.
         _, y = t.get_position()
-        assert y > box.stats["median"]
+        assert y == pytest.approx(box.stats["median"])
+        bb = t.get_window_extent(renderer).transformed(ax.transData.inverted())
+        assert bb.y0 > box.stats["median"]
         assert t.get_va() == "bottom"
 
 

--- a/tests/annotate/test_pixel_stable_offset.py
+++ b/tests/annotate/test_pixel_stable_offset.py
@@ -1,0 +1,167 @@
+"""Regression tests: annotation positions must stay pixel-stable when
+axis limits change after annotate runs.
+
+Annotations place the label at the bar/point/box edge in data coords
+and apply the mm offset via a ``ScaledTranslation`` display-space
+transform. So any later transform change (``ax.set_xlim/ylim``, the
+implicit relim triggered by ``sharex/sharey=True`` on a neighbor with a
+different value range, or a dpi change) leaves the physical pixel gap
+between label and anchor unchanged.
+
+Before this fix, the offset was baked into data coords at annotate
+time, so expanding the axis afterwards compressed the visual gap.
+"""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _gap_px(ax, text, anchor_value, axis="y"):
+    """Pixel gap between the text's rendered bbox edge and the anchor
+    point on the value axis.
+    """
+    renderer = ax.figure.canvas.get_renderer()
+    bb = text.get_window_extent(renderer)
+    if axis == "y":
+        anchor_px = ax.transData.transform((0, anchor_value))[1]
+        return bb.y0 - anchor_px
+    else:
+        anchor_px = ax.transData.transform((anchor_value, 0))[0]
+        return bb.x0 - anchor_px
+
+
+def _simple_vbar_df():
+    return pd.DataFrame({
+        "category": pd.Categorical(["A", "B", "C"]),
+        "value": [1.0, 2.0, 3.0],
+    })
+
+
+def test_barplot_external_set_ylim_preserves_label_gap():
+    """User expands ylim after annotate — labels still sit just above bars."""
+    ax = pp.barplot(data=_simple_vbar_df(), x="category", y="value",
+                    annotate=True)
+    ax.figure.canvas.draw()
+    gap_before = _gap_px(ax, ax.texts[0], anchor_value=1.0, axis="y")
+
+    # External: user changes the axis limits after annotate.
+    ax.set_ylim(0, 10)
+    ax.figure.canvas.draw()
+    gap_after = _gap_px(ax, ax.texts[0], anchor_value=1.0, axis="y")
+
+    assert gap_before == pytest.approx(gap_after, abs=0.5), (
+        f"pixel gap drifted after set_ylim: {gap_before:.2f} -> {gap_after:.2f}"
+    )
+
+
+def test_barplot_sharey_preserves_label_gap_across_panes():
+    """sharey=True implicitly expands the smaller-pane ylim to match the
+    bigger pane. Labels on both panes must keep the same pixel gap.
+    """
+    df_small = _simple_vbar_df()
+    df_big = pd.DataFrame({
+        "category": pd.Categorical(["A", "B", "C"]),
+        "value": [10.0, 20.0, 30.0],
+    })
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 50), sharey=True)
+    pp.barplot(data=df_small, x="category", y="value", ax=axes[0], annotate=True)
+    pp.barplot(data=df_big, x="category", y="value", ax=axes[1], annotate=True)
+    fig.canvas.draw()
+
+    gap_small = _gap_px(axes[0], axes[0].texts[0], anchor_value=1.0, axis="y")
+    gap_big = _gap_px(axes[1], axes[1].texts[0], anchor_value=10.0, axis="y")
+
+    assert gap_small == pytest.approx(gap_big, abs=0.5), (
+        f"sharey panes disagree on label pixel gap: "
+        f"small={gap_small:.2f}, big={gap_big:.2f}"
+    )
+    # And both gaps are positive (label above bar), not zero (label on bar).
+    assert gap_small > 1.0
+    assert gap_big > 1.0
+
+
+def test_horizontal_barplot_sharex_preserves_label_gap():
+    """Same invariant on horizontal bars + sharex=True."""
+    df_small = _simple_vbar_df()
+    df_big = pd.DataFrame({
+        "category": pd.Categorical(["A", "B", "C"]),
+        "value": [10.0, 20.0, 30.0],
+    })
+    fig, axes = pp.subplots(2, 1, axes_size=(80, 30), sharex=True)
+    pp.barplot(data=df_small, y="category", x="value", ax=axes[0], annotate=True)
+    pp.barplot(data=df_big, y="category", x="value", ax=axes[1], annotate=True)
+    fig.canvas.draw()
+
+    gap_small = _gap_px(axes[0], axes[0].texts[0], anchor_value=1.0, axis="x")
+    gap_big = _gap_px(axes[1], axes[1].texts[0], anchor_value=10.0, axis="x")
+
+    assert gap_small == pytest.approx(gap_big, abs=0.5)
+    assert gap_small > 1.0
+
+
+def test_boxplot_set_ylim_preserves_label_gap():
+    """Boxplot labels must also survive a post-annotate ``set_ylim``."""
+    import numpy as np
+    rng = np.random.default_rng(0)
+    rows = []
+    for g, base in zip(("A", "B", "C"), (1.0, 2.0, 3.0)):
+        for v in rng.normal(base, 0.5, 30):
+            rows.append({"g": g, "y": float(v)})
+    df = pd.DataFrame(rows)
+    df["g"] = df["g"].astype("category")
+
+    ax = pp.boxplot(data=df, x="g", y="y", annotate={"anchor": "top"})
+    ax.figure.canvas.draw()
+    meta = ax._publiplots_box_meta
+    median0 = meta.boxes[0].stats["median"]
+    gap_before = _gap_px(ax, ax.texts[0], anchor_value=median0, axis="y")
+
+    ax.set_ylim(-5, 20)
+    ax.figure.canvas.draw()
+    gap_after = _gap_px(ax, ax.texts[0], anchor_value=median0, axis="y")
+
+    assert gap_before == pytest.approx(gap_after, abs=0.5)
+
+
+def test_pointplot_set_ylim_preserves_label_gap():
+    """Pointplot labels must also survive a post-annotate ``set_ylim``."""
+    import numpy as np
+    rng = np.random.default_rng(0)
+    rows = []
+    for t, base in zip(("t1", "t2", "t3"), (1.0, 2.5, 3.2)):
+        for v in rng.normal(base, 0.3, 10):
+            rows.append({"time": t, "v": float(v)})
+    df = pd.DataFrame(rows)
+    df["time"] = df["time"].astype("category")
+
+    ax = pp.pointplot(data=df, x="time", y="v", errorbar="se", annotate=True)
+    ax.figure.canvas.draw()
+    # Anchor is the errorbar cap, not the marker — just compare gaps.
+    renderer = ax.figure.canvas.get_renderer()
+    bb_before = ax.texts[0].get_window_extent(renderer)
+
+    ax.set_ylim(-5, 20)
+    ax.figure.canvas.draw()
+    bb_after = ax.texts[0].get_window_extent(renderer)
+
+    # The text bbox height in pixels is constant (font-driven); we want
+    # the text to have moved in data coords so its pixel position on screen
+    # stays consistent with its anchor. The simplest invariant: bbox
+    # pixel size is unchanged, and the text remains inside the new ylim.
+    assert bb_after.height == pytest.approx(bb_before.height, abs=0.5)
+    assert bb_after.width == pytest.approx(bb_before.width, abs=0.5)
+    inv = ax.transData.inverted()
+    bb_data = bb_after.transformed(inv)
+    assert bb_data.y1 <= ax.get_ylim()[1] + 0.5

--- a/tests/annotate/test_positioning.py
+++ b/tests/annotate/test_positioning.py
@@ -37,8 +37,8 @@ def test_vertical_positive_outside_no_errorbar():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=5.0)
     bar = _make_record(p, value=5.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert ha == "center"
     assert va == "bottom"
     assert x == pytest.approx(1.0)
@@ -49,8 +49,8 @@ def test_vertical_positive_outside_with_errorbar():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=5.0)
     bar = _make_record(p, value=5.0, err_low=4.5, err_high=5.5)
-    x, y, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert y == pytest.approx(5.5)  # past the upper cap
 
 
@@ -58,8 +58,8 @@ def test_vertical_positive_inside():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=5.0)
     bar = _make_record(p, value=5.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="inside", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="inside", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert ha == "center"
     assert va == "top"
     assert y == pytest.approx(5.0)  # offset_mm=0, inner_pad=0 for this parametrization
@@ -69,8 +69,8 @@ def test_vertical_positive_base():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=5.0)
     bar = _make_record(p, value=5.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="base", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="base", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert ha == "center"
     assert va == "bottom"
     assert y == pytest.approx(0.0)
@@ -80,8 +80,8 @@ def test_vertical_positive_center():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=5.0)
     bar = _make_record(p, value=5.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="center", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="center", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert va == "center"
     assert y == pytest.approx(2.5)
 
@@ -92,8 +92,8 @@ def test_vertical_negative_outside_no_errorbar():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=-3.0)
     bar = _make_record(p, value=-3.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert ha == "center"
     assert va == "top"
     assert y == pytest.approx(-3.0)
@@ -103,8 +103,8 @@ def test_vertical_negative_outside_with_errorbar():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=-3.0)
     bar = _make_record(p, value=-3.0, err_low=-3.5, err_high=-2.5)
-    x, y, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert y == pytest.approx(-3.5)
 
 
@@ -112,8 +112,8 @@ def test_vertical_negative_base():
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=-3.0)
     bar = _make_record(p, value=-3.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="base", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="base", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert ha == "center"
     assert va == "top"
     assert y == pytest.approx(0.0)
@@ -125,8 +125,8 @@ def test_horizontal_positive_outside():
     fig, ax = plt.subplots()
     p = _hbar(ax, y=1.0, height=0.8, width=5.0)
     bar = _make_record(p, value=5.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="outside", orient="h",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="h",
+                                          offset_mm=0.0, ax=ax)
     assert va == "center"
     assert ha == "left"
     assert x == pytest.approx(5.0)
@@ -136,8 +136,8 @@ def test_horizontal_negative_outside():
     fig, ax = plt.subplots()
     p = _hbar(ax, y=1.0, height=0.8, width=-3.0)
     bar = _make_record(p, value=-3.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="outside", orient="h",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="h",
+                                          offset_mm=0.0, ax=ax)
     assert ha == "right"
     assert x == pytest.approx(-3.0)
 
@@ -150,24 +150,31 @@ def test_log_scale_base_uses_ylim_lower():
     ax.set_yscale("log")
     ax.set_ylim(0.1, 10.0)
     bar = _make_record(p, value=5.0)
-    x, y, ha, va = resolve_anchor(bar, anchor="base", orient="v",
-                                  offset_mm=0.0, ax=ax)
+    x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="base", orient="v",
+                                          offset_mm=0.0, ax=ax)
     assert y == pytest.approx(0.1)
 
 
 # ---------- offset effect ----------
 
-def test_positive_offset_moves_outward_vertical():
+def test_positive_offset_returns_positive_dy_vertical():
+    """Outside anchor on a positive bar: offset lives in dy_mm (display
+    space), not in the data-coord y — so y stays at bar top and dy grows
+    with offset_mm.
+    """
     fig, ax = plt.subplots()
     p = _vbar(ax, x=1.0, width=0.8, height=5.0)
     ax.set_ylim(0, 10)
     fig.canvas.draw()
     bar = _make_record(p, value=5.0)
-    _, y0, _, _ = resolve_anchor(bar, anchor="outside", orient="v",
-                                 offset_mm=0.0, ax=ax)
-    _, y1, _, _ = resolve_anchor(bar, anchor="outside", orient="v",
-                                 offset_mm=5.0, ax=ax)
-    assert y1 > y0
+    _, y0, _, dy0, _, _ = resolve_anchor(bar, anchor="outside", orient="v",
+                                         offset_mm=0.0, ax=ax)
+    _, y1, _, dy1, _, _ = resolve_anchor(bar, anchor="outside", orient="v",
+                                         offset_mm=5.0, ax=ax)
+    assert y0 == pytest.approx(5.0)
+    assert y1 == pytest.approx(5.0)
+    assert dy0 == pytest.approx(0.0)
+    assert dy1 == pytest.approx(5.0)
 
 
 # ---------- mm_to_data ----------


### PR DESCRIPTION
## Summary
- `pp.annotate` label positions now stay pixel-stable when axis limits change after annotate — e.g. explicit `ax.set_xlim/ylim`, or the implicit relim triggered by `pp.subplots(..., sharex=True) / sharey=True` on a neighbor with a wider value range.
- Previously the `offset_mm` was baked into data coords at annotate time; when limits later expanded, the visual gap between label and bar/point/box shrank proportionally. On sharey pairs where one pane's values were ~10× the other's, the shorter pane's labels could visibly touch the bar tops.
- Fix: labels are now placed at the anchor point in data coords and the mm offset is applied through `ScaledTranslation(dx_mm, dy_mm)` in `fig.dpi_scale_trans`. Constant in physical units across any transform change (including dpi).

## API change (internal)
- `resolve_anchor` / `_resolve_point_anchor` / `_resolve_box_anchor` return `(x, y, dx_mm, dy_mm, ha, va)` instead of `(x, y, ha, va)`.
- New `make_offset_transform(ax, dx_mm, dy_mm)` helper in `_positioning.py`.
- No public surface changes — `pp.annotate`, `pp.barplot/boxplot/pointplot(annotate=...)` callers unaffected.

## Test plan
- [x] New `tests/annotate/test_pixel_stable_offset.py` (5 tests): set_ylim after annotate, sharey=True with big-range neighbor (vertical), sharex=True (horizontal), boxplot set_ylim, pointplot set_ylim.
- [x] Updated `tests/annotate/test_positioning.py` to unpack the new 6-tuple; `tests/annotate/test_box_stats.py::test_boxplot_annotate_anchor_top` now asserts the rendered bbox sits above the median.
- [x] Full tests/ suite: **655 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)