### PR TITLE
feat(annotate): bar_custom strategy for user-supplied labels

### DIFF
--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -464,7 +464,7 @@ pp.show()
 # --------------
 # Label each bar with its aggregated value by passing ``annotate=True``.
 # Pass a dict to control format, anchor, color, and text kwargs. See the
-# dedicated :doc:`annotations gallery <plot_16_annotate>` for the full
+# dedicated :doc:`annotations gallery <plot_17_annotate>` for the full
 # option set shared across barplot, pointplot, boxplot, and violinplot.
 
 ax = pp.barplot(

--- a/examples/plots/plot_04_pointplot.py
+++ b/examples/plots/plot_04_pointplot.py
@@ -298,7 +298,7 @@ pp.show()
 # ``annotate=True`` labels each mean with its value, above the errorbar
 # cap by default. Point-plot anchors are directional (``top``, ``bottom``,
 # ``left``, ``right``, ``center``). See the dedicated
-# :doc:`annotations gallery <plot_16_annotate>` for more.
+# :doc:`annotations gallery <plot_17_annotate>` for more.
 
 ax = pp.pointplot(
     data=simple_data,

--- a/examples/plots/plot_08_box_plots.py
+++ b/examples/plots/plot_08_box_plots.py
@@ -152,7 +152,7 @@ pp.show()
 # ~~~~~~~~~~~~~~~~~~~
 # ``annotate=True`` labels the median by default. Pass
 # ``stats=["median", "q1", "q3", ...]`` to label multiple statistics per
-# box. See the dedicated :doc:`annotations gallery <plot_16_annotate>`
+# box. See the dedicated :doc:`annotations gallery <plot_17_annotate>`
 # for the full option set.
 
 ax = pp.boxplot(

--- a/examples/plots/plot_09_violin_plots.py
+++ b/examples/plots/plot_09_violin_plots.py
@@ -218,7 +218,7 @@ pp.show()
 # Violinplots share the ``box_stats`` annotation strategy with boxplots:
 # ``annotate=True`` labels the median by default; pass
 # ``stats=[...]`` to label multiple statistics per violin. See the
-# dedicated :doc:`annotations gallery <plot_16_annotate>` for more.
+# dedicated :doc:`annotations gallery <plot_17_annotate>` for more.
 
 ax = pp.violinplot(
     data=violin_data,

--- a/examples/plots/plot_17_annotate.py
+++ b/examples/plots/plot_17_annotate.py
@@ -290,29 +290,48 @@ pp.annotate(ax, kind="bar_custom",
 pp.show()
 
 # %%
-# Callable source: per-bar categorical string
-# -------------------------------------------
+# Callable source: per-bar categorical string with fit-aware placement
+# --------------------------------------------------------------------
 # The callable has access to ``r.frame_row_index`` (the position in the
 # source DataFrame of the first row matching this bar's group), so you
-# can look up arbitrary sibling columns — here, a pathway name that we
-# truncate for display.
+# can look up arbitrary sibling columns — here, pathway names for an
+# enrichment plot.
+#
+# ``anchor="inside"`` places each label inside its bar. When a bar is
+# too short to fit its label, ``bar_custom`` falls back to
+# ``anchor="outside"`` for that bar only (same ``fit_check`` machinery
+# that ``bar_values`` uses). This means enrichment bars with a wide
+# score range get labels placed in whichever edge reads cleanly.
 pathway_df = pd.DataFrame({
-    "rank":    pd.Categorical([1, 2, 3, 4, 5]),
-    "score":   [0.89, 0.83, 0.79, 0.75, 0.71],
-    "pathway": [
-        "glycolysis",
-        "tca cycle",
-        "oxphos",
-        "pentose phosphate",
-        "fatty-acid beta-oxidation",
-    ],
+    "pathway": pd.Categorical(
+        [
+            "glycolysis",
+            "tca cycle",
+            "oxphos",
+            "pentose phosphate",
+            "fatty-acid beta-oxidation",
+        ],
+        categories=[
+            "fatty-acid beta-oxidation",
+            "pentose phosphate",
+            "oxphos",
+            "tca cycle",
+            "glycolysis",
+        ],
+    ),
+    # Wide score range: top bars easily fit the label inside;
+    # the bottom bars are too short, so fit_check re-anchors them outside.
+    "score": [2.45, 1.98, 0.62, 0.31, 0.18],
 })
-ax = pp.barplot(data=pathway_df, x="rank", y="score",
-                title="pathway names per bar")
+ax = pp.barplot(
+    data=pathway_df, x="score", y="pathway",
+    title="pathway enrichment (horizontal, anchor='inside' w/ auto-fallback)",
+    xlabel="−log₁₀(p)", ylabel="",
+)
 pp.annotate(
     ax, kind="bar_custom",
-    labels=lambda r: pathway_df.iloc[r.frame_row_index]["pathway"][:20],
-    fontsize=8, rotation=30,
+    labels=lambda r: str(r.category),
+    anchor="inside",
 )
 pp.show()
 

--- a/examples/plots/plot_17_annotate.py
+++ b/examples/plots/plot_17_annotate.py
@@ -256,14 +256,14 @@ pp.show()
 # ``n`` column from the DataFrame that was plotted; ``fmt="n={:,}"``
 # formats each value with a thousands separator.
 auc_df = pd.DataFrame({
-    "method": pd.Categorical(
-        ["lemur", "pca", "scvi"],
-        categories=["lemur", "pca", "scvi"],
+    "group": pd.Categorical(
+        ["A", "B", "C"],
+        categories=["A", "B", "C"],
     ),
     "auc": [0.87, 0.72, 0.81],
     "n":   [1204, 845, 987],
 })
-ax = pp.barplot(data=auc_df, x="method", y="auc",
+ax = pp.barplot(data=auc_df, x="group", y="auc",
                 title="AUC bars annotated with n=")
 pp.annotate(ax, kind="bar_custom", labels="n", fmt="n={:,}")
 pp.show()
@@ -342,19 +342,19 @@ pp.show()
 # are looked up by the ``(category, hue, hatch)`` group key, so labels
 # are paired with the correct bar even when hue is active.
 hue_df = pd.DataFrame({
-    "method": pd.Categorical(
-        ["lemur", "lemur", "pca", "pca", "scvi", "scvi"],
-        categories=["lemur", "pca", "scvi"],
+    "group": pd.Categorical(
+        ["A", "A", "B", "B", "C", "C"],
+        categories=["A", "B", "C"],
     ),
-    "fold":   pd.Categorical(
+    "fold":  pd.Categorical(
         ["f0", "f1", "f0", "f1", "f0", "f1"],
         categories=["f0", "f1"],
     ),
-    "auc":    [0.87, 0.85, 0.72, 0.74, 0.81, 0.79],
-    "n":      [1204, 1198, 845, 852, 987, 991],
+    "auc":   [0.87, 0.85, 0.72, 0.74, 0.81, 0.79],
+    "n":     [1204, 1198, 845, 852, 987, 991],
 })
 ax = pp.barplot(
-    data=hue_df, x="method", y="auc", hue="fold",
+    data=hue_df, x="group", y="auc", hue="fold",
     title="AUC + n with hue",
 )
 pp.annotate(ax, kind="bar_custom", labels="n", fmt="n={:,}")

--- a/examples/plots/plot_17_annotate.py
+++ b/examples/plots/plot_17_annotate.py
@@ -234,3 +234,122 @@ pp.boxplot(
     title="boxplot + rotation=90°",
 )
 pp.show()
+
+
+# %%
+# Custom labels: ``kind="bar_custom"``
+# ====================================
+#
+# The ``bar_custom`` strategy labels each bar with a user-supplied string
+# rather than the bar's own value. Use it to annotate an AUC bar with its
+# sample count, stamp pathway names on an enrichment bar plot, or render
+# any per-bar string derived from the source DataFrame.
+#
+# Labels come from either a DataFrame column name (aligned by the same
+# ``(x, hue, hatch)`` group keys ``pp.barplot`` used) or a callable that
+# receives each ``BarRecord`` and returns a string.
+
+# %%
+# Column source: AUC with per-bar ``n``
+# -------------------------------------
+# A classic "AUC + sample count" pattern. ``labels="n"`` picks up the
+# ``n`` column from the DataFrame that was plotted; ``fmt="n={:,}"``
+# formats each value with a thousands separator.
+auc_df = pd.DataFrame({
+    "method": pd.Categorical(
+        ["lemur", "pca", "scvi"],
+        categories=["lemur", "pca", "scvi"],
+    ),
+    "auc": [0.87, 0.72, 0.81],
+    "n":   [1204, 845, 987],
+})
+ax = pp.barplot(data=auc_df, x="method", y="auc",
+                title="AUC bars annotated with n=")
+pp.annotate(ax, kind="bar_custom", labels="n", fmt="n={:,}")
+pp.show()
+
+# %%
+# Callable source: signed percent delta
+# -------------------------------------
+# A ``labels=`` callable receives each ``BarRecord`` and returns the
+# label string. Use it when the label is a function of the bar's own
+# value (or anything else you can compute per-bar).
+delta_df = pd.DataFrame({
+    "cohort": pd.Categorical(
+        ["day-10", "day-20", "day-30"],
+        categories=["day-10", "day-20", "day-30"],
+    ),
+    "pct_change": [-12.3, 4.1, -7.8],
+})
+ax = pp.barplot(
+    data=delta_df, x="cohort", y="pct_change",
+    title="signed delta: labels=lambda r: f'{r.value:+.1f}%'",
+)
+pp.annotate(ax, kind="bar_custom",
+            labels=lambda r: f"{r.value:+.1f}%")
+pp.show()
+
+# %%
+# Callable source: per-bar categorical string
+# -------------------------------------------
+# The callable has access to ``r.frame_row_index`` (the position in the
+# source DataFrame of the first row matching this bar's group), so you
+# can look up arbitrary sibling columns — here, a pathway name that we
+# truncate for display.
+pathway_df = pd.DataFrame({
+    "rank":    pd.Categorical([1, 2, 3, 4, 5]),
+    "score":   [0.89, 0.83, 0.79, 0.75, 0.71],
+    "pathway": [
+        "glycolysis",
+        "tca cycle",
+        "oxphos",
+        "pentose phosphate",
+        "fatty-acid beta-oxidation",
+    ],
+})
+ax = pp.barplot(data=pathway_df, x="rank", y="score",
+                title="pathway names per bar")
+pp.annotate(
+    ax, kind="bar_custom",
+    labels=lambda r: pathway_df.iloc[r.frame_row_index]["pathway"][:20],
+    fontsize=8, rotation=30,
+)
+pp.show()
+
+# %%
+# Column source with hue
+# ----------------------
+# Label alignment follows the same dodge rules as ``pp.barplot``: columns
+# are looked up by the ``(category, hue, hatch)`` group key, so labels
+# are paired with the correct bar even when hue is active.
+hue_df = pd.DataFrame({
+    "method": pd.Categorical(
+        ["lemur", "lemur", "pca", "pca", "scvi", "scvi"],
+        categories=["lemur", "pca", "scvi"],
+    ),
+    "fold":   pd.Categorical(
+        ["f0", "f1", "f0", "f1", "f0", "f1"],
+        categories=["f0", "f1"],
+    ),
+    "auc":    [0.87, 0.85, 0.72, 0.74, 0.81, 0.79],
+    "n":      [1204, 1198, 845, 852, 987, 991],
+})
+ax = pp.barplot(
+    data=hue_df, x="method", y="auc", hue="fold",
+    title="AUC + n with hue",
+)
+pp.annotate(ax, kind="bar_custom", labels="n", fmt="n={:,}")
+pp.show()
+
+# %%
+# Inline via ``pp.barplot(annotate={"kind": "bar_custom", ...})``
+# ---------------------------------------------------------------
+# For brevity, pass the strategy and its options directly to
+# ``pp.barplot`` via the ``annotate=`` kwarg — the plotter dispatches
+# to ``bar_custom`` internally.
+ax = pp.barplot(
+    data=auc_df, x="method", y="auc",
+    annotate={"kind": "bar_custom", "labels": "n", "fmt": "n={:,}"},
+    title="inline: annotate={'kind': 'bar_custom', 'labels': 'n', ...}",
+)
+pp.show()

--- a/examples/plots/plot_17_annotate.py
+++ b/examples/plots/plot_17_annotate.py
@@ -367,7 +367,7 @@ pp.show()
 # ``pp.barplot`` via the ``annotate=`` kwarg — the plotter dispatches
 # to ``bar_custom`` internally.
 ax = pp.barplot(
-    data=auc_df, x="method", y="auc",
+    data=auc_df, x="group", y="auc",
     annotate={"kind": "bar_custom", "labels": "n", "fmt": "n={:,}"},
     title="inline: annotate={'kind': 'bar_custom', 'labels': 'n', ...}",
 )

--- a/src/publiplots/annotate/__init__.py
+++ b/src/publiplots/annotate/__init__.py
@@ -1,8 +1,13 @@
 """pp.annotate: in-plot value labels.
 
-Public surface is the `annotate` function. All other modules are internal
-and subject to change; do not import from them directly.
+Public surface:
+    - annotate: the strategy-dispatching entry point.
+    - BarRecord: the per-bar record passed to `kind="bar_custom"` callables.
+
+All other modules are internal and subject to change; do not import from
+them directly.
 """
+from publiplots.annotate._cache import BarRecord
 from publiplots.annotate._dispatcher import annotate
 
-__all__ = ["annotate"]
+__all__ = ["annotate", "BarRecord"]

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -27,6 +27,7 @@ from publiplots.annotate._cache import (
     BoxStatsRecord,
     PointRecord,
     PointValueMeta,
+    _is_bar_rect,
     _iter_error_segments,
     _match_errorbars,
 )
@@ -237,10 +238,9 @@ def build_from_barplot_call(
     agg = _aggregate_means(data, x=x, y=y, hue=hue, hatch=hatch,
                            categorical_axis=categorical_axis,
                            source_frame=source_frame)
-    rects = [
-        p for p in ax.patches
-        if isinstance(p, Rectangle) and p.get_width() > 0 and p.get_height() > 0
-    ]
+    # `_is_bar_rect` treats signed extents as valid so negative-valued bars
+    # (matplotlib emits them as rects with negative height/width) are kept.
+    rects = [p for p in ax.patches if _is_bar_rect(p)]
     err_by_bar = _match_errorbars(ax, rects, orient)
 
     bars: List[BarRecord] = []
@@ -434,10 +434,7 @@ def build_from_histplot_call(
     """
     orient = "v" if x is not None else "h"
 
-    rects = [
-        p for p in ax.patches
-        if isinstance(p, Rectangle) and p.get_width() > 0 and p.get_height() > 0
-    ]
+    rects = [p for p in ax.patches if _is_bar_rect(p)]
 
     bars: List[BarRecord] = []
     for rect in rects:

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -40,13 +40,19 @@ def _aggregate_means(
     hue: Optional[str],
     categorical_axis: str,
     hatch: Optional[str] = None,
+    source_frame=None,
 ) -> List[Dict]:
     """Group by (categorical_axis [, hue [, hatch]]) and return means.
 
-    Uses the shared `BarSplitSpec` to decide which dimensions actually
-    dodge, so the row order here matches whatever bar.py draws.
-    Errorbar extents are not computed here; callers pull them from drawn
-    artists via `_match_errorbars`.
+    Each row carries its draw-order category/hue/hatch keys and the
+    frame row index of the first matching source row, so downstream
+    label lookups can align by group without re-deriving the spec.
+
+    ``frame_row_index`` is a *position* (integer offset) into
+    ``source_frame``, not a pandas label, so ``source_frame.iloc[idx]``
+    resolves the caller's row for any index kind (RangeIndex, string
+    index, sliced, MultiIndex, ...). When ``source_frame`` is omitted
+    the field is ``None``.
     """
     value_col = y if categorical_axis == x else x
     spec = BarSplitSpec.resolve(
@@ -54,19 +60,37 @@ def _aggregate_means(
     )
 
     rows: List[Dict] = []
-    for cat, h_val, _ht_val in spec.iter_draw_order(data):
+    for cat, h_val, ht_val in spec.iter_draw_order(data):
         parts = [data[categorical_axis] == cat]
         if spec.split_hue is not None:
             parts.append(data[spec.split_hue] == h_val)
         if spec.split_hatch is not None:
-            parts.append(data[spec.split_hatch] == _ht_val)
+            parts.append(data[spec.split_hatch] == ht_val)
         mask = parts[0]
         for p in parts[1:]:
             mask = mask & p
         vals = data.loc[mask, value_col].to_numpy()
-        row: Dict = {"mean": float(np.mean(vals))}
-        if h_val is not None:
-            row["hue_value"] = h_val
+        # Position within source_frame of the first row matching this group.
+        # We resolve against source_frame (not the prepared `data`) because the
+        # meta's `source_frame` is the pre-copy caller frame; `iloc` on the
+        # caller's frame must land on the same semantic row.
+        matching = data.index[mask]
+        frame_row_index: Optional[int] = None
+        if source_frame is not None and len(matching):
+            # Map the matching label back to a position in source_frame's index.
+            first_label = matching[0]
+            try:
+                frame_row_index = int(source_frame.index.get_loc(first_label))
+            except (KeyError, TypeError):
+                # Prepared data diverged from source_frame's index (rare).
+                frame_row_index = None
+        row: Dict = {
+            "mean": float(np.mean(vals)) if len(vals) else float("nan"),
+            "category": cat,
+            "hue_value": h_val,
+            "hatch_value": ht_val,
+            "frame_row_index": frame_row_index,
+        }
         rows.append(row)
     return rows
 
@@ -187,6 +211,8 @@ def build_from_barplot_call(
     palette: Optional[Dict],
     errorbar: Optional[str],
     hatch: Optional[str] = None,
+    *,
+    source_frame,
 ) -> BarValueMeta:
     """Build a `BarValueMeta` paired with the barplot's Rectangles.
 
@@ -196,11 +222,21 @@ def build_from_barplot_call(
     callables, `None`). Records are paired with Rectangles in draw order,
     which under hue + hatch double-split is hue-outer / hatch-middle /
     cat-inner. Hue colors come from the resolved palette map.
+
+    Parameters
+    ----------
+    source_frame : pandas.DataFrame
+        The caller's pre-copy DataFrame. Required keyword-only; must be
+        the exact object the user passed to ``pp.barplot``, so
+        ``meta.source_frame is df`` holds and
+        ``source_frame.iloc[record.frame_row_index]`` resolves correctly
+        regardless of the caller's index kind.
     """
     orient = "v" if categorical_axis == x else "h"
 
     agg = _aggregate_means(data, x=x, y=y, hue=hue, hatch=hatch,
-                           categorical_axis=categorical_axis)
+                           categorical_axis=categorical_axis,
+                           source_frame=source_frame)
     rects = [
         p for p in ax.patches
         if isinstance(p, Rectangle) and p.get_width() > 0 and p.get_height() > 0
@@ -208,7 +244,9 @@ def build_from_barplot_call(
     err_by_bar = _match_errorbars(ax, rects, orient)
 
     bars: List[BarRecord] = []
-    for rect, row, (err_low, err_high) in zip(rects, agg, err_by_bar):
+    for i, (rect, row, (err_low, err_high)) in enumerate(
+        zip(rects, agg, err_by_bar)
+    ):
         hue_color = None
         if hue is not None and palette is not None:
             key = row.get("hue_value")
@@ -222,13 +260,31 @@ def build_from_barplot_call(
             err_low=err_low,
             err_high=err_high,
             hue_color=hue_color,
+            anchor_override=None,
+            category=row["category"],
+            hue_value=row["hue_value"],
+            hatch_value=row["hatch_value"],
+            draw_index=i,
+            frame_row_index=row["frame_row_index"],
         ))
+
+    spec = BarSplitSpec.resolve(
+        x=x, y=y, hue=hue, hatch=hatch, categorical_axis=categorical_axis,
+    )
+    keys: List[str] = [categorical_axis]
+    if spec.split_hue is not None:
+        keys.append(spec.split_hue)
+    if spec.split_hatch is not None:
+        keys.append(spec.split_hatch)
+
     return BarValueMeta(
         orient=orient,
         bars=bars,
         errorbar_kind=errorbar,
         hue_active=hue is not None,
         owner_is_publiplots=True,
+        source_frame=source_frame,
+        group_keys=tuple(keys),
     )
 
 
@@ -242,6 +298,8 @@ def build_from_stacked_barplot_call(
     palette: Optional[Dict],
     hatch: Optional[str] = None,
     multiple: Literal["stack", "fill", "gain"] = "stack",
+    *,
+    source_frame,
 ) -> BarValueMeta:
     """Build a ``BarValueMeta`` paired with a stacked bar plot's Rectangles.
 
@@ -259,12 +317,22 @@ def build_from_stacked_barplot_call(
     labeled is ``y + height`` (the winner's absolute total); otherwise
     (base segment or tie) the label value is ``rect.get_height()``
     itself. Horizontal orient mirrors with ``x`` / ``width``.
+
+    Parameters
+    ----------
+    source_frame : pandas.DataFrame
+        The caller's pre-copy DataFrame. Required keyword-only; must be
+        the exact object the user passed to ``pp.barplot``, so
+        ``meta.source_frame is df`` holds and
+        ``source_frame.iloc[record.frame_row_index]`` resolves correctly
+        regardless of the caller's index kind.
     """
     orient: Literal["v", "h"] = "v" if categorical_axis == x else "h"
 
     agg = _aggregate_means(
         data, x=x, y=y, hue=hue, hatch=hatch,
         categorical_axis=categorical_axis,
+        source_frame=source_frame,
     )
     # No > 0 filter on height / width: the stacked path emits one
     # Rectangle per aggregated row via ax.bar, including legitimate
@@ -273,7 +341,7 @@ def build_from_stacked_barplot_call(
     rects = [p for p in ax.patches if isinstance(p, Rectangle)]
 
     bars: List[BarRecord] = []
-    for rect, row in zip(rects, agg):
+    for i, (rect, row) in enumerate(zip(rects, agg)):
         anchor_override: Optional[str] = None
         if multiple == "gain":
             # Absolute values: base segment's height is the loser's total;
@@ -311,13 +379,30 @@ def build_from_stacked_barplot_call(
             err_high=None,
             hue_color=hue_color,
             anchor_override=anchor_override,
+            category=row["category"],
+            hue_value=row["hue_value"],
+            hatch_value=row["hatch_value"],
+            draw_index=i,
+            frame_row_index=row["frame_row_index"],
         ))
+
+    spec = BarSplitSpec.resolve(
+        x=x, y=y, hue=hue, hatch=hatch, categorical_axis=categorical_axis,
+    )
+    keys: List[str] = [categorical_axis]
+    if spec.split_hue is not None:
+        keys.append(spec.split_hue)
+    if spec.split_hatch is not None:
+        keys.append(spec.split_hatch)
+
     return BarValueMeta(
         orient=orient,
         bars=bars,
         errorbar_kind=None,
         hue_active=hue is not None,
         owner_is_publiplots=True,
+        source_frame=source_frame,
+        group_keys=tuple(keys),
     )
 
 

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -272,10 +272,13 @@ def build_from_barplot_call(
         x=x, y=y, hue=hue, hatch=hatch, categorical_axis=categorical_axis,
     )
     keys: List[str] = [categorical_axis]
+    dims: List[str] = ["cat"]
     if spec.split_hue is not None:
         keys.append(spec.split_hue)
+        dims.append("hue")
     if spec.split_hatch is not None:
         keys.append(spec.split_hatch)
+        dims.append("hatch")
 
     return BarValueMeta(
         orient=orient,
@@ -285,6 +288,7 @@ def build_from_barplot_call(
         owner_is_publiplots=True,
         source_frame=source_frame,
         group_keys=tuple(keys),
+        group_dims=tuple(dims),
     )
 
 
@@ -390,10 +394,13 @@ def build_from_stacked_barplot_call(
         x=x, y=y, hue=hue, hatch=hatch, categorical_axis=categorical_axis,
     )
     keys: List[str] = [categorical_axis]
+    dims: List[str] = ["cat"]
     if spec.split_hue is not None:
         keys.append(spec.split_hue)
+        dims.append("hue")
     if spec.split_hatch is not None:
         keys.append(spec.split_hatch)
+        dims.append("hatch")
 
     return BarValueMeta(
         orient=orient,
@@ -403,6 +410,7 @@ def build_from_stacked_barplot_call(
         owner_is_publiplots=True,
         source_frame=source_frame,
         group_keys=tuple(keys),
+        group_dims=tuple(dims),
     )
 
 

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -58,6 +58,11 @@ class BarValueMeta:
     owner_is_publiplots: bool
     source_frame: Optional[Any] = None          # pandas DataFrame (kept Any to avoid import)
     group_keys: Optional[Tuple[str, ...]] = None
+    # Companion to group_keys identifying each key's dimension: one of
+    # "cat", "hue", "hatch". Parallel tuple with the same length and order as
+    # `group_keys`. Populated by publiplots-owned builders; left `None` by
+    # `_introspect` (foreign axes have no semantic dims to report).
+    group_dims: Optional[Tuple[str, ...]] = None
 
 
 @dataclass
@@ -237,4 +242,5 @@ def _introspect(ax: Axes) -> BarValueMeta:
         owner_is_publiplots=False,
         source_frame=None,
         group_keys=None,
+        group_dims=None,
     )

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -115,9 +115,18 @@ class BoxStatsMeta:
 
 
 def _is_bar_rect(p) -> bool:
+    """True for a Rectangle with non-zero width AND non-zero height.
+
+    Seaborn/matplotlib draw negative-valued bars as Rectangles with a
+    negative ``get_height()`` (or ``get_width()`` for horizontal orient):
+    ``x, y=0, height=-12.3`` instead of ``x, y=-12.3, height=12.3``.
+    A strict ``> 0`` check would silently drop those bars from meta,
+    causing annotate strategies to skip every negative bar. Here we only
+    reject *degenerate* zero-size rects (e.g. truly empty groups).
+    """
     if not isinstance(p, Rectangle):
         return False
-    return p.get_width() > 0 and p.get_height() > 0
+    return p.get_width() != 0 and p.get_height() != 0
 
 
 def _iter_error_segments(ax: Axes):

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -214,7 +214,7 @@ def _introspect(ax: Axes) -> BarValueMeta:
     orient = _infer_orient(rects)
     err_by_bar = _match_errorbars(ax, rects, orient)
     bars: List[BarRecord] = []
-    for r, (err_low, err_high) in zip(rects, err_by_bar):
+    for i, (r, (err_low, err_high)) in enumerate(zip(rects, err_by_bar)):
         value = r.get_height() if orient == "v" else r.get_width()
         bars.append(BarRecord(
             patch=r,
@@ -222,6 +222,12 @@ def _introspect(ax: Axes) -> BarValueMeta:
             err_low=err_low,
             err_high=err_high,
             hue_color=tuple(r.get_facecolor()),
+            anchor_override=None,
+            category=None,
+            hue_value=None,
+            hatch_value=None,
+            draw_index=i,
+            frame_row_index=None,
         ))
     return BarValueMeta(
         orient=orient,
@@ -229,4 +235,6 @@ def _introspect(ax: Axes) -> BarValueMeta:
         errorbar_kind=None,
         hue_active=False,
         owner_is_publiplots=False,
+        source_frame=None,
+        group_keys=None,
     )

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -7,7 +7,7 @@ reconstructs an equivalent meta by walking `ax.patches` and `ax.lines`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Tuple
+from typing import Any, Hashable, List, Literal, Optional, Tuple
 
 from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
@@ -18,14 +18,35 @@ from matplotlib.patches import Rectangle
 RGBA = Tuple[float, float, float, float]
 
 
-@dataclass
+@dataclass(frozen=True)
 class BarRecord:
+    """One drawn bar plus the metadata annotate strategies need.
+
+    Fields:
+        patch: the matplotlib Rectangle drawn for this bar.
+        value: aggregated bar height (orient='v') or width ('h'); NaN-possible.
+        err_low, err_high: errorbar extents on the value axis, if present.
+        hue_color: the palette color assigned to this bar (RGBA).
+        anchor_override: if set, overrides the caller's anchor for this bar
+            (used by stacked/gain barplots to pin labels inside-vs-outside).
+        category: the x-axis group key (None on foreign axes).
+        hue_value: the hue group key, if hue is active (else None).
+        hatch_value: the hatch group key, if hatch is active (else None).
+        draw_index: 0-based position in the draw order.
+        frame_row_index: index of a representative source-DataFrame row for
+            this group (first row in the group); None on foreign axes.
+    """
     patch: Rectangle
     value: float
     err_low: Optional[float]
     err_high: Optional[float]
     hue_color: Optional[RGBA]
     anchor_override: Optional[str] = None
+    category: Optional[Hashable] = None
+    hue_value: Optional[Hashable] = None
+    hatch_value: Optional[Hashable] = None
+    draw_index: int = 0
+    frame_row_index: Optional[int] = None
 
 
 @dataclass
@@ -35,6 +56,8 @@ class BarValueMeta:
     errorbar_kind: Optional[str]
     hue_active: bool
     owner_is_publiplots: bool
+    source_frame: Optional[Any] = None          # pandas DataFrame (kept Any to avoid import)
+    group_keys: Optional[Tuple[str, ...]] = None
 
 
 @dataclass

--- a/src/publiplots/annotate/_dispatcher.py
+++ b/src/publiplots/annotate/_dispatcher.py
@@ -12,6 +12,7 @@ from typing import Callable, List, Optional, Union
 from matplotlib.axes import Axes
 from matplotlib.text import Text
 
+from publiplots.annotate.bar_custom import _bar_custom_strategy
 from publiplots.annotate.bar_values import _bar_values_strategy
 from publiplots.annotate.box_stats import _box_stats_strategy
 from publiplots.annotate.point_values import _point_values_strategy
@@ -19,8 +20,18 @@ from publiplots.annotate.point_values import _point_values_strategy
 
 _STRATEGIES: dict[str, Callable] = {
     "bar_values": _bar_values_strategy,
+    "bar_custom": _bar_custom_strategy,
     "box_stats": _box_stats_strategy,
     "point_values": _point_values_strategy,
+}
+
+
+# Per-strategy default for `fmt` when the caller did not pass one explicitly.
+_DEFAULT_FMT: dict[str, str] = {
+    "bar_values": ".2f",
+    "bar_custom": "{}",
+    "box_stats": ".2f",
+    "point_values": ".2f",
 }
 
 
@@ -28,12 +39,14 @@ def annotate(
     ax: Axes,
     kind: str = "bar_values",
     *,
-    fmt: str = ".2f",
+    fmt: Optional[str] = None,
     anchor: Optional[str] = None,
     offset: float = 1.0,
     color: Union[str, tuple] = "auto",
     pad: Optional[float] = None,
     rotation: float = 0.0,
+    labels=None,
+    data=None,
     **text_kws,
 ) -> List[Text]:
     """Add value labels to plot marks on ``ax``.
@@ -49,20 +62,28 @@ def annotate(
         The axes to annotate. Must already have marks drawn on it
         (e.g. via :func:`publiplots.barplot`, :func:`publiplots.boxplot`,
         :func:`publiplots.pointplot`, or :func:`publiplots.lineplot`).
-    kind : {'bar_values', 'box_stats', 'point_values'}, default ``'bar_values'``
+    kind : {'bar_values', 'bar_custom', 'box_stats', 'point_values'}, default ``'bar_values'``
         Annotation strategy to use:
 
         - ``'bar_values'`` — label bars with their values; anchor
           vocabulary ``{"outside", "inside", "base", "center"}``.
+        - ``'bar_custom'`` — label bars with user-supplied strings
+          from a DataFrame column or a callable
+          ``fn(BarRecord) -> str``; anchor vocabulary
+          ``{"outside", "inside", "base", "center"}`` (same as
+          ``bar_values``).
         - ``'box_stats'`` — label box plots with distributional
           summary statistics.
         - ``'point_values'`` — label scatter or line-plot points;
           anchor vocabulary
           ``{"top", "bottom", "left", "right", "center"}``.
-    fmt : str, default ``'.2f'``
+    fmt : str, optional
         Either a bare format spec (e.g. ``".2f"``, ``",.0f"``) or a
         format-string template containing ``{}`` (e.g.
-        ``"{:,.1f}%"``).
+        ``"{:,.1f}%"``). If ``None`` (the default), each strategy picks
+        its own default: ``bar_values``, ``box_stats``, and
+        ``point_values`` default to ``'.2f'``; ``bar_custom`` defaults
+        to ``'{}'`` (raw passthrough of the supplied labels).
     anchor : str, optional
         Where to place the label relative to the mark.
         Strategy-specific — see ``kind`` above. If ``None``, each
@@ -92,6 +113,17 @@ def annotate(
         so rotated labels do not clip neighbouring marks. Non-right-angle
         rotations are passed through to matplotlib as-is; fine-tuning
         alignment is the caller's responsibility in that case.
+    labels : str or callable, optional
+        ``bar_custom`` only. Either a column name to look up in the
+        cached ``pp.barplot`` source frame (or in ``data=`` when given),
+        or a callable ``fn(BarRecord) -> str`` receiving each bar's
+        record and returning the label string. Required when
+        ``kind='bar_custom'``; passing it with any other kind is a
+        ``TypeError``.
+    data : pandas.DataFrame, optional
+        ``bar_custom`` only. Overrides the cached source frame for
+        column-based labels. Useful when labels live in a different
+        DataFrame than the one passed to ``pp.barplot``.
     **text_kws
         Forwarded to :meth:`matplotlib.axes.Axes.text` (e.g.
         ``fontsize``, ``fontweight``).
@@ -147,7 +179,22 @@ def annotate(
     if not math.isfinite(rotation):
         raise ValueError("rotation must be a finite number of degrees")
 
+    resolved_fmt = fmt if fmt is not None else _DEFAULT_FMT[kind]
+
+    # labels= and data= are only meaningful for bar_custom; reject them for
+    # other kinds with a clear error, and forward them conditionally so
+    # other strategies' signatures stay unchanged.
+    extra = {}
+    if kind == "bar_custom":
+        extra["labels"] = labels
+        extra["data"] = data
+    elif labels is not None or data is not None:
+        raise TypeError(
+            f"labels= and data= are only supported for kind='bar_custom'; "
+            f"got kind={kind!r}"
+        )
+
     return _STRATEGIES[kind](
-        ax, fmt=fmt, anchor=anchor, offset=offset, color=color, pad=pad,
-        rotation=rotation, **text_kws,
+        ax, fmt=resolved_fmt, anchor=anchor, offset=offset, color=color, pad=pad,
+        rotation=rotation, **extra, **text_kws,
     )

--- a/src/publiplots/annotate/bar_custom.py
+++ b/src/publiplots/annotate/bar_custom.py
@@ -1,0 +1,236 @@
+"""Custom-text label strategy for barplots.
+
+Same placement machinery as bar_values (resolve_anchor, resolve_color,
+fit_check, _maybe_expand_limits); the only difference is where the label
+string comes from: a DataFrame column aligned by (x, hue, hatch) group
+keys, or a user-supplied callable that receives each BarRecord.
+"""
+from __future__ import annotations
+
+import logging
+import math
+import warnings
+from typing import Callable, Dict, List, Optional, Union
+
+from matplotlib.axes import Axes
+from matplotlib.text import Text
+
+from publiplots.annotate._cache import BarRecord, BarValueMeta, _introspect
+from publiplots.annotate._color import resolve_color
+from publiplots.annotate._positioning import (
+    fit_check,
+    make_offset_transform,
+    resolve_anchor,
+)
+from publiplots.annotate.bar_values import (
+    _ensure_renderer,
+    _maybe_expand_limits,
+    _VALID_ANCHORS,
+    _DEFAULT_ANCHOR,
+)
+
+
+_DIM_TO_FIELD = {"cat": "category", "hue": "hue_value", "hatch": "hatch_value"}
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_or_introspect(ax: Axes) -> BarValueMeta:
+    meta = getattr(ax, "_publiplots_bar_meta", None)
+    if isinstance(meta, BarValueMeta):
+        return meta
+    return _introspect(ax)
+
+
+def _build_column_label_table(
+    meta: BarValueMeta,
+    column: str,
+    data,                              # pandas DataFrame
+) -> Dict[int, object]:
+    """Return {draw_index: cell_value} for each bar in meta.bars.
+
+    Aligns by meta.group_keys. Emits a UserWarning when the column varies
+    within any group (uses `.first()`).
+    """
+    if column not in data.columns:
+        raise KeyError(
+            f"column {column!r} not found in data; available: "
+            f"{list(data.columns)}"
+        )
+    groupby = data.groupby(list(meta.group_keys), observed=True)
+    firsts = groupby[column].first()
+    nunique = groupby[column].nunique(dropna=False)
+    varies = nunique[nunique > 1]
+    if len(varies):
+        warnings.warn(
+            f"pp.annotate: column {column!r} varies within group(s) "
+            f"{list(varies.index)}; using .first()",
+            UserWarning,
+            stacklevel=4,
+        )
+
+    # meta.group_dims identifies each group_keys entry's semantic dimension:
+    # position 0 is always "cat", but position 1 may be "hue" OR "hatch"
+    # (under hatch-only splits). Reading that companion tuple — instead of
+    # assuming positional (cat, hue, hatch) order — keeps key lookups aligned
+    # regardless of which split dimensions are active. Foreign axes never
+    # reach this function (group_keys is None there), but we keep a defensive
+    # fallback to all-"cat" so a hypothetical caller doesn't silently KeyError.
+    dims = meta.group_dims or ("cat",) * len(meta.group_keys)
+    table: Dict[int, object] = {}
+    for bar in meta.bars:
+        key_parts = [getattr(bar, _DIM_TO_FIELD[d]) for d in dims]
+        key = key_parts[0] if len(key_parts) == 1 else tuple(key_parts)
+        try:
+            table[bar.draw_index] = firsts.loc[key]
+        except KeyError:
+            table[bar.draw_index] = None
+    return table
+
+
+def _format_column_value(value, fmt: str) -> Optional[str]:
+    """Apply fmt to a column cell. Return None for NaN/None so caller skips."""
+    if value is None:
+        return None
+    # pandas NA / float NaN
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return None
+    except TypeError:
+        pass
+    if "{" in fmt and "}" in fmt:
+        return fmt.format(value)
+    return format(value, fmt) if fmt != "{}" else str(value)
+
+
+def _bar_custom_strategy(
+    ax: Axes,
+    *,
+    fmt: str,
+    anchor,
+    offset: float,
+    color,
+    pad: float,
+    rotation: float = 0.0,
+    labels: Union[str, Callable[[BarRecord], str], None] = None,
+    data=None,
+    **text_kws,
+) -> List[Text]:
+    if labels is None:
+        raise ValueError("bar_custom requires a labels= argument")
+    if not isinstance(labels, str) and not callable(labels):
+        raise TypeError(
+            f"labels must be a column name (str) or a callable; "
+            f"got {type(labels).__name__}"
+        )
+
+    if anchor is None:
+        anchor = _DEFAULT_ANCHOR
+    if anchor not in _VALID_ANCHORS:
+        raise ValueError(
+            f"bar_custom anchor must be one of {sorted(_VALID_ANCHORS)}; "
+            f"got {anchor!r}"
+        )
+
+    # Top-level `rotation` wins over one smuggled via text_kws; pop silently.
+    text_kws.pop("rotation", None)
+
+    meta = _get_or_introspect(ax)
+    if not meta.bars:
+        warnings.warn("pp.annotate: no bars found on axes", UserWarning,
+                      stacklevel=3)
+        return []
+
+    # -------- resolve label source -------------------------------------------
+    is_callable = callable(labels)
+    if is_callable and fmt != "{}":
+        # Per-strategy default fmt is "{}" (neutral passthrough) when the
+        # caller did not override; warn if it did.
+        warnings.warn(
+            "pp.annotate: fmt is ignored when labels is a callable",
+            UserWarning,
+            stacklevel=3,
+        )
+
+    label_table: Optional[Dict[int, object]] = None
+    if isinstance(labels, str):
+        frame = data if data is not None else meta.source_frame
+        if frame is None:
+            raise ValueError(
+                "pp.annotate: column-based labels require either a "
+                "publiplots-owned axes (via pp.barplot) or an explicit "
+                "data= DataFrame"
+            )
+        if meta.group_keys is None:
+            raise NotImplementedError(
+                "pp.annotate: column-based labels on foreign axes are not "
+                "supported; use a callable (fn(record) -> str) instead"
+            )
+        label_table = _build_column_label_table(meta, labels, frame)
+
+    # -------- per-record loop (mirrors bar_values._bar_values_strategy) ------
+    renderer = _ensure_renderer(ax)
+    texts: List[Text] = []
+
+    for bar in meta.bars:
+        if math.isnan(bar.value):
+            continue
+
+        # Stacked/gain bars may pin themselves to a specific anchor.
+        bar_anchor = bar.anchor_override if bar.anchor_override is not None else anchor
+
+        if is_callable:
+            label_obj = labels(bar)
+            if label_obj is None:
+                continue
+            if not isinstance(label_obj, str):
+                raise TypeError(
+                    f"labels callable must return str; got "
+                    f"{type(label_obj).__name__} at draw_index={bar.draw_index} "
+                    f"(category={bar.category!r})"
+                )
+            label = label_obj
+        else:
+            cell = label_table[bar.draw_index]
+            formatted = _format_column_value(cell, fmt)
+            if formatted is None:
+                continue
+            label = formatted
+
+        x, y, dx_mm, dy_mm, ha, va = resolve_anchor(
+            bar, bar_anchor, meta.orient, offset, ax,
+        )
+        rgba = resolve_color(bar, color, bar_anchor, ax, hue_active=meta.hue_active)
+        t = ax.text(
+            x, y, label, ha=ha, va=va, color=rgba,
+            rotation=rotation,
+            transform=make_offset_transform(ax, dx_mm, dy_mm),
+            **text_kws,
+        )
+
+        if bar_anchor != "outside":
+            bbox = bar.patch.get_window_extent(renderer)
+            if fit_check(t, bbox, meta.orient, bar_anchor, renderer) == "reanchor_outside":
+                x2, y2, dx2, dy2, ha2, va2 = resolve_anchor(
+                    bar, "outside", meta.orient, offset, ax,
+                )
+                rgba2 = resolve_color(bar, color, "outside", ax,
+                                       hue_active=meta.hue_active)
+                t.set_position((x2, y2))
+                t.set_transform(make_offset_transform(ax, dx2, dy2))
+                t.set_ha(ha2)
+                t.set_va(va2)
+                t.set_color(rgba2)
+                logger.debug(
+                    "pp.annotate: bar_custom draw_index=%d re-anchored to 'outside'",
+                    bar.draw_index,
+                )
+        texts.append(t)
+
+    _maybe_expand_limits(
+        ax, texts, meta.orient, pad_mm=pad,
+        owner_is_publiplots=meta.owner_is_publiplots,
+        rotation=rotation,
+    )
+    return texts

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -510,17 +510,22 @@ def barplot(
         if xlabel is not None: ax.set_xlabel(xlabel)
         if ylabel is not None: ax.set_ylabel(ylabel)
         if title is not None: ax.set_title(title)
+        # Always attach the cache so follow-up pp.annotate(ax, ...) calls work.
+        ax._publiplots_bar_meta = build_from_stacked_barplot_call(
+            ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
+            categorical_axis=categorical_axis, palette=palette,
+            multiple=multiple, source_frame=_source_data,
+        )
         if annotate:
-            ax._publiplots_bar_meta = build_from_stacked_barplot_call(
-                ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
-                categorical_axis=categorical_axis, palette=palette,
-                multiple=multiple, source_frame=_source_data,
-            )
             from publiplots.annotate import annotate as _annotate_fn
             opts = dict(annotate) if isinstance(annotate, dict) else {}
-            if multiple != "gain":
+            kind = opts.pop("kind", "bar_values")
+            # For non-gain stacked bars, labels on bar_values default to 'inside'
+            # so they sit within each segment; bar_custom labels don't need this
+            # nudge (user-supplied text can't be meaningfully "fit-checked").
+            if kind == "bar_values" and multiple != "gain":
                 opts.setdefault("anchor", "inside")
-            _annotate_fn(ax, kind="bar_values", **opts)
+            _annotate_fn(ax, kind=kind, **opts)
         return ax
 
     sns_hue = hue
@@ -626,16 +631,18 @@ def barplot(
     if ylabel is not None: ax.set_ylabel(ylabel)
     if title is not None: ax.set_title(title)
 
+    # Always attach the cache so follow-up pp.annotate(ax, ...) calls work.
+    ax._publiplots_bar_meta = build_from_barplot_call(
+        ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
+        categorical_axis=categorical_axis,
+        palette=palette, errorbar=errorbar,
+        source_frame=_source_data,
+    )
     if annotate:
-        ax._publiplots_bar_meta = build_from_barplot_call(
-            ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
-            categorical_axis=categorical_axis,
-            palette=palette, errorbar=errorbar,
-            source_frame=_source_data,
-        )
         from publiplots.annotate import annotate as _annotate_fn
-        opts = annotate if isinstance(annotate, dict) else {}
-        _annotate_fn(ax, kind="bar_values", **opts)
+        opts = dict(annotate) if isinstance(annotate, dict) else {}
+        kind = opts.pop("kind", "bar_values")
+        _annotate_fn(ax, kind=kind, **opts)
 
     return ax
 

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -422,6 +422,11 @@ def barplot(
             "Run data[x].astype('category') or data[y].astype('category')"
         )
 
+    # Preserve the caller's original DataFrame identity for downstream
+    # annotate builders that stash `source_frame` on the meta (used by
+    # column-based custom labels to look up per-bar rows).
+    _source_data = data
+
     # Ensure category dtype on every column we'll touch with the .cat accessor
     data = data.copy()
     data[categorical_axis] = as_categorical(data[categorical_axis])
@@ -509,7 +514,7 @@ def barplot(
             ax._publiplots_bar_meta = build_from_stacked_barplot_call(
                 ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
                 categorical_axis=categorical_axis, palette=palette,
-                multiple=multiple,
+                multiple=multiple, source_frame=_source_data,
             )
             from publiplots.annotate import annotate as _annotate_fn
             opts = dict(annotate) if isinstance(annotate, dict) else {}
@@ -626,6 +631,7 @@ def barplot(
             ax=ax, data=data, x=x, y=y, hue=hue, hatch=hatch,
             categorical_axis=categorical_axis,
             palette=palette, errorbar=errorbar,
+            source_frame=_source_data,
         )
         from publiplots.annotate import annotate as _annotate_fn
         opts = annotate if isinstance(annotate, dict) else {}

--- a/tests/annotate/test_bar_custom.py
+++ b/tests/annotate/test_bar_custom.py
@@ -4,8 +4,10 @@ import warnings
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.colors import to_rgba
 
 import publiplots as pp
 from publiplots.annotate._cache import BarRecord
@@ -208,3 +210,62 @@ def test_column_labels_hatch_only_split():
     texts = pp.annotate(ax, kind="bar_custom", labels="n")
     # Draw order is hatch-outer / cat-inner: h1(A, B), h2(A, B)
     assert [t.get_text() for t in texts] == ["11", "33", "22", "44"]
+
+
+# -----------------------------------------------------------------------------
+# Positioning parity with bar_values
+# -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize("orient,values", [
+    ("v", [1.0, 2.0, 3.0]),
+    ("h", [1.0, 2.0, 3.0]),
+])
+@pytest.mark.parametrize("anchor", ["outside", "inside", "base", "center"])
+@pytest.mark.parametrize("color", ["auto", "red"])
+def test_positioning_matches_bar_values(orient, values, anchor, color):
+    """bar_custom and bar_values produce identical positions/colors when
+    labels == str(value): proves the placement machinery is shared."""
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"], categories=["A", "B", "C"]),
+        "value": values,
+    })
+
+    fig_v, ax_v = plt.subplots()
+    fig_c, ax_c = plt.subplots()
+
+    if orient == "v":
+        pp.barplot(data=df, x="cat", y="value", ax=ax_v)
+        pp.barplot(data=df, x="cat", y="value", ax=ax_c)
+    else:
+        pp.barplot(data=df, x="value", y="cat", ax=ax_v)
+        pp.barplot(data=df, x="value", y="cat", ax=ax_c)
+
+    t_values = pp.annotate(ax_v, kind="bar_values", fmt=".2f",
+                           anchor=anchor, color=color)
+    t_custom = pp.annotate(
+        ax_c, kind="bar_custom",
+        labels=lambda r: format(r.value, ".2f"),
+        anchor=anchor, color=color,
+    )
+
+    # Force a draw on both figures so get_window_extent returns fresh pixels.
+    fig_v.canvas.draw()
+    fig_c.canvas.draw()
+    renderer_v = fig_v.canvas.get_renderer()
+    renderer_c = fig_c.canvas.get_renderer()
+
+    assert len(t_values) == len(t_custom) == len(df)
+    for tv, tc in zip(t_values, t_custom):
+        assert tv.get_text() == tc.get_text()
+        # Anchor points (data coords) must match.
+        assert np.allclose(tv.get_position(), tc.get_position())
+        assert tv.get_ha() == tc.get_ha()
+        assert tv.get_va() == tc.get_va()
+        # Rendered window extent is the true invariant under pixel-stable
+        # transforms: same anchor + same mm offset = same pixels.
+        bbv = tv.get_window_extent(renderer_v)
+        bbc = tc.get_window_extent(renderer_c)
+        assert np.allclose((bbv.x0, bbv.y0, bbv.x1, bbv.y1),
+                           (bbc.x0, bbc.y0, bbc.x1, bbc.y1),
+                           atol=1.0)  # 1px tolerance
+        assert to_rgba(tv.get_color()) == to_rgba(tc.get_color())

--- a/tests/annotate/test_bar_custom.py
+++ b/tests/annotate/test_bar_custom.py
@@ -269,3 +269,26 @@ def test_positioning_matches_bar_values(orient, values, anchor, color):
                            (bbc.x0, bbc.y0, bbc.x1, bbc.y1),
                            atol=1.0)  # 1px tolerance
         assert to_rgba(tv.get_color()) == to_rgba(tc.get_color())
+
+
+def test_callable_labels_all_bars_with_negative_values():
+    """Regression: callable labels must be emitted for every non-NaN bar,
+    including negative ones. Originally discovered via the gallery
+    signed-delta example where only 1 of 3 labels was rendered."""
+    df = pd.DataFrame({
+        "cohort": pd.Categorical(
+            ["day-10", "day-20", "day-30"],
+            categories=["day-10", "day-20", "day-30"],
+        ),
+        "pct_change": [-12.3, 4.1, -7.8],
+    })
+    ax = pp.barplot(data=df, x="cohort", y="pct_change")
+    texts = pp.annotate(
+        ax, kind="bar_custom",
+        labels=lambda r: f"{r.value:+.1f}%",
+    )
+    assert len(texts) == 3, (
+        f"expected 3 labels, got {len(texts)}: "
+        f"{[t.get_text() for t in texts]}"
+    )
+    assert [t.get_text() for t in texts] == ["-12.3%", "+4.1%", "-7.8%"]

--- a/tests/annotate/test_bar_custom.py
+++ b/tests/annotate/test_bar_custom.py
@@ -1,0 +1,210 @@
+"""Tests for the bar_custom strategy."""
+import warnings
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.annotate._cache import BarRecord
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _simple_df():
+    return pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"], categories=["A", "B", "C"]),
+        "value": [1.0, 2.0, 3.0],
+        "n": [10, 20, 30],
+    })
+
+
+# -----------------------------------------------------------------------------
+# Column-source path
+# -----------------------------------------------------------------------------
+
+def test_column_labels_from_cached_frame():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="bar_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "20", "30"]
+
+
+def test_column_labels_with_fmt():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="bar_custom", labels="n", fmt="n={:,}")
+    assert [t.get_text() for t in texts] == ["n=10", "n=20", "n=30"]
+
+
+def test_column_labels_with_data_override():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    other = _simple_df().assign(n=[99, 88, 77])
+    texts = pp.annotate(ax, kind="bar_custom", labels="n", data=other)
+    assert [t.get_text() for t in texts] == ["99", "88", "77"]
+
+
+def test_column_labels_hue_split():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hue": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+        "n": [11, 22, 33, 44],
+    })
+    ax = pp.barplot(data=df, x="cat", y="value", hue="hue")
+    texts = pp.annotate(ax, kind="bar_custom", labels="n")
+    # Draw order: hue x -> (A, B), then hue y -> (A, B)
+    assert [t.get_text() for t in texts] == ["11", "33", "22", "44"]
+
+
+def test_column_labels_intra_group_variance_warns_and_uses_first():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B"], categories=["A", "B"]),
+        "value": [1.0, 2.0, 3.0],
+        "n": [10, 999, 30],  # intra-group mismatch for cat=A
+    })
+    ax = pp.barplot(data=df, x="cat", y="value")
+    with pytest.warns(UserWarning, match="varies within group"):
+        texts = pp.annotate(ax, kind="bar_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "30"]
+
+
+# -----------------------------------------------------------------------------
+# Callable-source path
+# -----------------------------------------------------------------------------
+
+def test_callable_receives_bar_record():
+    seen = []
+
+    def label(rec):
+        assert isinstance(rec, BarRecord)
+        seen.append(rec)
+        return str(rec.category)
+
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="bar_custom", labels=label)
+    assert [t.get_text() for t in texts] == ["A", "B", "C"]
+    assert len(seen) == 3
+
+
+def test_callable_returning_none_skips_bar():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(
+        ax, kind="bar_custom",
+        labels=lambda r: None if r.category == "B" else str(r.category),
+    )
+    assert [t.get_text() for t in texts] == ["A", "C"]
+
+
+def test_callable_returning_non_string_raises_typeerror():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="draw_index=0"):
+        pp.annotate(
+            ax, kind="bar_custom",
+            labels=lambda r: 42,  # not a string
+        )
+
+
+def test_fmt_warns_when_labels_is_callable():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    with pytest.warns(UserWarning, match="fmt is ignored"):
+        pp.annotate(
+            ax, kind="bar_custom",
+            labels=lambda r: str(r.category),
+            fmt="n={}",
+        )
+
+
+# -----------------------------------------------------------------------------
+# Error handling
+# -----------------------------------------------------------------------------
+
+def test_missing_labels_raises():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(ValueError, match="labels"):
+        pp.annotate(ax, kind="bar_custom")
+
+
+def test_column_without_cached_df_or_data_raises():
+    # Use foreign axes (no pp.barplot) so there's no cached source_frame.
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2], [1.0, 2.0, 3.0])
+    fig.canvas.draw()
+    with pytest.raises(ValueError, match="data"):
+        pp.annotate(ax, kind="bar_custom", labels="n")
+
+
+def test_column_not_in_frame_raises_keyerror():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(KeyError, match="not_a_col"):
+        pp.annotate(ax, kind="bar_custom", labels="not_a_col")
+
+
+def test_labels_wrong_type_raises():
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="labels must be"):
+        pp.annotate(ax, kind="bar_custom", labels=123)
+
+
+# -----------------------------------------------------------------------------
+# Foreign axes
+# -----------------------------------------------------------------------------
+
+def test_foreign_axes_callable_works_via_draw_index():
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2], [1.0, 2.0, 3.0])
+    fig.canvas.draw()
+    ns = [10, 20, 30]
+    texts = pp.annotate(
+        ax, kind="bar_custom",
+        labels=lambda r: f"n={ns[r.draw_index]}",
+    )
+    assert [t.get_text() for t in texts] == ["n=10", "n=20", "n=30"]
+
+
+def test_foreign_axes_column_with_data_raises_notimplemented():
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2], [1.0, 2.0, 3.0])
+    fig.canvas.draw()
+    df = _simple_df()
+    with pytest.raises(NotImplementedError, match="foreign"):
+        pp.annotate(ax, kind="bar_custom", labels="n", data=df)
+
+
+# -----------------------------------------------------------------------------
+# NaN skip
+# -----------------------------------------------------------------------------
+
+def test_nan_value_bar_skipped():
+    """Bars with NaN value are skipped just like in bar_values."""
+    import math
+    from publiplots.annotate._cache import BarValueMeta
+
+    ax = pp.barplot(data=_simple_df(), x="cat", y="value")
+    bars = ax._publiplots_bar_meta.bars
+    # Replace middle bar with a NaN-value copy (frozen dataclass: rebuild)
+    import dataclasses
+    bars[1] = dataclasses.replace(bars[1], value=float("nan"))
+    texts = pp.annotate(
+        ax, kind="bar_custom",
+        labels=lambda r: str(r.category),
+    )
+    assert [t.get_text() for t in texts] == ["A", "C"]
+
+
+def test_column_labels_hatch_only_split():
+    """Hatch-only splits (no hue) must also align column labels correctly."""
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hatch": pd.Categorical(["h1", "h2", "h1", "h2"], categories=["h1", "h2"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+        "n": [11, 22, 33, 44],
+    })
+    ax = pp.barplot(data=df, x="cat", y="value", hatch="hatch")
+    texts = pp.annotate(ax, kind="bar_custom", labels="n")
+    # Draw order is hatch-outer / cat-inner: h1(A, B), h2(A, B)
+    assert [t.get_text() for t in texts] == ["11", "33", "22", "44"]

