### PR TITLE
feat(barplot): multiple="gain" — pairwise comparison bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     dodge and stacked paths — previously the legend ignored the
     ordering kwargs in favor of palette-resolution order.
 
+- `pp.barplot(multiple="gain")` — pairwise comparison bars for exactly
+  two levels. Per category: bottom segment = `min` of the two values
+  (loser color), top segment = `max - min` (winner color). Bar top
+  = `max`. Annotate shows absolute values; ties render as a single
+  bar; missing-level-at-a-category raises `ValueError`. Works
+  side-by-side with a second non-cat column via `stack_by=`. Useful
+  for summary metrics (AUC, accuracy, F1) where additive stacking is
+  semantically wrong.
+
 ## [0.10.8] - 2026-05-10
 
 ### Fixed

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -703,3 +703,39 @@ ax = pp.barplot(
     ylabel="Count (summed)",
 )
 pp.show()
+
+# %%
+# Gain / Improvement Bars — ``multiple="gain"``
+# ---------------------------------------------
+# For comparing exactly two conditions whose values don't compose by
+# sum (AUC, accuracy, F1, expression ceiling). Per category: bottom
+# segment = ``min`` of the two values (loser color), top segment =
+# ``max - min`` (winner color). Bar top = ``max``. Who wins can flip
+# across categories — the base color flips accordingly.
+#
+# In the figure below, Proposed wins on AUC and F1 (teal top); Baseline
+# wins on Recall (purple top). Annotate shows **absolute values**
+# (loser total on the base, winner total on the top) — not the delta.
+
+metric_df = pd.DataFrame({
+    "metric": pd.Categorical(
+        ["AUC", "F1", "Recall"] * 2,
+        categories=["AUC", "F1", "Recall"],
+    ),
+    "model": pd.Categorical(
+        ["Baseline"] * 3 + ["Proposed"] * 3,
+        categories=["Baseline", "Proposed"],
+    ),
+    "score": [0.80, 0.75, 0.88, 0.90, 0.82, 0.85],
+})
+
+ax = pp.barplot(
+    data=metric_df,
+    x="metric", y="score", hue="model",
+    multiple="gain", errorbar=None,
+    palette={"Baseline": "#8E8EC1", "Proposed": "#60a8a8"},
+    annotate={"fmt": ".2f"},
+    title='multiple="gain" — pairwise metric comparison',
+    ylabel="Score",
+)
+pp.show()

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -274,6 +274,7 @@ def build_from_stacked_barplot_call(
 
     bars: List[BarRecord] = []
     for rect, row in zip(rects, agg):
+        anchor_override: Optional[str] = None
         if multiple == "gain":
             # Absolute values: base segment's height is the loser's total;
             # top segment's cumulative (y + height) is the winner's total.
@@ -282,13 +283,17 @@ def build_from_stacked_barplot_call(
             if orient == "v":
                 if rect.get_y() > 0:
                     value = rect.get_y() + rect.get_height()  # top: winner abs
+                    anchor_override = "outside"                # winner label floats above
                 else:
                     value = rect.get_height()                  # base or tie
+                    anchor_override = "inside"                 # loser label inside base
             else:
                 if rect.get_x() > 0:
                     value = rect.get_x() + rect.get_width()
+                    anchor_override = "outside"
                 else:
                     value = rect.get_width()
+                    anchor_override = "inside"
         else:
             value = rect.get_height() if orient == "v" else rect.get_width()
 
@@ -305,6 +310,7 @@ def build_from_stacked_barplot_call(
             err_low=None,
             err_high=None,
             hue_color=hue_color,
+            anchor_override=anchor_override,
         ))
     return BarValueMeta(
         orient=orient,

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -241,7 +241,7 @@ def build_from_stacked_barplot_call(
     categorical_axis: str,
     palette: Optional[Dict],
     hatch: Optional[str] = None,
-    multiple: str = "stack",
+    multiple: Literal["stack", "fill", "gain"] = "stack",
 ) -> BarValueMeta:
     """Build a ``BarValueMeta`` paired with a stacked bar plot's Rectangles.
 
@@ -251,6 +251,14 @@ def build_from_stacked_barplot_call(
     aggregate row yielded by ``BarSplitSpec.iter_draw_order`` in the same order
     the plotter painted them, so hue color resolution is deterministic and
     does not rely on color-matching heuristics.
+
+    For ``multiple="gain"``, the drawing path at `_draw_stacked` in
+    `plot/bar.py` emits the base segment with ``bottom=0`` and the top
+    segment with ``bottom=lo``. This function inverts that geometry:
+    when ``rect.get_y() > 0`` the rect is a top segment and the value
+    labeled is ``y + height`` (the winner's absolute total); otherwise
+    (base segment or tie) the label value is ``rect.get_height()``
+    itself. Horizontal orient mirrors with ``x`` / ``width``.
     """
     orient: Literal["v", "h"] = "v" if categorical_axis == x else "h"
 

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -241,6 +241,7 @@ def build_from_stacked_barplot_call(
     categorical_axis: str,
     palette: Optional[Dict],
     hatch: Optional[str] = None,
+    multiple: str = "stack",
 ) -> BarValueMeta:
     """Build a ``BarValueMeta`` paired with a stacked bar plot's Rectangles.
 
@@ -265,7 +266,24 @@ def build_from_stacked_barplot_call(
 
     bars: List[BarRecord] = []
     for rect, row in zip(rects, agg):
-        value = rect.get_height() if orient == "v" else rect.get_width()
+        if multiple == "gain":
+            # Absolute values: base segment's height is the loser's total;
+            # top segment's cumulative (y + height) is the winner's total.
+            # For ties we get a single rect whose height is already the
+            # absolute value.
+            if orient == "v":
+                if rect.get_y() > 0:
+                    value = rect.get_y() + rect.get_height()  # top: winner abs
+                else:
+                    value = rect.get_height()                  # base or tie
+            else:
+                if rect.get_x() > 0:
+                    value = rect.get_x() + rect.get_width()
+                else:
+                    value = rect.get_width()
+        else:
+            value = rect.get_height() if orient == "v" else rect.get_width()
+
         hue_color: Optional[Tuple[float, float, float, float]] = None
         if palette is not None:
             key = row.get("hue_value")

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -25,6 +25,7 @@ class BarRecord:
     err_low: Optional[float]
     err_high: Optional[float]
     hue_color: Optional[RGBA]
+    anchor_override: Optional[str] = None
 
 
 @dataclass

--- a/src/publiplots/annotate/bar_values.py
+++ b/src/publiplots/annotate/bar_values.py
@@ -81,10 +81,11 @@ def _bar_values_strategy(
     for bar in meta.bars:
         if math.isnan(bar.value):
             continue
+        bar_anchor = bar.anchor_override if bar.anchor_override is not None else anchor
         x, y, dx_mm, dy_mm, ha, va = resolve_anchor(
-            bar, anchor, meta.orient, offset, ax,
+            bar, bar_anchor, meta.orient, offset, ax,
         )
-        rgba = resolve_color(bar, color, anchor, ax, hue_active=meta.hue_active)
+        rgba = resolve_color(bar, color, bar_anchor, ax, hue_active=meta.hue_active)
         label = _format_value(bar.value, fmt)
         t = ax.text(
             x, y, label, ha=ha, va=va, color=rgba,
@@ -93,9 +94,9 @@ def _bar_values_strategy(
             **text_kws,
         )
 
-        if anchor != "outside":
+        if bar_anchor != "outside":
             bbox = bar.patch.get_window_extent(renderer)
-            if fit_check(t, bbox, meta.orient, anchor, renderer) == "reanchor_outside":
+            if fit_check(t, bbox, meta.orient, bar_anchor, renderer) == "reanchor_outside":
                 x2, y2, dx2, dy2, ha2, va2 = resolve_anchor(
                     bar, "outside", meta.orient, offset, ax,
                 )

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -911,10 +911,10 @@ def _validate_gain_levels(
     stack_col: str,
     categorical_axis: str,
     dodge_col: Optional[str],
-) -> List[object]:
+) -> None:
     """Validate that ``stack_col`` has exactly 2 unique levels and that
     both levels have at least one observation at every (cat, dodge)
-    combination. Returns the 2 levels in their category order.
+    combination.
 
     Raises ``ValueError`` on level-count mismatch or on a missing
     (cat, dodge, level) combination — gain semantics are ill-defined
@@ -952,7 +952,6 @@ def _validate_gain_levels(
                         f"at every category; missing level {lv!r} at "
                         f"{categorical_axis}={cat!r}"
                     )
-    return list(levels)
 
 
 def _draw_stacked(

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -487,6 +487,7 @@ def barplot(
             ax._publiplots_bar_meta = build_from_stacked_barplot_call(
                 ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
                 categorical_axis=categorical_axis, palette=palette,
+                multiple=multiple,
             )
             from publiplots.annotate import annotate as _annotate_fn
             opts = dict(annotate) if isinstance(annotate, dict) else {}

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -1106,8 +1106,7 @@ def _draw_stacked(
     cum: Dict[Tuple[object, Optional[object]], float] = {}
 
     if multiple == "gain":
-        levels = _categories_in_draw_order(data[stack_col])
-        l0, l1 = levels[0], levels[1]
+        l0, l1 = stack_levels[0], stack_levels[1]
 
         # means dict was already populated above; keys are (cat, dodge_level,
         # stack_level). _validate_gain_levels guarantees every (cat, d_lv, l0)

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -219,7 +219,7 @@ def barplot(
         Order of hatch levels. Under ``"stack"`` / ``"fill"`` with
         ``hatch`` driving the stack, determines stack order
         bottom-to-top.
-    multiple : {"dodge", "stack", "fill"}, default="dodge"
+    multiple : {"dodge", "stack", "fill", "gain"}, default="dodge"
         How to arrange bars across the secondary (hue / hatch)
         categorical dimension within each category of the primary axis.
 
@@ -235,6 +235,16 @@ def barplot(
         - ``"fill"``: stack and then normalize so every stack sums to
           1.0 (100%-stacked bars — good for showing proportions whose
           totals differ across categories).
+        - ``"gain"``: pairwise comparison for exactly 2 levels. Per
+          category: the bottom segment shows ``min`` of the two values
+          (colored by the losing level); the top segment shows
+          ``max - min`` (colored by the winning level). Bar top = max.
+          Who wins can flip across categories — the base color flips
+          accordingly. Use for summary metrics that don't compose by
+          sum (AUC, accuracy, F1); for additive quantities use
+          ``"stack"``. Ties render as a single bar in the first
+          level's color. Missing one of the two levels at some
+          category raises ``ValueError``.
 
         Stacking requires at least one of ``hue`` / ``hatch`` to be set
         and distinct from the categorical axis. If *neither* is set,
@@ -268,11 +278,14 @@ def barplot(
     ------
     ValueError
         If neither ``x`` nor ``y`` is categorical; if ``multiple`` is
-        not one of ``"dodge"``, ``"stack"``, ``"fill"``; if
-        ``multiple="stack"|"fill"`` is requested without a stack column
-        (``hue`` / ``hatch``); if ``multiple="stack"|"fill"`` is
-        requested with both ``hue`` and ``hatch`` set as distinct
-        non-categorical columns but no ``stack_by=`` was provided.
+        not one of ``"dodge"``, ``"stack"``, ``"fill"``, ``"gain"``;
+        if ``multiple="stack"|"fill"|"gain"`` is requested without a
+        stack column (``hue`` / ``hatch``); if
+        ``multiple="stack"|"fill"|"gain"`` is requested with both
+        ``hue`` and ``hatch`` set as distinct non-categorical columns
+        but no ``stack_by=`` was provided; if ``multiple="gain"`` is
+        requested with a stack column that has ≠ 2 levels or a level
+        missing at some category.
     TypeError
         If ``figsize`` is passed (publiplots owns figure geometry via
         :func:`publiplots.subplots`).
@@ -350,6 +363,15 @@ def barplot(
     >>> ax = pp.barplot(
     ...     data=df, x="count", y="cohort", hue="stage",
     ...     multiple="stack", errorbar=None,
+    ... )
+
+    Gain / improvement bars (pairwise comparison of 2 levels):
+
+    >>> ax = pp.barplot(
+    ...     data=df, x="metric", y="score", hue="model",
+    ...     multiple="gain", errorbar=None,
+    ...     palette={"Baseline": "#8E8EC1", "Proposed": "#60a8a8"},
+    ...     annotate={"fmt": ".2f"},
     ... )
 
     Two categoricals: stack one, dodge the other (``stack_by``):

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -1085,23 +1085,14 @@ def _draw_stacked(
     if multiple == "gain":
         levels = _categories_in_draw_order(data[stack_col])
         l0, l1 = levels[0], levels[1]
-        k = len(dodge_levels)
-        slot = max(1.0 - gap, 0.0)
-        sub_width = slot / k
 
+        # means dict was already populated above; keys are (cat, dodge_level,
+        # stack_level). _validate_gain_levels guarantees every (cat, d_lv, l0)
+        # and (cat, d_lv, l1) combination has data, so lookups won't return None.
         for cat in cats:
             for d_idx, d_lv in enumerate(dodge_levels):
-                # compute v0, v1 for the 2 stack levels at this (cat, d_lv)
-                m0 = data[categorical_axis] == cat
-                m0 = m0 & (data[stack_col] == l0)
-                if dodge_col is not None:
-                    m0 = m0 & (data[dodge_col] == d_lv)
-                m1 = data[categorical_axis] == cat
-                m1 = m1 & (data[stack_col] == l1)
-                if dodge_col is not None:
-                    m1 = m1 & (data[dodge_col] == d_lv)
-                v0 = float(data.loc[m0, value_col].mean())
-                v1 = float(data.loc[m1, value_col].mean())
+                v0 = means[(cat, d_lv, l0)]
+                v1 = means[(cat, d_lv, l1)]
 
                 pos_cat = cat_to_pos[cat]
                 if dodge_col is not None:

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -513,7 +513,8 @@ def barplot(
             )
             from publiplots.annotate import annotate as _annotate_fn
             opts = dict(annotate) if isinstance(annotate, dict) else {}
-            opts.setdefault("anchor", "inside")
+            if multiple != "gain":
+                opts.setdefault("anchor", "inside")
             _annotate_fn(ax, kind="bar_values", **opts)
         return ax
 

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -59,7 +59,7 @@ def barplot(
     order: Optional[List[str]] = None,
     hue_order: Optional[List[str]] = None,
     hatch_order: Optional[List[str]] = None,
-    multiple: Literal["dodge", "stack", "fill"] = "dodge",
+    multiple: Literal["dodge", "stack", "fill", "gain"] = "dodge",
     stack_by: Optional[Literal["hue", "hatch"]] = None,
     **kwargs
 ) -> Axes:
@@ -449,13 +449,13 @@ def barplot(
     split_by_hatch = _split.split_hatch is not None
     double_split = _split.split_hue is not None and _split.split_hatch is not None
 
-    if multiple not in ("dodge", "stack", "fill"):
+    if multiple not in ("dodge", "stack", "fill", "gain"):
         raise ValueError(
-            "barplot: multiple must be one of 'dodge', 'stack', 'fill'; "
-            f"got {multiple!r}"
+            "barplot: multiple must be one of 'dodge', 'stack', 'fill', "
+            f"'gain'; got {multiple!r}"
         )
 
-    if multiple in ("stack", "fill"):
+    if multiple in ("stack", "fill", "gain"):
         tracker = ArtistTracker(ax)
         _draw_stacked(
             ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
@@ -906,6 +906,55 @@ def _legend(
 # =============================================================================
 
 
+def _validate_gain_levels(
+    data: pd.DataFrame,
+    stack_col: str,
+    categorical_axis: str,
+    dodge_col: Optional[str],
+) -> List[object]:
+    """Validate that ``stack_col`` has exactly 2 unique levels and that
+    both levels have at least one observation at every (cat, dodge)
+    combination. Returns the 2 levels in their category order.
+
+    Raises ``ValueError`` on level-count mismatch or on a missing
+    (cat, dodge, level) combination — gain semantics are ill-defined
+    when a level is absent at some cat, and the caller cannot compute
+    a meaningful ``min`` / ``max`` pair.
+    """
+    levels = _categories_in_draw_order(data[stack_col])
+    if len(levels) != 2:
+        raise ValueError(
+            f"barplot: multiple='gain' requires exactly 2 levels on "
+            f"{stack_col!r}; got {len(levels)} ({list(levels)!r})"
+        )
+    cats = _categories_in_draw_order(data[categorical_axis])
+    dodge_levels = (
+        _categories_in_draw_order(data[dodge_col])
+        if dodge_col is not None else [None]
+    )
+    for cat in cats:
+        for d_lv in dodge_levels:
+            for lv in levels:
+                mask = data[categorical_axis] == cat
+                mask = mask & (data[stack_col] == lv)
+                if dodge_col is not None:
+                    mask = mask & (data[dodge_col] == d_lv)
+                if not mask.any():
+                    if dodge_col is not None:
+                        raise ValueError(
+                            f"barplot: multiple='gain' requires both "
+                            f"levels at every (category, dodge) combination; "
+                            f"missing level {lv!r} at ({categorical_axis}="
+                            f"{cat!r}, {dodge_col}={d_lv!r})"
+                        )
+                    raise ValueError(
+                        f"barplot: multiple='gain' requires both levels "
+                        f"at every category; missing level {lv!r} at "
+                        f"{categorical_axis}={cat!r}"
+                    )
+    return list(levels)
+
+
 def _draw_stacked(
     *,
     ax: Axes,
@@ -982,6 +1031,14 @@ def _draw_stacked(
         stack_is_hue = split.split_hue is not None
     stack_col = split.split_hue if stack_is_hue else split.split_hatch
     dodge_col = split.split_hatch if stack_is_hue else split.split_hue
+
+    if multiple == "gain":
+        _validate_gain_levels(
+            data=data,
+            stack_col=stack_col,
+            categorical_axis=categorical_axis,
+            dodge_col=dodge_col,
+        )
 
     stack_levels = _categories_in_draw_order(data[stack_col])
     dodge_levels = (

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -1082,6 +1082,85 @@ def _draw_stacked(
 
     cum: Dict[Tuple[object, Optional[object]], float] = {}
 
+    if multiple == "gain":
+        levels = _categories_in_draw_order(data[stack_col])
+        l0, l1 = levels[0], levels[1]
+        k = len(dodge_levels)
+        slot = max(1.0 - gap, 0.0)
+        sub_width = slot / k
+
+        for cat in cats:
+            for d_idx, d_lv in enumerate(dodge_levels):
+                # compute v0, v1 for the 2 stack levels at this (cat, d_lv)
+                m0 = data[categorical_axis] == cat
+                m0 = m0 & (data[stack_col] == l0)
+                if dodge_col is not None:
+                    m0 = m0 & (data[dodge_col] == d_lv)
+                m1 = data[categorical_axis] == cat
+                m1 = m1 & (data[stack_col] == l1)
+                if dodge_col is not None:
+                    m1 = m1 & (data[dodge_col] == d_lv)
+                v0 = float(data.loc[m0, value_col].mean())
+                v1 = float(data.loc[m1, value_col].mean())
+
+                pos_cat = cat_to_pos[cat]
+                if dodge_col is not None:
+                    d_offset = -slot / 2 + sub_width / 2 + d_idx * sub_width
+                else:
+                    d_offset = 0.0
+                pos = pos_cat + d_offset
+
+                if v0 == v1:
+                    # Tie: one rect only, colored by levels[0].
+                    face = palette.get(l0, color) if palette else color
+                    edge = edgecolor if edgecolor is not None else face
+                    if split.orient == "v":
+                        ax.bar(pos, v0, bottom=0.0, width=sub_width,
+                               color=face, edgecolor=edge,
+                               linewidth=linewidth)
+                    else:
+                        ax.barh(pos, v0, left=0.0, height=sub_width,
+                                color=face, edgecolor=edge,
+                                linewidth=linewidth)
+                    continue
+
+                # Distinct: sort into (lo_level, lo_val) + (hi_level, hi_val)
+                if v0 < v1:
+                    lo_lv, lo_v, hi_lv, hi_v = l0, v0, l1, v1
+                else:
+                    lo_lv, lo_v, hi_lv, hi_v = l1, v1, l0, v0
+
+                lo_face = palette.get(lo_lv, color) if palette else color
+                hi_face = palette.get(hi_lv, color) if palette else color
+                lo_edge = edgecolor if edgecolor is not None else lo_face
+                hi_edge = edgecolor if edgecolor is not None else hi_face
+
+                if split.orient == "v":
+                    ax.bar(pos, lo_v, bottom=0.0, width=sub_width,
+                           color=lo_face, edgecolor=lo_edge,
+                           linewidth=linewidth)
+                    ax.bar(pos, hi_v - lo_v, bottom=lo_v, width=sub_width,
+                           color=hi_face, edgecolor=hi_edge,
+                           linewidth=linewidth)
+                else:
+                    ax.barh(pos, lo_v, left=0.0, height=sub_width,
+                            color=lo_face, edgecolor=lo_edge,
+                            linewidth=linewidth)
+                    ax.barh(pos, hi_v - lo_v, left=lo_v, height=sub_width,
+                            color=hi_face, edgecolor=hi_edge,
+                            linewidth=linewidth)
+
+        # tick + invert logic identical to the stack/fill tail below
+        if split.orient == "v":
+            ax.set_xticks(list(range(len(cats))))
+            ax.set_xticklabels([str(c) for c in cats])
+        else:
+            ax.set_yticks(list(range(len(cats))))
+            ax.set_yticklabels([str(c) for c in cats])
+            if ax.get_ylim()[0] < ax.get_ylim()[1]:
+                ax.invert_yaxis()
+        return
+
     # Iteration order for double-dim matches the dodge path's draw order
     # (split.iter_draw_order) so the annotate builder pairs patches to
     # aggregates identically. That order is:

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -167,6 +167,70 @@ def test_gain_annotate_tie_single_label():
     assert ax.texts[0].get_text() == "0.50"
 
 
+def test_gain_annotate_default_mixed_per_segment_anchor():
+    """Winner (top) label above the bar; loser (base) label inside base."""
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None, annotate=True)
+    ax.figure.canvas.draw()
+
+    base_segs = [r for r in _bars(ax) if r.get_y() == 0 and r.get_height() < 1.0]
+    top_segs  = [r for r in _bars(ax) if r.get_y() > 0]
+
+    # Each rect type has its own label. Pair by matching text position x
+    # to segment center.
+    for rect in base_segs:
+        cx = rect.get_x() + rect.get_width() / 2
+        # find text positioned at this x
+        matches = [t for t in ax.texts
+                   if abs(t.get_position()[0] - cx) < 0.15]
+        assert len(matches) >= 1, f"no text near base at x={cx}"
+        # base label should sit INSIDE the base segment (y between 0 and height)
+        base_top = rect.get_height()
+        base_bot = 0.0
+        inside = any(base_bot <= t.get_position()[1] <= base_top for t in matches)
+        assert inside, (
+            f"base label at x={cx} not inside base segment [0, {base_top}]; "
+            f"text ys={[t.get_position()[1] for t in matches]}"
+        )
+
+    for rect in top_segs:
+        cx = rect.get_x() + rect.get_width() / 2
+        matches = [t for t in ax.texts
+                   if abs(t.get_position()[0] - cx) < 0.15]
+        # top label should be at the TOP of the rect (winner's absolute value)
+        rect_top = rect.get_y() + rect.get_height()
+        # The label's data-coord y should be approximately at rect_top
+        # (the offset is applied via ScaledTranslation in display space).
+        has_winner_label = any(
+            abs(t.get_position()[1] - rect_top) < 0.02 for t in matches
+        )
+        assert has_winner_label, (
+            f"winner label at x={cx} not anchored at rect top={rect_top}; "
+            f"text ys={[t.get_position()[1] for t in matches]}"
+        )
+
+
+def test_gain_annotate_user_anchor_override_still_wins():
+    """annotate={'anchor': 'outside'} should put ALL labels outside."""
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None,
+                    annotate={"anchor": "outside"})
+    ax.figure.canvas.draw()
+    # All 6 labels should sit ABOVE their rect tops.
+    for rect in _bars(ax):
+        rect_top = rect.get_y() + rect.get_height()
+        cx = rect.get_x() + rect.get_width() / 2
+        matches = [t for t in ax.texts
+                   if abs(t.get_position()[0] - cx) < 0.15]
+        # At least one label at this x should be at rect_top.
+        assert any(abs(t.get_position()[1] - rect_top) < 0.02
+                   for t in matches), (
+            f"expected outside label at x={cx} near y={rect_top}"
+        )
+
+
 def test_gain_missing_level_at_cat_raises():
     # "Recall" only has Baseline data — Proposed missing there.
     df = pd.DataFrame({

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -240,3 +240,52 @@ def test_gain_stack_by_hatch_flips_roles():
     # Now seeds (2 levels) compare; models (2 levels) dodge.
     # 2 cats × 2 model-dodge × 2 = 8.
     assert len(_bars(ax)) == 8
+
+
+def test_gain_horizontal_widths_and_inverted_y():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="score", y="metric", hue="model",
+                    multiple="gain", errorbar=None)
+    assert len(_bars(ax)) == 6
+    assert ax.get_ylim()[0] > ax.get_ylim()[1]  # inverted
+    # Group rects by y-center; each group = 2 rects, base at x=0, delta
+    # at x=min.
+    groups: dict = {}
+    for r in _bars(ax):
+        k = round(r.get_y() + r.get_height() / 2, 3)
+        groups.setdefault(k, []).append(r)
+    for k, segs in groups.items():
+        assert len(segs) == 2
+        segs.sort(key=lambda r: r.get_x())
+        assert segs[0].get_x() == pytest.approx(0.0)
+        assert segs[1].get_x() == pytest.approx(segs[0].get_width())
+
+
+def test_gain_stashes_hue_legend_entry():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None)
+    entries = get_entries(ax)
+    kinds = [(e.name, e.kind) for e in entries]
+    assert ("model", "hue") in kinds
+
+
+def test_gain_legend_false_does_not_stash():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None, legend=False)
+    assert get_entries(ax) == []
+
+
+def test_gain_returns_axes():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None)
+    assert isinstance(ax, Axes)
+
+
+def test_gain_rejects_figsize():
+    df = _simple_gain_df()
+    with pytest.raises(TypeError):
+        pp.barplot(data=df, x="metric", y="score", hue="model",
+                   multiple="gain", errorbar=None, figsize=(4, 3))

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -165,3 +165,33 @@ def test_gain_annotate_tie_single_label():
                     annotate={"fmt": ".2f"})
     assert len(ax.texts) == 1
     assert ax.texts[0].get_text() == "0.50"
+
+
+def test_gain_missing_level_at_cat_raises():
+    # "Recall" only has Baseline data — Proposed missing there.
+    df = pd.DataFrame({
+        "metric": pd.Categorical(["AUC", "AUC", "Recall"]),
+        "model": pd.Categorical(["Baseline", "Proposed", "Baseline"],
+                                categories=["Baseline", "Proposed"]),
+        "score": [0.80, 0.90, 0.88],
+    })
+    with pytest.raises(ValueError, match="missing"):
+        pp.barplot(data=df, x="metric", y="score", hue="model",
+                   multiple="gain", errorbar=None)
+
+
+def test_gain_without_hue_or_hatch_raises():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"]),
+        "val": [1.0, 2.0, 3.0],
+    })
+    with pytest.raises(ValueError, match="stack'\\|'fill"):
+        pp.barplot(data=df, x="cat", y="val",
+                   multiple="gain", errorbar=None)
+
+
+def test_gain_with_errorbar_warns():
+    df = _simple_gain_df()
+    with pytest.warns(UserWarning, match="errorbars"):
+        pp.barplot(data=df, x="metric", y="score", hue="model",
+                   multiple="gain", errorbar="se")

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -1,0 +1,55 @@
+"""Tests for `pp.barplot(multiple="gain")`.
+
+Pairwise comparison mode: per cat, base segment = min(v0, v1) colored by
+the losing level; top segment = max - min colored by the winning level.
+Absolute values via annotate. Ties → single bar in hue_order[0] color.
+"""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.colors import to_rgba
+
+import publiplots as pp
+from publiplots.utils.legend_entries import get_entries
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _bars(ax):
+    return [p for p in ax.patches if hasattr(p, "get_height")]
+
+
+def _simple_gain_df():
+    """3 metrics × 2 models. Proposed wins AUC/F1; Baseline wins Recall."""
+    return pd.DataFrame({
+        "metric": pd.Categorical(
+            ["AUC", "F1", "Recall", "AUC", "F1", "Recall"],
+            categories=["AUC", "F1", "Recall"],
+        ),
+        "model": pd.Categorical(
+            ["Baseline"] * 3 + ["Proposed"] * 3,
+            categories=["Baseline", "Proposed"],
+        ),
+        "score": [0.80, 0.75, 0.88, 0.90, 0.82, 0.85],
+    })
+
+
+def test_gain_three_level_hue_raises():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B"] * 3),
+        "grp": pd.Categorical(["x", "y", "z"] * 2),
+        "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    })
+    with pytest.raises(ValueError, match="exactly 2 levels"):
+        pp.barplot(data=df, x="cat", y="val", hue="grp",
+                   multiple="gain", errorbar=None)

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -140,3 +140,28 @@ def test_gain_tie_uses_hue_order_first_color():
     assert len(rects) == 1
     assert tuple(rects[0].get_facecolor()[:3]) == to_rgba("#ff0000")[:3]
     assert rects[0].get_height() == pytest.approx(0.5)
+
+
+def test_gain_annotate_labels_show_absolute_values():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None,
+                    annotate={"fmt": ".2f"})
+    # 6 rects → 6 labels. Labels show absolute values (0.80, 0.90, 0.75,
+    # 0.82, 0.85, 0.88) — never the delta (0.10, 0.07, 0.03).
+    assert len(ax.texts) == 6
+    texts = {t.get_text() for t in ax.texts}
+    assert texts == {"0.80", "0.90", "0.75", "0.82", "0.85", "0.88"}
+
+
+def test_gain_annotate_tie_single_label():
+    df = pd.DataFrame({
+        "metric": pd.Categorical(["Tied"] * 2),
+        "model": pd.Categorical(["A", "B"], categories=["A", "B"]),
+        "score": [0.5, 0.5],
+    })
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None,
+                    annotate={"fmt": ".2f"})
+    assert len(ax.texts) == 1
+    assert ax.texts[0].get_text() == "0.50"

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -113,3 +113,30 @@ def test_gain_base_color_is_loser_top_is_winner():
     # Baseline (winner) red.
     assert tuple(recall_segs[0].get_facecolor()[:3]) == to_rgba("#00ff00")[:3]
     assert tuple(recall_segs[1].get_facecolor()[:3]) == to_rgba("#ff0000")[:3]
+
+
+def test_gain_tie_produces_single_rect():
+    df = pd.DataFrame({
+        "metric": pd.Categorical(["Tied", "Tied", "Distinct", "Distinct"]),
+        "model": pd.Categorical(["A", "B"] * 2, categories=["A", "B"]),
+        "score": [0.8, 0.8, 0.7, 0.9],
+    })
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None)
+    # Tied → 1 rect; Distinct → 2 rects. Total 3.
+    assert len(_bars(ax)) == 3
+
+
+def test_gain_tie_uses_hue_order_first_color():
+    df = pd.DataFrame({
+        "metric": pd.Categorical(["Tied"] * 2),
+        "model": pd.Categorical(["A", "B"], categories=["A", "B"]),
+        "score": [0.5, 0.5],
+    })
+    palette = {"A": "#ff0000", "B": "#00ff00"}
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None, palette=palette)
+    rects = _bars(ax)
+    assert len(rects) == 1
+    assert tuple(rects[0].get_facecolor()[:3]) == to_rgba("#ff0000")[:3]
+    assert rects[0].get_height() == pytest.approx(0.5)

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -195,3 +195,48 @@ def test_gain_with_errorbar_warns():
     with pytest.warns(UserWarning, match="errorbars"):
         pp.barplot(data=df, x="metric", y="score", hue="model",
                    multiple="gain", errorbar="se")
+
+
+def _dual_gain_df():
+    """2 cats × 2 models × 2 seeds → 8 rows. Both models present in both
+    seeds at both cats."""
+    rows = []
+    for cat, base in zip(("A", "B"), (0.80, 0.85)):
+        for model, m_add in zip(("Baseline", "Proposed"), (0.00, 0.05)):
+            for seed, s_add in zip(("s1", "s2"), (0.00, 0.02)):
+                rows.append({"cat": cat, "model": model, "seed": seed,
+                             "score": base + m_add + s_add})
+    df = pd.DataFrame(rows)
+    df["cat"] = pd.Categorical(df["cat"])
+    df["model"] = pd.Categorical(df["model"], categories=["Baseline", "Proposed"])
+    df["seed"] = pd.Categorical(df["seed"], categories=["s1", "s2"])
+    return df
+
+
+def test_gain_dual_dim_requires_stack_by():
+    df = _dual_gain_df()
+    with pytest.raises(ValueError, match="stack_by"):
+        pp.barplot(data=df, x="cat", y="score",
+                   hue="model", hatch="seed",
+                   multiple="gain", errorbar=None)
+
+
+def test_gain_stack_by_hue_dodges_hatch():
+    df = _dual_gain_df()
+    ax = pp.barplot(data=df, x="cat", y="score",
+                    hue="model", hatch="seed",
+                    multiple="gain", stack_by="hue", errorbar=None)
+    # 2 cats × 2 seed-dodge sub-positions × 2 (base+delta) = 8 rects.
+    # (Assumes every (cat, seed) has distinct Baseline/Proposed values;
+    # _dual_gain_df is constructed that way.)
+    assert len(_bars(ax)) == 8
+
+
+def test_gain_stack_by_hatch_flips_roles():
+    df = _dual_gain_df()
+    ax = pp.barplot(data=df, x="cat", y="score",
+                    hue="model", hatch="seed",
+                    multiple="gain", stack_by="hatch", errorbar=None)
+    # Now seeds (2 levels) compare; models (2 levels) dodge.
+    # 2 cats × 2 model-dodge × 2 = 8.
+    assert len(_bars(ax)) == 8

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -53,3 +53,36 @@ def test_gain_three_level_hue_raises():
     with pytest.raises(ValueError, match="exactly 2 levels"):
         pp.barplot(data=df, x="cat", y="val", hue="grp",
                    multiple="gain", errorbar=None)
+
+
+def test_gain_single_dim_produces_two_rects_per_cat_when_distinct():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None)
+    # AUC: 0.80/0.90 → 2 rects; F1: 0.75/0.82 → 2 rects;
+    # Recall: 0.88/0.85 → 2 rects. Total 6.
+    assert len(_bars(ax)) == 6
+
+
+def test_gain_base_y_zero_top_stacked_on_min():
+    df = _simple_gain_df()
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None)
+    # Group rects by x-center; each group = 2 rects, base at y=0, delta
+    # at y=min.
+    groups: dict = {}
+    for r in _bars(ax):
+        k = round(r.get_x() + r.get_width() / 2, 3)
+        groups.setdefault(k, []).append(r)
+    for k, segs in groups.items():
+        assert len(segs) == 2
+        segs.sort(key=lambda r: r.get_y())
+        lo = segs[0].get_height()
+        assert segs[0].get_y() == pytest.approx(0.0)
+        assert segs[1].get_y() == pytest.approx(lo)
+        hi = segs[1].get_y() + segs[1].get_height()
+        # hi matches one of the two model scores at that metric
+        metric = ["AUC", "F1", "Recall"][int(round(k))]
+        scores = df.loc[df["metric"] == metric, "score"].tolist()
+        assert hi == pytest.approx(max(scores))
+        assert lo == pytest.approx(min(scores))

--- a/tests/test_bar_gain.py
+++ b/tests/test_bar_gain.py
@@ -86,3 +86,30 @@ def test_gain_base_y_zero_top_stacked_on_min():
         scores = df.loc[df["metric"] == metric, "score"].tolist()
         assert hi == pytest.approx(max(scores))
         assert lo == pytest.approx(min(scores))
+
+
+def test_gain_base_color_is_loser_top_is_winner():
+    df = _simple_gain_df()
+    palette = {"Baseline": "#ff0000", "Proposed": "#00ff00"}
+    ax = pp.barplot(data=df, x="metric", y="score", hue="model",
+                    multiple="gain", errorbar=None, palette=palette)
+
+    groups: dict = {}
+    for r in _bars(ax):
+        k = round(r.get_x() + r.get_width() / 2, 3)
+        groups.setdefault(k, []).append(r)
+
+    # AUC (x=0): Baseline=0.80, Proposed=0.90 → Baseline loses (red base),
+    # Proposed wins (green top).
+    # F1 (x=1): same direction (Baseline loses).
+    # Recall (x=2): Baseline=0.88, Proposed=0.85 → Baseline WINS → green
+    # top, red base flip: red is now on top, green on bottom.
+    auc_segs = sorted(groups[0.0], key=lambda r: r.get_y())
+    assert tuple(auc_segs[0].get_facecolor()[:3]) == to_rgba("#ff0000")[:3]
+    assert tuple(auc_segs[1].get_facecolor()[:3]) == to_rgba("#00ff00")[:3]
+
+    recall_segs = sorted(groups[2.0], key=lambda r: r.get_y())
+    # Baseline wins Recall → base is Proposed (loser) green, top is
+    # Baseline (winner) red.
+    assert tuple(recall_segs[0].get_facecolor()[:3]) == to_rgba("#00ff00")[:3]
+    assert tuple(recall_segs[1].get_facecolor()[:3]) == to_rgba("#ff0000")[:3]


### PR DESCRIPTION
## Summary

Adds `multiple="gain"` to `pp.barplot` for pairwise comparison of exactly 2 hue/hatch levels. Per cat, bottom segment = `min` (loser color), top segment = `max - min` (winner color). Bar top = `max`. Who wins can flip across cats; the base color flips accordingly.

Intended for summary metrics that don't compose by sum (AUC, accuracy, F1, expression ceiling) — where plain `multiple="stack"` is semantically wrong and plain `multiple="dodge"` hides the gain magnitude.

## Behavior

- **Stack column**: exactly 2 levels. ≠ 2 → `ValueError`. When both `hue` and `hatch` are distinct non-cat columns, `stack_by=` picks the gain pair (same semantics as stack/fill).
- **Tie** (`min == max` at some cat): single bar in `hue_order[0]` color.
- **Missing level** at some cat: `ValueError` with the cat name.
- **Annotate**: default `anchor="inside"`; labels show **absolute values** (loser total on base, winner total on top), not the delta.
- **Errorbars**: dropped with `UserWarning` (same rationale as stack/fill — no covariance-aware error propagation).
- **Horizontal orient**: supported, y-axis inverted to match seaborn.

## Files

- `src/publiplots/plot/bar.py` — `"gain"` added to `multiple` Literal; `_validate_gain_levels` helper; gain branch inside `_draw_stacked`; docstring updated.
- `src/publiplots/annotate/_builders.py` — `build_from_stacked_barplot_call` takes `multiple=`; gain-mode branch writes absolute values.
- `tests/test_bar_gain.py` — **19 tests**: contract, geometry, colors, tie, annotate, errors, dual-dim, horizontal, legend.
- `examples/plots/plot_01_bar_plots.py` — "Gain / Improvement Bars" section with AUC/F1/Recall color-flip example.
- `CHANGELOG.md` — `[Unreleased] → Added` entry.

## Test plan

- [x] `uv run pytest tests/test_bar_gain.py -v` — 19/19 passing
- [x] `uv run pytest --no-cov` — **707 passed** (688 baseline + 19 new gain tests)
- [x] `tests/test_bar_stacked.py` — 33/33 passing; stacked/fill path untouched
- [x] Gallery runs headless end-to-end
- [x] Smoke figure verified: 3 bars, AUC/F1 with Proposed-color tops, Recall with Baseline-color top (color flip), per-segment absolute-value labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)