### PR TITLE
chore(release): v0.10.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9] - 2026-05-11
+
 ### Added
 
 - `pp.barplot(multiple="stack"|"fill", stack_by=...)` — stacked and
@@ -47,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   side-by-side with a second non-cat column via `stack_by=`. Useful
   for summary metrics (AUC, accuracy, F1) where additive stacking is
   semantically wrong.
+  - `annotate=True` defaults to **mixed per-segment anchoring** on
+    gain: winner label floats above the bar top (`anchor="outside"`),
+    loser label sits inside the base segment (`anchor="inside"`), tie
+    label sits inside the single rect. Pass `annotate={"anchor": ...}`
+    to override uniformly. Stack/fill defaults stay `"inside"` for
+    all segments.
+  - New `anchor_override` field on `BarRecord` lets annotate strategies
+    resolve anchor per-bar (consumed by the gain-mode meta builder;
+    transparent to existing callers).
 
 ## [0.10.8] - 2026-05-10
 
@@ -211,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
   the title correctly regardless (PR #128).
 
+[0.10.9]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.9
 [0.10.8]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.8
 [0.10.7]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.7
 [0.10.6]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.8"
+version = "0.10.9"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.8"
+__version__ = "0.10.9"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.8"
+version = "0.10.9"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

Release v0.10.9. Promotes `[Unreleased]` → `[0.10.9]` in CHANGELOG with the features from PRs #137 (stack/fill + `stack_by`) and #138 (gain mode + mixed per-segment annotate).

## Version bumps

- `pyproject.toml` `0.10.8 → 0.10.9`
- `src/publiplots/__init__.py` `0.10.8 → 0.10.9`
- `.claude-plugin/plugin.json` `0.10.8 → 0.10.9`
- `uv.lock` regenerated

## Highlights

- `pp.barplot(multiple="stack"|"fill", stack_by=...)` — stacked / 100%-stacked bars, single-dim or dual-dim (with `stack_by` picking the stack dimension)
- `pp.barplot(multiple="gain")` — pairwise min+delta comparison bars for 2-level hue/hatch, with mixed per-segment annotate (winner outside, loser inside)
- Incidental fix: `hue_order` / `hatch_order` now drive legend entry order on the dodge path too (previously ignored)
- New `anchor_override` field on `BarRecord` for per-bar annotate anchor resolution

## Test plan

- [x] `uv run python -c "import publiplots as pp; print(pp.__version__)"` → `0.10.9`
- [x] `uv run pytest tests/test_bar_gain.py tests/test_bar_stacked.py` → 54 passed
- [x] CHANGELOG `[0.10.9]` tag link present

## Release steps (after merge)

1. Tag `v0.10.9` on the squash-merge commit
2. Create GitHub Release (triggers PyPI publish workflow)
3. Verify workflow completes successfully on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)