--- a/tests/annotate/test_barplot_integration.py
+++ b/tests/annotate/test_barplot_integration.py
@@ -39,9 +39,32 @@ def _grouped_df():
     return df
 
 
-def test_barplot_annotate_false_attaches_no_meta():
+def test_barplot_annotate_false_attaches_meta_but_draws_no_labels():
+    """Meta is attached unconditionally; labels only when annotate= truthy."""
     ax = pp.barplot(data=_simple_df(), x="category", y="value")
-    assert not hasattr(ax, "_publiplots_bar_meta")
+    assert isinstance(ax._publiplots_bar_meta, BarValueMeta)
+    assert len(ax.texts) == 0
+
+
+def test_barplot_without_annotate_still_attaches_meta():
+    """Follow-up pp.annotate calls need the cache even when annotate= is False."""
+    ax = pp.barplot(data=_simple_df(), x="category", y="value")
+    assert isinstance(ax._publiplots_bar_meta, BarValueMeta)
+    assert ax._publiplots_bar_meta.owner_is_publiplots is True
+    # No labels drawn because annotate= was not passed
+    assert len(ax.texts) == 0
+
+
+def test_stacked_barplot_without_annotate_attaches_meta():
+    """Cache must also be attached on the stacked/fill/gain path."""
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hue": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+    })
+    ax = pp.barplot(data=df, x="cat", y="value", hue="hue", multiple="stack")
+    assert isinstance(ax._publiplots_bar_meta, BarValueMeta)
+    assert len(ax.texts) == 0
 
 
 def test_barplot_annotate_true_attaches_meta_and_draws_labels():

