### PR TITLE
chore(release): v0.10.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.8] - 2026-05-10
+
 ### Fixed
 
 - `pp.annotate` label positions now stay stable when the axis limits
@@ -168,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
   the title correctly regardless (PR #128).
 
+[0.10.8]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.8
 [0.10.7]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.7
 [0.10.6]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.6
 [0.10.5]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.7"
+version = "0.10.8"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.7"
+__version__ = "0.10.8"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.7"
+version = "0.10.8"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

Cuts **v0.10.8**, bundling the two post-0.10.7 annotate PRs:

- **#134** — `pp.annotate(rotation=...)`: first-class text rotation on bar-value, box-stat, and point-value annotations. Primary use case: vertical labels on narrow bars (`annotate={"rotation": 90}`). Categorical axis auto-expands; inverted-axis convention preserved on horizontal bars.
- **#135** — pixel-stable annotation offset: labels now stay at a constant pixel gap from the bar/point/box edge when axis limits change after annotate (explicit `set_xlim`/`set_ylim`, or implicit relim from `sharex=True`/`sharey=True` with a wider-range neighbor). Fixes the regression where the shorter pane's labels could drift so close that they touched the bar tops.

## Changes

- `pyproject.toml`: `0.10.7` → `0.10.8`
- `src/publiplots/__init__.py` (`__version__`): `0.10.7` → `0.10.8`
- `.claude-plugin/plugin.json`: `0.10.7` → `0.10.8`
- `uv.lock`: regenerated
- `CHANGELOG.md`: `[Unreleased]` block promoted to `[0.10.8] - 2026-05-10` with the release-tag footer link.

## Test plan

- [x] `pytest tests/` → **655 passed**.
- [ ] After merge, tag `v0.10.8` on main to trigger the PyPI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)