### PR TITLE
chore(release): v0.10.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.10] - 2026-05-12
+
+### Added
+
+- `pp.hexbinplot` — new bivariate 2D-density plot. Aggregates an
+  `(x, y)` point cloud into a hexagonal grid and colors each cell by
+  count (default) or by a user-supplied reduction of a third column
+  (`C=` + `reduce_C_function=`). Supports `bins="log"` for heavy-tailed
+  densities and `mincnt=` to hide sparse cells (PR #141).
+  - Sits in the plot surface as the 2D sibling of `pp.histplot`. Reach
+    for it when scatter is too dense to read as points.
+  - Legend integrates with the shared reactor: one continuous-hue
+    `ScalarMappable` stashed via `stash_continuous_hue`, so
+    `pp.legend(side=...)`, `legend_kws={"inside": True}`, and figure-
+    level bands all work without plot-specific legend code.
+  - `alpha` defaults to `1.0` (literal, not `rcParams["alpha"]=0.1`):
+    hex cells are solid density patches, not layered markers, so the
+    scatter-tuned rcParams default would wash them out.
+  - `gridsize=30` default (matplotlib's 100 is too fine at publiplots'
+    mm-sized axes); `cmap=None` falls back to
+    `matplotlib.rcParams["image.cmap"]`; `edgecolor=None` coerces to
+    `"none"` (stroking thousands of cells rarely reads well).
+
+### Changed
+
+- Gallery reorganized: `plot_03_hexbinplot.py` inserted right after
+  `plot_02_histogram.py` so 1D and 2D density sit together. Existing
+  `plot_03` through `plot_18` renumbered to `plot_04` through
+  `plot_19`. Four intra-gallery cross-references to
+  `plot_17_annotate` updated to `plot_18_annotate`.
+
 ## [0.10.9] - 2026-05-11
 
 ### Added
@@ -222,6 +253,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
   the title correctly regardless (PR #128).
 
+[0.10.10]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.10
 [0.10.9]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.9
 [0.10.8]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.8
 [0.10.7]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.9"
+version = "0.10.10"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.9"
+__version__ = "0.10.10"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.9"
+version = "0.10.10"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` → `[0.10.10]` in CHANGELOG with the new `pp.hexbinplot` plot primitive and the gallery reorg from #141.
- Bumps `pyproject.toml`, `src/publiplots/__init__.py`, and `.claude-plugin/plugin.json` from `0.10.9` → `0.10.10`.
- Regenerates `uv.lock`.

## Release notes

**Added**
- `pp.hexbinplot` — bivariate 2D hexagonal density plot. `C=` + `reduce_C_function=` for arbitrary reductions, `bins="log"` for heavy-tailed data, `mincnt=` to hide sparse cells. Colorbar integrates with the shared legend reactor automatically.

**Changed**
- Gallery reorganized: `plot_03_hexbinplot.py` inserted right after `plot_02_histogram.py` so 1D and 2D density sit together. Existing `plot_03..plot_18` renumbered to `plot_04..plot_19`.

## Test plan

- [x] `uv lock` resolves cleanly; `publiplots v0.10.9 -> v0.10.10`.
- [x] `python -c "import publiplots; print(publiplots.__version__)"` → `0.10.10`; `pp.hexbinplot` importable.
- [x] Matches the shape of prior release PRs (`#139` v0.10.9, `#136` v0.10.8) — same 5 files, same sections.
- [ ] On merge: tag `v0.10.10` on main, publish GitHub release pointing at the new CHANGELOG anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)