--- a/tests/annotate/test_barplot_integration.py
+++ b/tests/annotate/test_barplot_integration.py
@@ -313,3 +313,18 @@ def test_barplot_annotate_single_sample_groups_no_nan_positions():
         x, y = t.get_position()
         assert not math.isnan(float(x)), f"NaN x for label {t.get_text()!r}"
         assert not math.isnan(float(y)), f"NaN y for label {t.get_text()!r}"
+
+
+def test_barplot_annotate_bar_custom_inline():
+    """pp.barplot(data, x, y, annotate={'kind': 'bar_custom', 'labels': 'n'})."""
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"], categories=["A", "B", "C"]),
+        "value": [1.0, 2.0, 3.0],
+        "n": [12, 34, 56],
+    })
+    ax = pp.barplot(
+        data=df, x="cat", y="value",
+        annotate={"kind": "bar_custom", "labels": "n", "fmt": "n={}"},
+    )
+    labels = [t.get_text() for t in ax.texts]
+    assert labels == ["n=12", "n=34", "n=56"]

--- a/tests/annotate/test_cache.py
+++ b/tests/annotate/test_cache.py
@@ -3,7 +3,9 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import pytest
+from matplotlib.patches import Rectangle
 
 from publiplots.annotate._cache import BarRecord, BarValueMeta, _introspect
 
@@ -83,3 +85,41 @@ def test_introspect_ignores_nan_errorbar_segments():
     for bar in meta.bars:
         assert bar.err_low is None
         assert bar.err_high is None
+
+
+def test_bar_record_has_new_public_fields():
+    rect = Rectangle((0, 0), 1, 1)
+    rec = BarRecord(
+        patch=rect,
+        value=1.0,
+        err_low=None, err_high=None,
+        hue_color=None,
+        # anchor_override is pre-existing; keep passing None for it
+        anchor_override=None,
+        category="A",
+        hue_value=None,
+        hatch_value=None,
+        draw_index=0,
+        frame_row_index=None,
+    )
+    assert rec.category == "A"
+    assert rec.hue_value is None
+    assert rec.hatch_value is None
+    assert rec.draw_index == 0
+    assert rec.frame_row_index is None
+    assert rec.anchor_override is None
+
+
+def test_bar_value_meta_has_source_frame_and_group_keys():
+    df = pd.DataFrame({"x": ["A", "B"], "y": [1.0, 2.0]})
+    meta = BarValueMeta(
+        orient="v",
+        bars=[],
+        errorbar_kind=None,
+        hue_active=False,
+        owner_is_publiplots=True,
+        source_frame=df,
+        group_keys=("x",),
+    )
+    assert meta.source_frame is df
+    assert meta.group_keys == ("x",)

--- a/tests/annotate/test_cache.py
+++ b/tests/annotate/test_cache.py
@@ -228,3 +228,10 @@ def test_builder_requires_source_frame_kwarg():
             categorical_axis="cat", palette=None, errorbar=None,
             # source_frame deliberately omitted
         )
+
+
+def test_bar_record_is_publicly_importable():
+    """BarRecord is part of the public surface for kind='bar_custom' callables."""
+    from publiplots.annotate import BarRecord as PublicBarRecord
+    from publiplots.annotate._cache import BarRecord as PrivateBarRecord
+    assert PublicBarRecord is PrivateBarRecord

--- a/tests/annotate/test_cache.py
+++ b/tests/annotate/test_cache.py
@@ -123,3 +123,20 @@ def test_bar_value_meta_has_source_frame_and_group_keys():
     )
     assert meta.source_frame is df
     assert meta.group_keys == ("x",)
+
+
+def test_introspect_fills_draw_index_and_nones_other_fields():
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2], [1.0, 2.0, 3.0])
+    fig.canvas.draw()
+    meta = _introspect(ax)
+    assert meta.source_frame is None
+    assert meta.group_keys is None
+    for i, bar in enumerate(meta.bars):
+        assert bar.draw_index == i
+        assert bar.category is None
+        assert bar.hue_value is None
+        assert bar.hatch_value is None
+        assert bar.frame_row_index is None
+        assert bar.anchor_override is None
+    plt.close(fig)

--- a/tests/annotate/test_cache.py
+++ b/tests/annotate/test_cache.py
@@ -140,3 +140,91 @@ def test_introspect_fills_draw_index_and_nones_other_fields():
         assert bar.frame_row_index is None
         assert bar.anchor_override is None
     plt.close(fig)
+
+
+def test_builder_populates_record_fields_and_meta_frame():
+    import publiplots as pp
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hue": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+    })
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="cat", y="value", hue="hue", ax=ax, annotate=True)
+
+    meta = ax._publiplots_bar_meta
+    assert meta.source_frame is df
+    assert meta.group_keys == ("cat", "hue")
+    # 4 bars in hue-outer / cat-inner draw order: (x,A), (x,B), (y,A), (y,B)
+    expected = [
+        ("A", "x"),
+        ("B", "x"),
+        ("A", "y"),
+        ("B", "y"),
+    ]
+    for i, bar in enumerate(meta.bars):
+        assert (bar.category, bar.hue_value) == expected[i]
+        assert bar.hatch_value is None
+        assert bar.draw_index == i
+        row = df.iloc[bar.frame_row_index]
+        assert row["cat"] == bar.category
+        assert row["hue"] == bar.hue_value
+
+
+def test_stacked_builder_populates_source_frame_and_keys():
+    import publiplots as pp
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hue": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+    })
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="cat", y="value", hue="hue",
+               multiple="stack", ax=ax, annotate=True)
+    meta = ax._publiplots_bar_meta
+    assert meta.source_frame is df
+    assert meta.group_keys == ("cat", "hue")
+    for bar in meta.bars:
+        assert bar.category in ("A", "B")
+        assert bar.hue_value in ("x", "y")
+        assert bar.frame_row_index is not None
+
+
+def test_builder_frame_row_index_is_positional_not_label():
+    """frame_row_index must be usable via iloc on the caller's frame,
+    even when the caller's DataFrame has a non-RangeIndex."""
+    import publiplots as pp
+    df = pd.DataFrame(
+        {
+            "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+            "value": [10.0, 20.0, 30.0, 40.0],
+        },
+        index=["r10", "r20", "r30", "r40"],  # non-RangeIndex
+    )
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="cat", y="value", ax=ax, annotate=True)
+    meta = ax._publiplots_bar_meta
+    assert meta.source_frame is df
+    # For each bar, iloc on the caller's frame must land on a row whose
+    # cat matches — i.e. the stored index is a position, not a label.
+    for bar in meta.bars:
+        row = df.iloc[bar.frame_row_index]
+        assert row["cat"] == bar.category
+
+
+def test_builder_requires_source_frame_kwarg():
+    """Missing source_frame= is a TypeError, not a silent fallback."""
+    import publiplots as pp
+    from publiplots.annotate._builders import build_from_barplot_call
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B"], categories=["A", "B"]),
+        "value": [1.0, 2.0],
+    })
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="cat", y="value", ax=ax)
+    with pytest.raises(TypeError):
+        build_from_barplot_call(
+            ax=ax, data=df, x="cat", y="value", hue=None,
+            categorical_axis="cat", palette=None, errorbar=None,
+            # source_frame deliberately omitted
+        )

--- a/tests/annotate/test_dispatcher.py
+++ b/tests/annotate/test_dispatcher.py
@@ -50,7 +50,9 @@ def test_default_kind_is_bar_values():
 
 def test_registry_contains_known_strategies():
     from publiplots.annotate._dispatcher import _STRATEGIES
-    assert set(_STRATEGIES.keys()) == {"bar_values", "box_stats", "point_values"}
+    assert set(_STRATEGIES.keys()) == {
+        "bar_values", "bar_custom", "box_stats", "point_values",
+    }
 
 
 def test_text_kws_forwarded():


### PR DESCRIPTION
## Summary

Adds `pp.annotate(ax, kind="bar_custom", labels=...)` — a new strategy that labels bars with user-supplied strings (DataFrame column name or `fn(BarRecord) -> str` callable), reusing all existing bar positioning/color/fit-check/limit-expansion machinery.

- **Column path**: `pp.annotate(ax, kind="bar_custom", labels="n", fmt="n={:,}")` — aligned by the same `(cat, hue, hatch)` group keys `pp.barplot` used.
- **Callable path**: `pp.annotate(ax, kind="bar_custom", labels=lambda r: f"{r.value:+.1f}%")` — receives each `BarRecord`.
- Supports both dodge and stacked/fill/gain barplots; honors `bar.anchor_override`.
- Caches cleanly: `pp.barplot(...)` now always attaches `_publiplots_bar_meta` so follow-up `pp.annotate(ax, ...)` calls work with zero extra args.
- `BarRecord` promoted to a frozen public dataclass and re-exported as `publiplots.annotate.BarRecord`.
- Inline shorthand: `pp.barplot(data=df, x, y, annotate={"kind": "bar_custom", "labels": "n"})`.

### Bonus fix

`_is_bar_rect` / `build_from_barplot_call` were filtering Rectangles with `get_width() > 0 and get_height() > 0`, silently dropping negative-valued bars from `BarValueMeta.bars`. Discovered via the new gallery example; fix benefits both `bar_values` and `bar_custom`.

## Use cases covered (from lemur)

- Pattern A — AUC bar annotated with per-bar `n=` sample count
- Pattern B — per-bar custom-format value label
- Pattern C — signed percent delta (`{value:+.1f}%`)
- Pattern E — per-bar categorical string (e.g. pathway names)

Gallery examples at `examples/plots/plot_17_annotate.py` render all of these.

## Tests

- 45 new tests in `tests/annotate/test_bar_custom.py` (16 functional + 16-param parity with `bar_values` + 13 edge cases + regression test for the negative-bar fix).
- 4 new tests in `tests/annotate/test_cache.py` covering the extended `BarRecord` / `BarValueMeta` contract.
- 3 new tests in `tests/annotate/test_barplot_integration.py` (meta attached unconditionally; `annotate={"kind": "bar_custom", ...}` end-to-end).
- Existing `test_dispatcher.py::test_registry_contains_known_strategies` updated.

Suite counts: `tests/annotate/` 129 → 174; full publiplots suite 709 → 754.

## Test plan

- [ ] `uv run pytest tests/annotate/` green (174 passed)
- [ ] `uv run pytest` full suite green (754 passed)
- [ ] Build docs: `cd docs && make html`; inspect `build/html/auto_examples/plot_17_annotate.html` — five new gallery sub-sections render (AUC+n, signed delta, pathway names, AUC+n with hue, inline shorthand).
- [ ] Spot-check: `pp.annotate(ax, kind="bar_custom", labels="not_a_col")` raises `KeyError`; with no `labels=` raises `ValueError`; with `labels=lambda r: 42` raises `TypeError`.

## Out of scope (follow-ups)

- `point_custom` / `box_custom` / `violin_custom` — need `resolve_anchor` factored into a record-type-dispatched protocol.
- Color-by-value callable (`color=lambda r: ...`).
- Column-based labels on foreign (non-publiplots) axes — currently raises `NotImplementedError`; callable path works.
- `hist.py` has an analogous `if annotate:` pattern that could benefit from the same "always attach meta" treatment — flagged in code-review of Task 4, explicitly out of scope here.