### PR TITLE
feat(annotate): point/box/violin custom-text strategies

### DIFF
--- a/examples/plots/plot_18_annotate.py
+++ b/examples/plots/plot_18_annotate.py
@@ -372,3 +372,79 @@ ax = pp.barplot(
     title="inline: annotate={'kind': 'bar_custom', 'labels': 'n', ...}",
 )
 pp.show()
+
+# %%
+# ``kind="point_custom"``: per-point column labels
+# ================================================
+#
+# Same ``labels=(column|callable)`` contract as ``bar_custom``, but for
+# ``pp.pointplot``. Label each point with a sibling column (here,
+# sample count) aligned by the same ``(x, hue)`` group keys that
+# ``pp.pointplot`` used.
+point_df = pd.DataFrame({
+    "group": pd.Categorical(
+        ["A", "B", "C", "D"], categories=["A", "B", "C", "D"],
+    ),
+    "auc": [0.62, 0.71, 0.83, 0.79],
+    "n":   [120, 145, 98, 87],
+})
+ax = pp.pointplot(data=point_df, x="group", y="auc",
+                   title="pointplot annotated with n=")
+pp.annotate(ax, kind="point_custom", labels="n", fmt="n={:,}",
+            anchor="top")
+pp.show()
+
+# %%
+# ``kind="box_custom"``: per-box callable labels
+# ==============================================
+#
+# ``labels=`` accepts a callable ``(BoxStatsRecord) -> str``. Use
+# ``record.stats`` to read any of the six statistics on the fly
+# (median, q1, q3, whisker_low, whisker_high, mean) — here, the
+# IQR alongside the group position.
+box_df = pd.DataFrame({
+    "group": pd.Categorical(
+        (["A"] * 20 + ["B"] * 20 + ["C"] * 20),
+        categories=["A", "B", "C"],
+    ),
+    "score": (
+        list(0.6 + 0.01 * i for i in range(20))
+        + list(0.5 + 0.012 * i for i in range(20))
+        + list(0.8 + 0.008 * i for i in range(20))
+    ),
+})
+ax = pp.boxplot(data=box_df, x="group", y="score",
+                 title="boxplot with IQR annotations")
+pp.annotate(
+    ax, kind="box_custom",
+    labels=lambda r: f"IQR {r.stats['q3'] - r.stats['q1']:.2f}",
+    anchor="right",
+)
+pp.show()
+
+# %%
+# ``kind="violin_custom"``: per-violin inline annotation
+# ======================================================
+#
+# ``pp.violinplot(annotate={"kind": "violin_custom", ...})`` dispatches
+# to ``violin_custom`` without a follow-up ``pp.annotate`` call. Use
+# the inline form for one-shot figures; reach for the two-call form
+# when you want to compose multiple annotation layers.
+violin_df = pd.DataFrame({
+    "group": pd.Categorical(
+        (["A"] * 30 + ["B"] * 30 + ["C"] * 30),
+        categories=["A", "B", "C"],
+    ),
+    "score": (
+        list(0.6 + 0.011 * i for i in range(30))
+        + list(0.5 + 0.013 * i for i in range(30))
+        + list(0.8 + 0.009 * i for i in range(30))
+    ),
+    "n": [30] * 30 + [30] * 30 + [30] * 30,
+})
+ax = pp.violinplot(
+    data=violin_df, x="group", y="score",
+    annotate={"kind": "violin_custom", "labels": "n", "fmt": "n={}"},
+    title="violinplot inline: annotate={'kind': 'violin_custom', ...}",
+)
+pp.show()

--- a/src/publiplots/annotate/__init__.py
+++ b/src/publiplots/annotate/__init__.py
@@ -3,12 +3,13 @@
 Public surface:
     - annotate: the strategy-dispatching entry point.
     - BarRecord: the per-bar record passed to `kind="bar_custom"` callables.
+    - BoxStatsRecord: the per-box record passed to `kind="box_custom"` callables.
     - PointRecord: the per-point record passed to `kind="point_custom"` callables.
 
 All other modules are internal and subject to change; do not import from
 them directly.
 """
-from publiplots.annotate._cache import BarRecord, PointRecord
+from publiplots.annotate._cache import BarRecord, BoxStatsRecord, PointRecord
 from publiplots.annotate._dispatcher import annotate
 
-__all__ = ["annotate", "BarRecord", "PointRecord"]
+__all__ = ["annotate", "BarRecord", "BoxStatsRecord", "PointRecord"]

--- a/src/publiplots/annotate/__init__.py
+++ b/src/publiplots/annotate/__init__.py
@@ -3,11 +3,12 @@
 Public surface:
     - annotate: the strategy-dispatching entry point.
     - BarRecord: the per-bar record passed to `kind="bar_custom"` callables.
+    - PointRecord: the per-point record passed to `kind="point_custom"` callables.
 
 All other modules are internal and subject to change; do not import from
 them directly.
 """
-from publiplots.annotate._cache import BarRecord
+from publiplots.annotate._cache import BarRecord, PointRecord
 from publiplots.annotate._dispatcher import annotate
 
-__all__ = ["annotate", "BarRecord"]
+__all__ = ["annotate", "BarRecord", "PointRecord"]

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -145,12 +145,14 @@ def build_from_pointplot_call(
     categorical_axis: str,
     palette: Optional[Dict],
     errorbar: Optional[str],
+    *,
+    source_frame,
 ) -> PointValueMeta:
     """Build a `PointValueMeta` paired with the pointplot's marker positions.
 
-    Iteration uses the shared `BarSplitSpec` so hue/categorical-axis
-    collapse rules match barplot. Errorbar extents are pulled from the
-    drawn errorbar Line2D segments via `_match_point_errorbars`.
+    ``source_frame`` is a required keyword-only: must be the caller's
+    pre-copy DataFrame so ``meta.source_frame is df`` holds and
+    ``source_frame.iloc[record.frame_row_index]`` resolves correctly.
     """
     spec = BarSplitSpec.resolve(
         x=x, y=y, hue=hue, hatch=None, categorical_axis=categorical_axis,
@@ -161,7 +163,7 @@ def build_from_pointplot_call(
     value_col = y if categorical_axis == x else x
 
     points_xy: List[Tuple[float, float]] = []
-    hue_values_for_points: List = []
+    aggregated: List[Dict] = []
     for cat, h_val, _ht_val in spec.iter_draw_order(data):
         mask = data[categorical_axis] == cat
         if spec.split_hue is not None:
@@ -172,19 +174,33 @@ def build_from_pointplot_call(
         pos = cat_to_pos[cat]
         mean = float(np.mean(vals))
         points_xy.append((pos, mean) if orient == "v" else (mean, pos))
-        hue_values_for_points.append(h_val)
+        matching_labels = data.index[mask]
+        frame_row_index: Optional[int] = None
+        if source_frame is not None and len(matching_labels):
+            try:
+                frame_row_index = int(
+                    source_frame.index.get_loc(matching_labels[0])
+                )
+            except (KeyError, TypeError):
+                frame_row_index = None
+        aggregated.append({
+            "category": cat,
+            "hue_value": h_val,
+            "frame_row_index": frame_row_index,
+        })
 
     # Tolerance on the categorical axis: 0.5 is conservative (integer positions)
     tol = 0.5
     err_by_point = _match_point_errorbars(ax, points_xy, orient, tol)
 
     points: List[PointRecord] = []
-    for (xy, hue_value, (err_low, err_high)) in zip(
-        points_xy, hue_values_for_points, err_by_point
+    for i, (xy, row, (err_low, err_high)) in enumerate(
+        zip(points_xy, aggregated, err_by_point)
     ):
         hue_color = None
-        if hue_value is not None and palette is not None and hue_value in palette:
-            hue_color = to_rgba(palette[hue_value])
+        hv = row["hue_value"]
+        if hv is not None and palette is not None and hv in palette:
+            hue_color = to_rgba(palette[hv])
         value = xy[1] if orient == "v" else xy[0]
         points.append(PointRecord(
             xy=xy,
@@ -192,13 +208,28 @@ def build_from_pointplot_call(
             err_low=err_low,
             err_high=err_high,
             hue_color=hue_color,
+            category=row["category"],
+            hue_value=row["hue_value"],
+            hatch_value=None,
+            draw_index=i,
+            frame_row_index=row["frame_row_index"],
         ))
+
+    keys: List[str] = [categorical_axis]
+    dims: List[str] = ["cat"]
+    if spec.split_hue is not None:
+        keys.append(spec.split_hue)
+        dims.append("hue")
+
     return PointValueMeta(
         orient=orient,
         points=points,
         errorbar_kind=errorbar if isinstance(errorbar, str) else None,
         hue_active=spec.split_hue is not None,
         owner_is_publiplots=True,
+        source_frame=source_frame,
+        group_keys=tuple(keys),
+        group_dims=tuple(dims),
     )
 
 
@@ -504,10 +535,20 @@ def _aggregate_box_stats(
     hue: Optional[str],
     categorical_axis: str,
     whis: float,
+    *,
+    source_frame,
 ) -> List[Dict]:
     """Group by (categorical_axis [, hue]) and compute box stats per group.
 
     Row ordering matches seaborn's dodge draw order: hue-outer, cat-inner.
+
+    Each row carries its draw-order ``category`` / ``hue_value`` /
+    ``hatch_value`` (boxes don't dodge on hatch, always ``None``) plus
+    ``frame_row_index``: a *position* (integer offset) into
+    ``source_frame``, not a pandas label, so
+    ``source_frame.iloc[frame_row_index]`` resolves the caller's row for
+    any index kind. When ``source_frame`` is ``None`` or the label does
+    not map (rare), ``frame_row_index`` is ``None``.
     """
     value_col = y if categorical_axis == x else x
     spec = BarSplitSpec.resolve(
@@ -523,9 +564,18 @@ def _aggregate_box_stats(
         if len(vals) == 0:
             continue
         stats = _compute_box_stats(vals, whis)
-        stats["cat"] = cat
-        if h_val is not None:
-            stats["hue_value"] = h_val
+        # Position within source_frame of the first row matching this group.
+        matching = data.index[mask]
+        frame_row_index: Optional[int] = None
+        if source_frame is not None and len(matching):
+            try:
+                frame_row_index = int(source_frame.index.get_loc(matching[0]))
+            except (KeyError, TypeError):
+                frame_row_index = None
+        stats["category"] = cat
+        stats["hue_value"] = h_val
+        stats["hatch_value"] = None
+        stats["frame_row_index"] = frame_row_index
         rows.append(stats)
     return rows
 
@@ -565,23 +615,32 @@ def _build_box_stats_meta(
     palette: Optional[Dict],
     whis: float,
     artists: List,
+    *,
+    source_frame,
 ) -> BoxStatsMeta:
     """Shared builder for pp.boxplot / pp.violinplot.
 
     Stats are computed from raw data (exact, matching seaborn's whis rule
     for boxplot; violinplot shows the same underlying stats). Categorical
     positions come from the drawn artists so dodge groupings are honored.
+
+    ``source_frame`` is required keyword-only: the caller's pre-copy
+    DataFrame. The returned meta carries it so downstream annotate
+    strategies can look up per-box source rows.
     """
     orient = "v" if categorical_axis == x else "h"
-    agg = _aggregate_box_stats(data, x=x, y=y, hue=hue,
-                               categorical_axis=categorical_axis, whis=whis)
+    agg = _aggregate_box_stats(
+        data, x=x, y=y, hue=hue,
+        categorical_axis=categorical_axis, whis=whis,
+        source_frame=source_frame,
+    )
     if len(artists) != len(agg):
         n = min(len(artists), len(agg))
         artists = artists[:n]
         agg = agg[:n]
 
     boxes: List[BoxStatsRecord] = []
-    for artist, row in zip(artists, agg):
+    for i, (artist, row) in enumerate(zip(artists, agg)):
         center_pos, cat_half_width = _cat_extents_from_artist(artist, ax, orient)
         hue_color = None
         if hue is not None and palette is not None:
@@ -595,12 +654,30 @@ def _build_box_stats_meta(
             cat_half_width=cat_half_width,
             stats={k: v for k, v in row.items() if k in VALID_BOX_STATS},
             hue_color=hue_color,
+            category=row["category"],
+            hue_value=row["hue_value"],
+            hatch_value=row["hatch_value"],
+            draw_index=i,
+            frame_row_index=row["frame_row_index"],
         ))
+
+    spec = BarSplitSpec.resolve(
+        x=x, y=y, hue=hue, hatch=None, categorical_axis=categorical_axis,
+    )
+    keys: List[str] = [categorical_axis]
+    dims: List[str] = ["cat"]
+    if spec.split_hue is not None:
+        keys.append(spec.split_hue)
+        dims.append("hue")
+
     return BoxStatsMeta(
         orient=orient,
         boxes=boxes,
         hue_active=hue is not None,
         owner_is_publiplots=True,
+        source_frame=source_frame,
+        group_keys=tuple(keys),
+        group_dims=tuple(dims),
     )
 
 
@@ -613,11 +690,17 @@ def build_from_boxplot_call(
     categorical_axis: str,
     palette: Optional[Dict],
     whis: float,
+    *,
+    source_frame,
 ) -> BoxStatsMeta:
-    """Build a BoxStatsMeta paired with the boxplot's PathPatches."""
+    """Build a BoxStatsMeta paired with the boxplot's PathPatches.
+
+    ``source_frame`` is required keyword-only; see ``_build_box_stats_meta``.
+    """
     patches = [p for p in ax.patches if isinstance(p, PathPatch)]
     return _build_box_stats_meta(
         ax, data, x, y, hue, categorical_axis, palette, whis, patches,
+        source_frame=source_frame,
     )
 
 
@@ -630,14 +713,19 @@ def build_from_violinplot_call(
     categorical_axis: str,
     palette: Optional[Dict],
     whis: float = 1.5,
+    *,
+    source_frame,
 ) -> BoxStatsMeta:
     """Build a BoxStatsMeta paired with the violinplot's fill collections.
 
     Violin draws one FillBetweenPolyCollection per violin; stats are the
     same as for boxplot (computed from raw data with matching whis rule).
+
+    ``source_frame`` is required keyword-only; see ``_build_box_stats_meta``.
     """
     from matplotlib.collections import PolyCollection
     artists = [c for c in ax.collections if isinstance(c, PolyCollection)]
     return _build_box_stats_meta(
         ax, data, x, y, hue, categorical_axis, palette, whis, artists,
+        source_frame=source_frame,
     )

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -65,45 +65,73 @@ class BarValueMeta:
     group_dims: Optional[Tuple[str, ...]] = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class PointRecord:
     """A single point's anchor + aggregated value + errorbar extents.
 
     Unlike BarRecord, a point has no matplotlib artist for the *mark itself*
     (seaborn merges all points of one hue into a single Line2D). We track
     the data-coord position directly and the palette color that was used.
+
+    Fields:
+        xy: (x, y) in data coords; y is the value for orient="v".
+        value: aggregated estimate (mean/median); NaN-possible.
+        err_low, err_high: errorbar extents on the value axis, if present.
+        hue_color: palette color assigned by pointplot.
+        category: x-axis group key (None on foreign axes).
+        hue_value: hue group key if hue is active (else None).
+        hatch_value: hatch group key if hatch is active (else None). Points
+            don't dodge on hatch today, so this is always None; the field
+            exists for shape-symmetry with BarRecord.
+        draw_index: 0-based position in the draw order.
+        frame_row_index: position of the first matching source-DataFrame row.
     """
-    xy: Tuple[float, float]                # (x, y) in data coords; y is the value for orient="v"
-    value: float                           # aggregated estimate (mean/median)
-    err_low: Optional[float]               # lower errorbar extent on the value axis
-    err_high: Optional[float]              # upper errorbar extent on the value axis
-    hue_color: Optional[RGBA]              # palette color assigned by pointplot
+    xy: Tuple[float, float]
+    value: float
+    err_low: Optional[float]
+    err_high: Optional[float]
+    hue_color: Optional[RGBA]
+    category: Optional[Hashable] = None
+    hue_value: Optional[Hashable] = None
+    hatch_value: Optional[Hashable] = None
+    draw_index: int = 0
+    frame_row_index: Optional[int] = None
 
 
 @dataclass
 class PointValueMeta:
-    orient: Literal["v", "h"]              # "v" = value on y-axis (common pointplot)
+    orient: Literal["v", "h"]
     points: List[PointRecord]
     errorbar_kind: Optional[str]
     hue_active: bool
     owner_is_publiplots: bool
+    source_frame: Optional[Any] = None
+    group_keys: Optional[Tuple[str, ...]] = None
+    group_dims: Optional[Tuple[str, ...]] = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class BoxStatsRecord:
-    """Statistics computed for a single box.
+    """Statistics computed for a single box. Same field set as PointRecord
+    plus box-specific center_pos / cat_half_width / stats dict.
 
-    `center_pos` is the categorical-axis coordinate of the box's center
-    (e.g. x for orient="v"). `cat_half_width` is the half-extent of the
-    drawn artist on the same axis (in data coords) — used by the strategy
-    to place `left`/`right`-anchored labels just past the box edge.
-    `stats` is a dict mapping stat name to its value-axis coordinate,
-    populated only for the stats the caller asked to label.
+    Fields:
+        center_pos: categorical-axis coordinate of the box's center.
+        cat_half_width: half-extent on the categorical axis in data coords.
+        stats: dict mapping stat name to its value-axis coordinate.
+        hue_color: palette color assigned by boxplot/violinplot.
+        category/hue_value/hatch_value/draw_index/frame_row_index: same
+            semantics as in BarRecord; populated by the builder.
     """
-    center_pos: float                           # x for orient="v", y for "h"
-    cat_half_width: float                       # half-width on categorical axis (data coords)
-    stats: dict                                 # {"median": y, "q1": y, ...}
+    center_pos: float
+    cat_half_width: float
+    stats: dict
     hue_color: Optional[RGBA]
+    category: Optional[Hashable] = None
+    hue_value: Optional[Hashable] = None
+    hatch_value: Optional[Hashable] = None
+    draw_index: int = 0
+    frame_row_index: Optional[int] = None
 
 
 @dataclass
@@ -112,6 +140,9 @@ class BoxStatsMeta:
     boxes: List[BoxStatsRecord]
     hue_active: bool
     owner_is_publiplots: bool
+    source_frame: Optional[Any] = None
+    group_keys: Optional[Tuple[str, ...]] = None
+    group_dims: Optional[Tuple[str, ...]] = None
 
 
 def _is_bar_rect(p) -> bool:

--- a/src/publiplots/annotate/_custom.py
+++ b/src/publiplots/annotate/_custom.py
@@ -1,0 +1,277 @@
+"""Generic 'labels = column-or-callable' strategy over any mark type.
+
+Instantiated once per mark in bar_custom.py / point_custom.py / etc.
+Parameterized by:
+
+- `resolver`: an AnchorResolver for this mark type.
+- `record_type`: the record class, used for isinstance checks in callable
+  labels and for the NaN / anchor-override attribute probes.
+- `meta_attr`: attribute name on `ax` where pp.barplot / pp.pointplot /
+  etc. stashed the *Meta (e.g., "_publiplots_bar_meta").
+- `records_attr`: attribute on the meta holding the list of records
+  ("bars" / "points" / "boxes").
+- `introspect`: foreign-axes fallback; may be None for strategies that
+  don't support foreign axes (point, box, violin).
+- `has_fit_check`: whether this mark supports inside->outside fallback
+  when a label doesn't fit (bar only; points/boxes have no "interior").
+- `value_source`: callable (record) -> float returning the record's value
+  for the NaN skip. Most record types use `record.value`; box-stats uses
+  `record.stats["median"]`.
+- `axes_to_expand`: callable (anchor, orient, rotation) -> list of "x"/"y"
+  telling the limit-expansion logic which axes to grow to fit labels.
+"""
+from __future__ import annotations
+
+import logging
+import math
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+from matplotlib.axes import Axes
+from matplotlib.text import Text
+
+from publiplots.annotate._color import resolve_color
+from publiplots.annotate._positioning import (
+    AnchorResolver,
+    fit_check,
+    make_offset_transform,
+)
+from publiplots.annotate._shared import (
+    build_column_label_table,
+    ensure_renderer,
+    format_column_value,
+    maybe_expand_limits,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _default_value_source(r: Any) -> float:
+    return r.value
+
+
+def _default_axes_to_expand(anchor: str, orient: str, rotation: float) -> List[str]:
+    return ["y", "x"] if orient == "v" else ["x", "y"]
+
+
+@dataclass(frozen=True)
+class _CustomStrategy:
+    """Strategy-kind-agnostic custom-label implementation."""
+    resolver: AnchorResolver
+    record_type: Type
+    meta_attr: str
+    records_attr: str
+    introspect: Optional[Callable[[Axes], Any]] = None
+    has_fit_check: bool = False
+    value_source: Callable[[Any], float] = field(default=_default_value_source)
+    # Which axes to expand. For bars always both; for point/box it's
+    # computed from anchor + rotation.
+    axes_to_expand: Callable[[str, str, float], List[str]] = field(
+        default=_default_axes_to_expand
+    )
+
+    def __call__(
+        self,
+        ax: Axes,
+        *,
+        fmt: str,
+        anchor,
+        offset: float,
+        color,
+        pad: float,
+        rotation: float = 0.0,
+        labels: Union[str, Callable[[Any], str], None] = None,
+        data=None,
+        **text_kws,
+    ) -> List[Text]:
+        kind = self._kind_name()
+
+        # --- validate labels ---
+        if labels is None:
+            raise ValueError(f"{kind} requires a labels= argument")
+        if not isinstance(labels, str) and not callable(labels):
+            raise TypeError(
+                f"labels must be a column name (str) or a callable; "
+                f"got {type(labels).__name__}"
+            )
+
+        # --- validate anchor ---
+        valid = self.resolver.VALID_ANCHORS
+        default = self.resolver.DEFAULT_ANCHOR
+        if anchor is None:
+            anchor = default
+        if anchor not in valid:
+            raise ValueError(
+                f"{kind} anchor must be one of {sorted(valid)}; got {anchor!r}"
+            )
+
+        text_kws.pop("rotation", None)
+
+        # --- fetch meta ---
+        meta = getattr(ax, self.meta_attr, None)
+        if meta is None:
+            if self.introspect is not None:
+                meta = self.introspect(ax)
+            else:
+                warnings.warn(
+                    f"pp.annotate: kind='{kind}' needs publiplots-owned axes; "
+                    f"call the matching pp.*plot(..., annotate=True) first "
+                    "instead of annotating a foreign axes.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                return []
+        records = getattr(meta, self.records_attr)
+        if not records:
+            warnings.warn(
+                f"pp.annotate: no {self.records_attr} found on axes",
+                UserWarning,
+                stacklevel=3,
+            )
+            return []
+
+        # --- label source resolution ---
+        is_callable = callable(labels)
+        if is_callable and fmt != "{}":
+            warnings.warn(
+                "pp.annotate: fmt is ignored when labels is a callable",
+                UserWarning,
+                stacklevel=3,
+            )
+
+        label_table: Optional[Dict[int, object]] = None
+        if isinstance(labels, str):
+            frame = data if data is not None else meta.source_frame
+            if frame is None:
+                raise ValueError(
+                    f"pp.annotate: column-based labels require either a "
+                    f"publiplots-owned axes (via pp.{self._plotter_name()}) "
+                    f"or an explicit data= DataFrame"
+                )
+            if meta.group_keys is None:
+                raise NotImplementedError(
+                    "pp.annotate: column-based labels on foreign axes are not "
+                    "supported; use a callable (fn(record) -> str) instead"
+                )
+            label_table = build_column_label_table(
+                records, meta.group_keys,
+                getattr(meta, "group_dims", None),
+                labels, frame,
+            )
+
+        # --- per-record loop ---
+        renderer = ensure_renderer(ax)
+        texts: List[Text] = []
+        for rec in records:
+            val = self.value_source(rec)
+            if val is not None and isinstance(val, float) and math.isnan(val):
+                continue
+
+            rec_anchor = getattr(rec, "anchor_override", None) or anchor
+
+            if is_callable:
+                label_obj = labels(rec)
+                if label_obj is None:
+                    continue
+                if not isinstance(label_obj, str):
+                    raise TypeError(
+                        f"labels callable must return str; got "
+                        f"{type(label_obj).__name__} at "
+                        f"draw_index={rec.draw_index} "
+                        f"(category={getattr(rec, 'category', None)!r})"
+                    )
+                label = label_obj
+            else:
+                cell = label_table[rec.draw_index]
+                formatted = format_column_value(cell, fmt)
+                if formatted is None:
+                    continue
+                label = formatted
+
+            x, y, dx_mm, dy_mm, ha, va = self.resolver.resolve(
+                rec, rec_anchor, meta.orient, offset, ax,
+            )
+            rgba = resolve_color(
+                _ColorShim.wrap(rec), color, rec_anchor, ax,
+                hue_active=meta.hue_active,
+            )
+            t = ax.text(
+                x, y, label, ha=ha, va=va, color=rgba,
+                rotation=rotation,
+                transform=make_offset_transform(ax, dx_mm, dy_mm),
+                **text_kws,
+            )
+
+            if self.has_fit_check and rec_anchor != "outside":
+                bbox = rec.patch.get_window_extent(renderer)
+                if fit_check(t, bbox, meta.orient, rec_anchor, renderer) == "reanchor_outside":
+                    x2, y2, dx2, dy2, ha2, va2 = self.resolver.resolve(
+                        rec, "outside", meta.orient, offset, ax,
+                    )
+                    rgba2 = resolve_color(
+                        _ColorShim.wrap(rec), color, "outside", ax,
+                        hue_active=meta.hue_active,
+                    )
+                    t.set_position((x2, y2))
+                    t.set_transform(make_offset_transform(ax, dx2, dy2))
+                    t.set_ha(ha2)
+                    t.set_va(va2)
+                    t.set_color(rgba2)
+                    logger.debug(
+                        "pp.annotate: %s draw_index=%d re-anchored to 'outside'",
+                        kind, rec.draw_index,
+                    )
+            texts.append(t)
+
+        maybe_expand_limits(
+            ax, texts,
+            axes_to_expand=self.axes_to_expand(anchor, meta.orient, rotation),
+            pad_mm=pad, owner_is_publiplots=meta.owner_is_publiplots,
+        )
+        return texts
+
+    def _kind_name(self) -> str:
+        """e.g. '_publiplots_bar_meta' -> 'bar_custom'."""
+        core = self.meta_attr.removeprefix("_publiplots_").removesuffix("_meta")
+        return f"{core}_custom"
+
+    def _plotter_name(self) -> str:
+        """e.g. '_publiplots_bar_meta' -> 'barplot'."""
+        core = self.meta_attr.removeprefix("_publiplots_").removesuffix("_meta")
+        return f"{core}plot"
+
+
+class _ColorShim:
+    """Wrap any record so resolve_color can read .hue_color and .patch.
+
+    Bars have .patch (Rectangle) directly. Points / boxes have neither -
+    but resolve_color only reads hue_color + facecolor/edgecolor on the
+    "outside" paths, and when `color='hue'` the record's hue_color is
+    used directly. For our purposes a simple facade that forwards
+    hue_color and fabricates a dummy patch is sufficient.
+    """
+    def __init__(self, record):
+        self._record = record
+        self.hue_color = getattr(record, "hue_color", None)
+        self.patch = getattr(record, "patch", None) or _DummyPatch(self.hue_color)
+
+    @classmethod
+    def wrap(cls, record):
+        # Bars have .patch - pass the record through unchanged so resolve_color
+        # gets the real patch (needed for the "auto" luminance-contrast path).
+        if getattr(record, "patch", None) is not None:
+            return record
+        return cls(record)
+
+
+class _DummyPatch:
+    def __init__(self, rgba):
+        self._rgba = rgba or (0, 0, 0, 1)
+
+    def get_facecolor(self):
+        return self._rgba
+
+    def get_edgecolor(self):
+        return self._rgba

--- a/src/publiplots/annotate/_dispatcher.py
+++ b/src/publiplots/annotate/_dispatcher.py
@@ -15,6 +15,7 @@ from matplotlib.text import Text
 from publiplots.annotate.bar_custom import _bar_custom_strategy
 from publiplots.annotate.bar_values import _bar_values_strategy
 from publiplots.annotate.box_stats import _box_stats_strategy
+from publiplots.annotate.point_custom import _point_custom_strategy
 from publiplots.annotate.point_values import _point_values_strategy
 
 
@@ -23,6 +24,7 @@ _STRATEGIES: dict[str, Callable] = {
     "bar_custom": _bar_custom_strategy,
     "box_stats": _box_stats_strategy,
     "point_values": _point_values_strategy,
+    "point_custom": _point_custom_strategy,
 }
 
 
@@ -32,6 +34,7 @@ _DEFAULT_FMT: dict[str, str] = {
     "bar_custom": "{}",
     "box_stats": ".2f",
     "point_values": ".2f",
+    "point_custom": "{}",
 }
 
 
@@ -181,17 +184,18 @@ def annotate(
 
     resolved_fmt = fmt if fmt is not None else _DEFAULT_FMT[kind]
 
-    # labels= and data= are only meaningful for bar_custom; reject them for
-    # other kinds with a clear error, and forward them conditionally so
-    # other strategies' signatures stay unchanged.
+    # labels= and data= are only meaningful for *_custom strategies; reject
+    # them for other kinds with a clear error, and forward them conditionally
+    # so other strategies' signatures stay unchanged.
+    _custom_kinds = {"bar_custom", "point_custom"}
     extra = {}
-    if kind == "bar_custom":
+    if kind in _custom_kinds:
         extra["labels"] = labels
         extra["data"] = data
     elif labels is not None or data is not None:
         raise TypeError(
-            f"labels= and data= are only supported for kind='bar_custom'; "
-            f"got kind={kind!r}"
+            f"labels= and data= are only supported for custom-label kinds "
+            f"({sorted(_custom_kinds)}); got kind={kind!r}"
         )
 
     return _STRATEGIES[kind](

--- a/src/publiplots/annotate/_dispatcher.py
+++ b/src/publiplots/annotate/_dispatcher.py
@@ -14,6 +14,7 @@ from matplotlib.text import Text
 
 from publiplots.annotate.bar_custom import _bar_custom_strategy
 from publiplots.annotate.bar_values import _bar_values_strategy
+from publiplots.annotate.box_custom import _box_custom_strategy
 from publiplots.annotate.box_stats import _box_stats_strategy
 from publiplots.annotate.point_custom import _point_custom_strategy
 from publiplots.annotate.point_values import _point_values_strategy
@@ -23,6 +24,7 @@ _STRATEGIES: dict[str, Callable] = {
     "bar_values": _bar_values_strategy,
     "bar_custom": _bar_custom_strategy,
     "box_stats": _box_stats_strategy,
+    "box_custom": _box_custom_strategy,
     "point_values": _point_values_strategy,
     "point_custom": _point_custom_strategy,
 }
@@ -33,6 +35,7 @@ _DEFAULT_FMT: dict[str, str] = {
     "bar_values": ".2f",
     "bar_custom": "{}",
     "box_stats": ".2f",
+    "box_custom": "{}",
     "point_values": ".2f",
     "point_custom": "{}",
 }
@@ -187,7 +190,7 @@ def annotate(
     # labels= and data= are only meaningful for *_custom strategies; reject
     # them for other kinds with a clear error, and forward them conditionally
     # so other strategies' signatures stay unchanged.
-    _custom_kinds = {"bar_custom", "point_custom"}
+    _custom_kinds = {"bar_custom", "box_custom", "point_custom"}
     extra = {}
     if kind in _custom_kinds:
         extra["labels"] = labels

--- a/src/publiplots/annotate/_dispatcher.py
+++ b/src/publiplots/annotate/_dispatcher.py
@@ -18,6 +18,7 @@ from publiplots.annotate.box_custom import _box_custom_strategy
 from publiplots.annotate.box_stats import _box_stats_strategy
 from publiplots.annotate.point_custom import _point_custom_strategy
 from publiplots.annotate.point_values import _point_values_strategy
+from publiplots.annotate.violin_custom import _violin_custom_strategy
 
 
 _STRATEGIES: dict[str, Callable] = {
@@ -27,6 +28,7 @@ _STRATEGIES: dict[str, Callable] = {
     "box_custom": _box_custom_strategy,
     "point_values": _point_values_strategy,
     "point_custom": _point_custom_strategy,
+    "violin_custom": _violin_custom_strategy,
 }
 
 
@@ -38,6 +40,7 @@ _DEFAULT_FMT: dict[str, str] = {
     "box_custom": "{}",
     "point_values": ".2f",
     "point_custom": "{}",
+    "violin_custom": "{}",
 }
 
 
@@ -190,7 +193,7 @@ def annotate(
     # labels= and data= are only meaningful for *_custom strategies; reject
     # them for other kinds with a clear error, and forward them conditionally
     # so other strategies' signatures stay unchanged.
-    _custom_kinds = {"bar_custom", "box_custom", "point_custom"}
+    _custom_kinds = {"bar_custom", "box_custom", "point_custom", "violin_custom"}
     extra = {}
     if kind in _custom_kinds:
         extra["labels"] = labels

--- a/src/publiplots/annotate/_positioning.py
+++ b/src/publiplots/annotate/_positioning.py
@@ -15,7 +15,7 @@ transform to hand to ``ax.text(..., transform=...)``.
 """
 from __future__ import annotations
 
-from typing import Literal, Tuple
+from typing import ClassVar, FrozenSet, Literal, Protocol, Tuple, runtime_checkable
 
 from matplotlib.axes import Axes
 from matplotlib.text import Text
@@ -177,3 +177,40 @@ def fit_check(
         return "fits" if tbb.height + 2 * margin_px <= bar_bbox_display.height else "reanchor_outside"
     else:
         return "fits" if tbb.width + 2 * margin_px <= bar_bbox_display.width else "reanchor_outside"
+
+
+AnchorTuple = Tuple[float, float, float, float, str, str]
+#                   x,     y,     dx_mm, dy_mm, ha,  va
+
+
+@runtime_checkable
+class AnchorResolver(Protocol):
+    """Per-mark anchor-resolution contract.
+
+    Maps ``(record, anchor, orient, offset_mm, ax)`` to
+    ``(x, y, dx_mm, dy_mm, ha, va)``. ``VALID_ANCHORS`` defines the anchor
+    vocabulary for this mark type; ``DEFAULT_ANCHOR`` is the fallback when
+    the caller passes ``anchor=None``.
+    """
+    VALID_ANCHORS: ClassVar[FrozenSet[str]]
+    DEFAULT_ANCHOR: ClassVar[str]
+
+    def resolve(
+        self,
+        record,
+        anchor: str,
+        orient: Literal["v", "h"],
+        offset_mm: float,
+        ax: Axes,
+    ) -> AnchorTuple: ...
+
+
+class BarAnchorResolver:
+    """Adapter to the free-function resolve_anchor(bar, ...)."""
+    VALID_ANCHORS: ClassVar[FrozenSet[str]] = frozenset({
+        "outside", "inside", "base", "center",
+    })
+    DEFAULT_ANCHOR: ClassVar[str] = "outside"
+
+    def resolve(self, record, anchor, orient, offset_mm, ax):
+        return resolve_anchor(record, anchor, orient, offset_mm, ax)

--- a/src/publiplots/annotate/_shared.py
+++ b/src/publiplots/annotate/_shared.py
@@ -194,32 +194,20 @@ def compute_axes_to_expand_directional(
 ) -> List[Literal["x", "y"]]:
     """Pick which axes point/box strategies should expand.
 
-    ``anchor`` in ``{"top","bottom","left","right","center"}``. ``orient``
-    is ``"v"``/``"h"``; only box strategies care about it (box `left`/`right`
-    labels sit at ``cat_half_width`` away from center so they expand the
-    categorical axis, not the value axis). ``rotation`` turns on the
-    secondary axis expansion. ``rotated_both=True`` expands both axes even
-    without rotation (used by bar strategies that always expand both).
+    Always returns both axes, with the anchor-direction axis first so
+    it's the one matplotlib tries to grow first if only one needs it.
+    Previously returned only the anchor-direction axis (with rotation
+    forcing the secondary), which left edge-mark labels clipping the
+    perpendicular axis frame: e.g., an ``anchor="top"`` label on the
+    leftmost point has vertical headroom but is still flush against
+    the left y-axis frame. ``_expand_axis`` is a no-op whenever a label
+    already fits, so always checking both axes is safe — it only
+    actually changes limits when needed.
     """
+    _ = orient, rotation, rotated_both  # kept for signature compatibility
     if anchor in ("top", "bottom"):
-        primary = "y"
-    elif anchor in ("left", "right"):
-        primary = "x"
-    else:
-        primary = None
-
-    rotated = rotation % 360.0 != 0.0
-
-    if primary is None and not rotated and not rotated_both:
-        return []
-
-    axes: List[Literal["x", "y"]] = []
-    if primary is not None:
-        axes.append(primary)  # type: ignore[arg-type]
-    if rotated or rotated_both:
-        other: Literal["x", "y"] = "x" if primary == "y" else "y"
-        if primary is None:
-            axes.extend(["x", "y"])
-        elif other not in axes:
-            axes.append(other)
-    return axes
+        return ["y", "x"]
+    if anchor in ("left", "right"):
+        return ["x", "y"]
+    # "center" or an unexpected anchor — expand both regardless.
+    return ["y", "x"]

--- a/src/publiplots/annotate/_shared.py
+++ b/src/publiplots/annotate/_shared.py
@@ -1,0 +1,225 @@
+"""Shared helpers used by every annotate strategy.
+
+Factored out of bar_values, point_values, box_stats, bar_custom so the
+custom strategies for non-bar marks can reuse them without a fifth copy.
+
+`maybe_expand_limits` takes an explicit `axes_to_expand` list because
+different strategies expand different axes:
+
+- bar_values/bar_custom: always expand both value and cat axes.
+- point_values/point_custom: expand based on anchor direction + rotation.
+- box_stats/box_custom/violin_custom: expand based on anchor direction + rotation.
+
+Each caller computes its axes_to_expand list once and passes it in.
+"""
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Dict, List, Literal, Optional, Sequence
+
+from matplotlib.axes import Axes
+from matplotlib.text import Text
+
+from publiplots.annotate._positioning import mm_to_data
+
+
+def format_value(value: float, fmt: str) -> str:
+    """Apply ``fmt`` to a numeric value. Handles either bare spec (``".2f"``)
+    or template string (``"{:.2f}"``).
+    """
+    if "{" in fmt and "}" in fmt:
+        return fmt.format(value)
+    return format(value, fmt)
+
+
+def format_column_value(value, fmt: str) -> Optional[str]:
+    """Apply ``fmt`` to a DataFrame cell. Return None for NaN / None so the
+    caller can skip that record.
+    """
+    if value is None:
+        return None
+    try:
+        if isinstance(value, float) and math.isnan(value):
+            return None
+    except TypeError:
+        pass
+    if "{" in fmt and "}" in fmt:
+        return fmt.format(value)
+    return format(value, fmt) if fmt != "{}" else str(value)
+
+
+def ensure_renderer(ax: Axes):
+    """Return a valid renderer for ``ax``, drawing the canvas once if needed."""
+    canvas = ax.figure.canvas
+    renderer = canvas.get_renderer() if hasattr(canvas, "get_renderer") else None
+    if renderer is None:
+        canvas.draw()
+        renderer = canvas.get_renderer()
+    return renderer
+
+
+_DIM_TO_FIELD = {"cat": "category", "hue": "hue_value", "hatch": "hatch_value"}
+
+
+def build_column_label_table(
+    records: Sequence,
+    group_keys: Sequence[str],
+    group_dims: Optional[Sequence[str]],
+    column: str,
+    data,
+) -> Dict[int, object]:
+    """Return ``{draw_index: cell_value}`` for each record.
+
+    ``data.groupby(group_keys, observed=True)[column].first()`` resolves the
+    per-group value. ``group_dims`` tells us which record attribute each
+    group_key corresponds to (``"cat"``/``"hue"``/``"hatch"``) so we can
+    build the lookup tuple without assuming positional ordering. Emits a
+    ``UserWarning`` if the column varies within any group.
+    """
+    if column not in data.columns:
+        raise KeyError(
+            f"column {column!r} not found in data; available: "
+            f"{list(data.columns)}"
+        )
+    groupby = data.groupby(list(group_keys), observed=True)
+    firsts = groupby[column].first()
+    nunique = groupby[column].nunique(dropna=False)
+    varies = nunique[nunique > 1]
+    if len(varies):
+        warnings.warn(
+            f"pp.annotate: column {column!r} varies within group(s) "
+            f"{list(varies.index)}; using .first()",
+            UserWarning,
+            stacklevel=4,
+        )
+
+    dims = group_dims or ("cat",) * len(group_keys)
+    table: Dict[int, object] = {}
+    for rec in records:
+        key_parts = [getattr(rec, _DIM_TO_FIELD[d]) for d in dims]
+        key = key_parts[0] if len(key_parts) == 1 else tuple(key_parts)
+        try:
+            table[rec.draw_index] = firsts.loc[key]
+        except KeyError:
+            table[rec.draw_index] = None
+    return table
+
+
+_MAX_EXPAND_ITERS = 4
+
+
+def maybe_expand_limits(
+    ax: Axes,
+    texts: List[Text],
+    axes_to_expand: Sequence[Literal["x", "y"]],
+    pad_mm: float,
+    owner_is_publiplots: bool,
+) -> None:
+    """Expand the given axes so every text fits with ``pad_mm`` of breathing
+    room. Iterates up to 4 times to converge on a stable layout.
+    """
+    if not texts or not axes_to_expand:
+        return
+
+    renderer = ensure_renderer(ax)
+    for _ in range(_MAX_EXPAND_ITERS):
+        ax.figure.canvas.draw()
+        inv = ax.transData.inverted()
+        extents = [t.get_window_extent(renderer).transformed(inv) for t in texts]
+        any_changed = False
+        for ax_name in axes_to_expand:
+            if _expand_axis(
+                ax, extents, axis=ax_name, pad_mm=pad_mm,
+                owner_is_publiplots=owner_is_publiplots,
+            ):
+                any_changed = True
+        if not any_changed:
+            break
+
+
+def _expand_axis(
+    ax: Axes,
+    extents: list,
+    axis: str,
+    pad_mm: float,
+    owner_is_publiplots: bool,
+) -> bool:
+    """Expand one axis to fit extents. Return True if limits changed."""
+    autoscale_on = (ax.get_autoscaley_on() if axis == "y"
+                    else ax.get_autoscalex_on())
+    should_expand = owner_is_publiplots or autoscale_on
+
+    if axis == "y":
+        need_min = min(e.y0 for e in extents)
+        need_max = max(e.y1 for e in extents)
+        get_lim, set_lim = ax.get_ylim, ax.set_ylim
+    else:
+        need_min = min(e.x0 for e in extents)
+        need_max = max(e.x1 for e in extents)
+        get_lim, set_lim = ax.get_xlim, ax.set_xlim
+
+    cur_lo, cur_hi = get_lim()
+    pad_data = mm_to_data(pad_mm, ax, axis=axis)
+
+    inverted = cur_lo > cur_hi
+    cur_min = min(cur_lo, cur_hi)
+    cur_max = max(cur_lo, cur_hi)
+
+    if should_expand:
+        new_min = min(cur_min, need_min - pad_data)
+        new_max = max(cur_max, need_max + pad_data)
+        if new_min == cur_min and new_max == cur_max:
+            return False
+        if inverted:
+            set_lim(new_max, new_min)
+        else:
+            set_lim(new_min, new_max)
+        return True
+    else:
+        if need_min < cur_min or need_max > cur_max:
+            warnings.warn(
+                "pp.annotate: labels clipped; autoscale is off on this axis",
+                UserWarning,
+                stacklevel=3,
+            )
+        return False
+
+
+def compute_axes_to_expand_directional(
+    anchor: str,
+    orient: str,
+    rotation: float,
+    rotated_both: bool = False,
+) -> List[Literal["x", "y"]]:
+    """Pick which axes point/box strategies should expand.
+
+    ``anchor`` in ``{"top","bottom","left","right","center"}``. ``orient``
+    is ``"v"``/``"h"``; only box strategies care about it (box `left`/`right`
+    labels sit at ``cat_half_width`` away from center so they expand the
+    categorical axis, not the value axis). ``rotation`` turns on the
+    secondary axis expansion. ``rotated_both=True`` expands both axes even
+    without rotation (used by bar strategies that always expand both).
+    """
+    if anchor in ("top", "bottom"):
+        primary = "y"
+    elif anchor in ("left", "right"):
+        primary = "x"
+    else:
+        primary = None
+
+    rotated = rotation % 360.0 != 0.0
+
+    if primary is None and not rotated and not rotated_both:
+        return []
+
+    axes: List[Literal["x", "y"]] = []
+    if primary is not None:
+        axes.append(primary)  # type: ignore[arg-type]
+    if rotated or rotated_both:
+        other: Literal["x", "y"] = "x" if primary == "y" else "y"
+        if primary is None:
+            axes.extend(["x", "y"])
+        elif other not in axes:
+            axes.append(other)
+    return axes

--- a/src/publiplots/annotate/bar_custom.py
+++ b/src/publiplots/annotate/bar_custom.py
@@ -1,175 +1,23 @@
 """Custom-text label strategy for barplots.
 
-Same placement machinery as bar_values (resolve_anchor, resolve_color,
-fit_check, _maybe_expand_limits); the only difference is where the label
-string comes from: a DataFrame column aligned by (x, hue, hatch) group
-keys, or a user-supplied callable that receives each BarRecord.
+Bars can be labeled with either a DataFrame column (aligned by (x, hue,
+hatch) group keys) or a callable returning a string per BarRecord.
+Wires BarAnchorResolver into the generic _CustomStrategy machinery.
 """
 from __future__ import annotations
 
-import logging
-import math
-import warnings
-from typing import Callable, Dict, List, Optional, Union
+from publiplots.annotate._cache import BarRecord, _introspect as _bar_introspect
+from publiplots.annotate._custom import _CustomStrategy
+from publiplots.annotate._positioning import BarAnchorResolver
 
-from matplotlib.axes import Axes
-from matplotlib.text import Text
 
-from publiplots.annotate._cache import BarRecord, BarValueMeta, _introspect
-from publiplots.annotate._color import resolve_color
-from publiplots.annotate._positioning import (
-    fit_check,
-    make_offset_transform,
-    resolve_anchor,
+_bar_custom_strategy = _CustomStrategy(
+    resolver=BarAnchorResolver(),
+    record_type=BarRecord,
+    meta_attr="_publiplots_bar_meta",
+    records_attr="bars",
+    introspect=_bar_introspect,
+    has_fit_check=True,
+    # BarRecord.value is the canonical per-bar value; default value_source works.
+    # Bars always expand both axes regardless of anchor/rotation (default).
 )
-from publiplots.annotate._shared import (
-    build_column_label_table as _build_column_label_table_shared,
-    ensure_renderer as _ensure_renderer,
-    format_column_value as _format_column_value,
-    maybe_expand_limits,
-)
-from publiplots.annotate.bar_values import _VALID_ANCHORS, _DEFAULT_ANCHOR
-
-
-logger = logging.getLogger(__name__)
-
-
-def _get_or_introspect(ax: Axes) -> BarValueMeta:
-    meta = getattr(ax, "_publiplots_bar_meta", None)
-    if isinstance(meta, BarValueMeta):
-        return meta
-    return _introspect(ax)
-
-
-def _bar_custom_strategy(
-    ax: Axes,
-    *,
-    fmt: str,
-    anchor,
-    offset: float,
-    color,
-    pad: float,
-    rotation: float = 0.0,
-    labels: Union[str, Callable[[BarRecord], str], None] = None,
-    data=None,
-    **text_kws,
-) -> List[Text]:
-    if labels is None:
-        raise ValueError("bar_custom requires a labels= argument")
-    if not isinstance(labels, str) and not callable(labels):
-        raise TypeError(
-            f"labels must be a column name (str) or a callable; "
-            f"got {type(labels).__name__}"
-        )
-
-    if anchor is None:
-        anchor = _DEFAULT_ANCHOR
-    if anchor not in _VALID_ANCHORS:
-        raise ValueError(
-            f"bar_custom anchor must be one of {sorted(_VALID_ANCHORS)}; "
-            f"got {anchor!r}"
-        )
-
-    # Top-level `rotation` wins over one smuggled via text_kws; pop silently.
-    text_kws.pop("rotation", None)
-
-    meta = _get_or_introspect(ax)
-    if not meta.bars:
-        warnings.warn("pp.annotate: no bars found on axes", UserWarning,
-                      stacklevel=3)
-        return []
-
-    # -------- resolve label source -------------------------------------------
-    is_callable = callable(labels)
-    if is_callable and fmt != "{}":
-        # Per-strategy default fmt is "{}" (neutral passthrough) when the
-        # caller did not override; warn if it did.
-        warnings.warn(
-            "pp.annotate: fmt is ignored when labels is a callable",
-            UserWarning,
-            stacklevel=3,
-        )
-
-    label_table: Optional[Dict[int, object]] = None
-    if isinstance(labels, str):
-        frame = data if data is not None else meta.source_frame
-        if frame is None:
-            raise ValueError(
-                "pp.annotate: column-based labels require either a "
-                "publiplots-owned axes (via pp.barplot) or an explicit "
-                "data= DataFrame"
-            )
-        if meta.group_keys is None:
-            raise NotImplementedError(
-                "pp.annotate: column-based labels on foreign axes are not "
-                "supported; use a callable (fn(record) -> str) instead"
-            )
-        label_table = _build_column_label_table_shared(
-            meta.bars, meta.group_keys, meta.group_dims, labels, frame,
-        )
-
-    # -------- per-record loop (mirrors bar_values._bar_values_strategy) ------
-    renderer = _ensure_renderer(ax)
-    texts: List[Text] = []
-
-    for bar in meta.bars:
-        if math.isnan(bar.value):
-            continue
-
-        # Stacked/gain bars may pin themselves to a specific anchor.
-        bar_anchor = bar.anchor_override if bar.anchor_override is not None else anchor
-
-        if is_callable:
-            label_obj = labels(bar)
-            if label_obj is None:
-                continue
-            if not isinstance(label_obj, str):
-                raise TypeError(
-                    f"labels callable must return str; got "
-                    f"{type(label_obj).__name__} at draw_index={bar.draw_index} "
-                    f"(category={bar.category!r})"
-                )
-            label = label_obj
-        else:
-            cell = label_table[bar.draw_index]
-            formatted = _format_column_value(cell, fmt)
-            if formatted is None:
-                continue
-            label = formatted
-
-        x, y, dx_mm, dy_mm, ha, va = resolve_anchor(
-            bar, bar_anchor, meta.orient, offset, ax,
-        )
-        rgba = resolve_color(bar, color, bar_anchor, ax, hue_active=meta.hue_active)
-        t = ax.text(
-            x, y, label, ha=ha, va=va, color=rgba,
-            rotation=rotation,
-            transform=make_offset_transform(ax, dx_mm, dy_mm),
-            **text_kws,
-        )
-
-        if bar_anchor != "outside":
-            bbox = bar.patch.get_window_extent(renderer)
-            if fit_check(t, bbox, meta.orient, bar_anchor, renderer) == "reanchor_outside":
-                x2, y2, dx2, dy2, ha2, va2 = resolve_anchor(
-                    bar, "outside", meta.orient, offset, ax,
-                )
-                rgba2 = resolve_color(bar, color, "outside", ax,
-                                       hue_active=meta.hue_active)
-                t.set_position((x2, y2))
-                t.set_transform(make_offset_transform(ax, dx2, dy2))
-                t.set_ha(ha2)
-                t.set_va(va2)
-                t.set_color(rgba2)
-                logger.debug(
-                    "pp.annotate: bar_custom draw_index=%d re-anchored to 'outside'",
-                    bar.draw_index,
-                )
-        texts.append(t)
-
-    maybe_expand_limits(
-        ax, texts,
-        axes_to_expand=["y", "x"] if meta.orient == "v" else ["x", "y"],
-        pad_mm=pad, owner_is_publiplots=meta.owner_is_publiplots,
-    )
-    return texts

--- a/src/publiplots/annotate/bar_custom.py
+++ b/src/publiplots/annotate/bar_custom.py
@@ -22,15 +22,13 @@ from publiplots.annotate._positioning import (
     make_offset_transform,
     resolve_anchor,
 )
-from publiplots.annotate.bar_values import (
-    _ensure_renderer,
-    _maybe_expand_limits,
-    _VALID_ANCHORS,
-    _DEFAULT_ANCHOR,
+from publiplots.annotate._shared import (
+    build_column_label_table as _build_column_label_table_shared,
+    ensure_renderer as _ensure_renderer,
+    format_column_value as _format_column_value,
+    maybe_expand_limits,
 )
-
-
-_DIM_TO_FIELD = {"cat": "category", "hue": "hue_value", "hatch": "hatch_value"}
+from publiplots.annotate.bar_values import _VALID_ANCHORS, _DEFAULT_ANCHOR
 
 
 logger = logging.getLogger(__name__)
@@ -41,67 +39,6 @@ def _get_or_introspect(ax: Axes) -> BarValueMeta:
     if isinstance(meta, BarValueMeta):
         return meta
     return _introspect(ax)
-
-
-def _build_column_label_table(
-    meta: BarValueMeta,
-    column: str,
-    data,                              # pandas DataFrame
-) -> Dict[int, object]:
-    """Return {draw_index: cell_value} for each bar in meta.bars.
-
-    Aligns by meta.group_keys. Emits a UserWarning when the column varies
-    within any group (uses `.first()`).
-    """
-    if column not in data.columns:
-        raise KeyError(
-            f"column {column!r} not found in data; available: "
-            f"{list(data.columns)}"
-        )
-    groupby = data.groupby(list(meta.group_keys), observed=True)
-    firsts = groupby[column].first()
-    nunique = groupby[column].nunique(dropna=False)
-    varies = nunique[nunique > 1]
-    if len(varies):
-        warnings.warn(
-            f"pp.annotate: column {column!r} varies within group(s) "
-            f"{list(varies.index)}; using .first()",
-            UserWarning,
-            stacklevel=4,
-        )
-
-    # meta.group_dims identifies each group_keys entry's semantic dimension:
-    # position 0 is always "cat", but position 1 may be "hue" OR "hatch"
-    # (under hatch-only splits). Reading that companion tuple — instead of
-    # assuming positional (cat, hue, hatch) order — keeps key lookups aligned
-    # regardless of which split dimensions are active. Foreign axes never
-    # reach this function (group_keys is None there), but we keep a defensive
-    # fallback to all-"cat" so a hypothetical caller doesn't silently KeyError.
-    dims = meta.group_dims or ("cat",) * len(meta.group_keys)
-    table: Dict[int, object] = {}
-    for bar in meta.bars:
-        key_parts = [getattr(bar, _DIM_TO_FIELD[d]) for d in dims]
-        key = key_parts[0] if len(key_parts) == 1 else tuple(key_parts)
-        try:
-            table[bar.draw_index] = firsts.loc[key]
-        except KeyError:
-            table[bar.draw_index] = None
-    return table
-
-
-def _format_column_value(value, fmt: str) -> Optional[str]:
-    """Apply fmt to a column cell. Return None for NaN/None so caller skips."""
-    if value is None:
-        return None
-    # pandas NA / float NaN
-    try:
-        if isinstance(value, float) and math.isnan(value):
-            return None
-    except TypeError:
-        pass
-    if "{" in fmt and "}" in fmt:
-        return fmt.format(value)
-    return format(value, fmt) if fmt != "{}" else str(value)
 
 
 def _bar_custom_strategy(
@@ -167,7 +104,9 @@ def _bar_custom_strategy(
                 "pp.annotate: column-based labels on foreign axes are not "
                 "supported; use a callable (fn(record) -> str) instead"
             )
-        label_table = _build_column_label_table(meta, labels, frame)
+        label_table = _build_column_label_table_shared(
+            meta.bars, meta.group_keys, meta.group_dims, labels, frame,
+        )
 
     # -------- per-record loop (mirrors bar_values._bar_values_strategy) ------
     renderer = _ensure_renderer(ax)
@@ -228,9 +167,9 @@ def _bar_custom_strategy(
                 )
         texts.append(t)
 
-    _maybe_expand_limits(
-        ax, texts, meta.orient, pad_mm=pad,
-        owner_is_publiplots=meta.owner_is_publiplots,
-        rotation=rotation,
+    maybe_expand_limits(
+        ax, texts,
+        axes_to_expand=["y", "x"] if meta.orient == "v" else ["x", "y"],
+        pad_mm=pad, owner_is_publiplots=meta.owner_is_publiplots,
     )
     return texts

--- a/src/publiplots/annotate/bar_values.py
+++ b/src/publiplots/annotate/bar_values.py
@@ -14,8 +14,12 @@ from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
     fit_check,
     make_offset_transform,
-    mm_to_data,
     resolve_anchor,
+)
+from publiplots.annotate._shared import (
+    ensure_renderer as _ensure_renderer,
+    format_value as _format_value,
+    maybe_expand_limits,
 )
 
 
@@ -31,21 +35,6 @@ def _get_or_introspect(ax: Axes) -> BarValueMeta:
     if isinstance(meta, BarValueMeta):
         return meta
     return _introspect(ax)
-
-
-def _format_value(value: float, fmt: str) -> str:
-    if "{" in fmt and "}" in fmt:
-        return fmt.format(value)
-    return format(value, fmt)
-
-
-def _ensure_renderer(ax: Axes):
-    canvas = ax.figure.canvas
-    renderer = canvas.get_renderer() if hasattr(canvas, "get_renderer") else None
-    if renderer is None:
-        canvas.draw()
-        renderer = canvas.get_renderer()
-    return renderer
 
 
 def _bar_values_strategy(
@@ -118,95 +107,14 @@ def _bar_values_strategy(
     return texts
 
 
-# Expanding a limit changes the data→display scale, which shifts every text
-# artist's bbox in data coords even though its pixel extent is unchanged.
-# One pass always undershoots by a bounded geometric factor; 4 iterations
-# is overkill in practice — most plots converge in 2.
-_MAX_EXPAND_ITERS = 4
-
-
 def _maybe_expand_limits(
-    ax: Axes,
-    texts: List[Text],
-    orient: str,
-    pad_mm: float,
-    owner_is_publiplots: bool,
-    rotation: float = 0.0,
-) -> None:
-    if not texts:
-        return
-
-    value_axis = "y" if orient == "v" else "x"
-    cat_axis = "x" if value_axis == "y" else "y"
-
-    # Wide labels (long text at rotation=0, tall text at rotation=90) can
-    # spill onto the categorical axis too. `_expand_axis` is a no-op when
-    # labels already fit, so we always check both axes.
-    axes_to_expand = [value_axis, cat_axis]
-
-    renderer = _ensure_renderer(ax)
-    for _ in range(_MAX_EXPAND_ITERS):
-        # Force a fresh draw so get_window_extent returns a bbox consistent
-        # with the most recent limits; without this we'd loop on stale data.
-        # Re-fetch `inv` every iteration: set_xlim/ylim invalidates transData,
-        # and a cached inverted transform silently returns wrong data coords.
-        ax.figure.canvas.draw()
-        inv = ax.transData.inverted()
-        extents = [t.get_window_extent(renderer).transformed(inv) for t in texts]
-        any_changed = False
-        for ax_name in axes_to_expand:
-            if _expand_axis(
-                ax, extents, axis=ax_name, pad_mm=pad_mm,
-                owner_is_publiplots=owner_is_publiplots,
-            ):
-                any_changed = True
-        if not any_changed:
-            break
-
-
-def _expand_axis(
-    ax: Axes,
-    extents: list,
-    axis: str,
-    pad_mm: float,
-    owner_is_publiplots: bool,
-) -> bool:
-    """Expand one axis to fit the given extents. Return True if limits changed."""
-    autoscale_on = (ax.get_autoscaley_on() if axis == "y"
-                    else ax.get_autoscalex_on())
-    should_expand = owner_is_publiplots or autoscale_on
-
-    if axis == "y":
-        need_min = min(e.y0 for e in extents)
-        need_max = max(e.y1 for e in extents)
-        get_lim, set_lim = ax.get_ylim, ax.set_ylim
-    else:
-        need_min = min(e.x0 for e in extents)
-        need_max = max(e.x1 for e in extents)
-        get_lim, set_lim = ax.get_xlim, ax.set_xlim
-
-    cur_lo, cur_hi = get_lim()
-    pad_data = mm_to_data(pad_mm, ax, axis=axis)
-
-    inverted = cur_lo > cur_hi
-    cur_min = min(cur_lo, cur_hi)
-    cur_max = max(cur_lo, cur_hi)
-
-    if should_expand:
-        new_min = min(cur_min, need_min - pad_data)
-        new_max = max(cur_max, need_max + pad_data)
-        if new_min == cur_min and new_max == cur_max:
-            return False
-        if inverted:
-            set_lim(new_max, new_min)
-        else:
-            set_lim(new_min, new_max)
-        return True
-    else:
-        if need_min < cur_min or need_max > cur_max:
-            warnings.warn(
-                "pp.annotate: labels clipped; autoscale is off on this axis",
-                UserWarning,
-                stacklevel=3,
-            )
-        return False
+    ax, texts, orient, pad_mm, owner_is_publiplots, rotation: float = 0.0,
+):
+    """Back-compat wrapper: bar_custom imports this by name. New strategies
+    should call `maybe_expand_limits` directly."""
+    _ = rotation  # bars always expand both axes; rotation is informational
+    maybe_expand_limits(
+        ax, texts,
+        axes_to_expand=["y", "x"] if orient == "v" else ["x", "y"],
+        pad_mm=pad_mm, owner_is_publiplots=owner_is_publiplots,
+    )

--- a/src/publiplots/annotate/box_custom.py
+++ b/src/publiplots/annotate/box_custom.py
@@ -1,0 +1,27 @@
+"""Custom-text label strategy for boxplots.
+
+Parallels point_custom; uses BoxAnchorResolver. The value_source is
+``record.stats["median"]`` so NaN-skip uses the median (the anchor
+position). No foreign-axes introspection.
+"""
+from __future__ import annotations
+
+from publiplots.annotate._cache import BoxStatsRecord
+from publiplots.annotate._custom import _CustomStrategy
+from publiplots.annotate._shared import compute_axes_to_expand_directional
+from publiplots.annotate.box_stats import BoxAnchorResolver
+
+
+_box_custom_strategy = _CustomStrategy(
+    resolver=BoxAnchorResolver(),
+    record_type=BoxStatsRecord,
+    meta_attr="_publiplots_box_meta",
+    records_attr="boxes",
+    introspect=None,
+    has_fit_check=False,
+    value_source=lambda r: r.stats.get("median", float("nan")),
+    axes_to_expand=(
+        lambda anchor, orient, rotation:
+            compute_axes_to_expand_directional(anchor, orient, rotation)
+    ),
+)

--- a/src/publiplots/annotate/box_stats.py
+++ b/src/publiplots/annotate/box_stats.py
@@ -18,29 +18,18 @@ from publiplots.annotate._cache import BoxStatsMeta, BoxStatsRecord
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
     make_offset_transform,
-    mm_to_data,
+)
+from publiplots.annotate._shared import (
+    compute_axes_to_expand_directional,
+    ensure_renderer as _ensure_renderer,
+    format_value as _format_value,
+    maybe_expand_limits,
 )
 
 
 _VALID_ANCHORS = {"top", "bottom", "left", "right", "center"}
 _DEFAULT_ANCHOR = "right"
 _DEFAULT_STATS: Tuple[str, ...] = ("median",)
-
-
-
-def _format_value(value: float, fmt: str) -> str:
-    if "{" in fmt and "}" in fmt:
-        return fmt.format(value)
-    return format(value, fmt)
-
-
-def _ensure_renderer(ax: Axes):
-    canvas = ax.figure.canvas
-    renderer = canvas.get_renderer() if hasattr(canvas, "get_renderer") else None
-    if renderer is None:
-        canvas.draw()
-        renderer = canvas.get_renderer()
-    return renderer
 
 
 def _resolve_box_anchor(
@@ -164,9 +153,13 @@ def _box_stats_strategy(
             )
             texts.append(t)
 
-    _maybe_expand_box_limits(ax, texts, anchor, meta.orient, pad_mm=pad,
-                             owner_is_publiplots=meta.owner_is_publiplots,
-                             rotation=rotation)
+    maybe_expand_limits(
+        ax, texts,
+        axes_to_expand=compute_axes_to_expand_directional(
+            anchor, meta.orient, rotation,
+        ),
+        pad_mm=pad, owner_is_publiplots=meta.owner_is_publiplots,
+    )
     return texts
 
 
@@ -189,109 +182,3 @@ class _PatchShim:
 
     def get_edgecolor(self):
         return self._rgba
-
-
-_MAX_EXPAND_ITERS = 4
-
-
-def _maybe_expand_box_limits(
-    ax: Axes,
-    texts: List[Text],
-    anchor: str,
-    orient: str,
-    pad_mm: float,
-    owner_is_publiplots: bool,
-    rotation: float = 0.0,
-) -> None:
-    if not texts:
-        return
-
-    # Which axis matches the unrotated anchor direction?
-    # top/bottom → y; left/right → x; center → neither.
-    if anchor in ("top", "bottom"):
-        primary_axis = "y"
-    elif anchor in ("left", "right"):
-        primary_axis = "x"
-    else:
-        primary_axis = None
-
-    rotated = rotation % 360.0 != 0.0
-
-    # Under rotation, a rotated label can spill onto either axis regardless of
-    # anchor direction; expand both sides.
-    if primary_axis is None and not rotated:
-        return
-
-    axes_to_expand = []
-    if primary_axis is not None:
-        axes_to_expand.append(primary_axis)
-    if rotated:
-        other = "x" if primary_axis == "y" else "y"
-        if primary_axis is None:
-            axes_to_expand.extend(["x", "y"])
-        elif other not in axes_to_expand:
-            axes_to_expand.append(other)
-
-    renderer = _ensure_renderer(ax)
-    for _ in range(_MAX_EXPAND_ITERS):
-        # Re-fetch inverted transform each iter — set_xlim/ylim invalidates it.
-        ax.figure.canvas.draw()
-        inv = ax.transData.inverted()
-        extents = [t.get_window_extent(renderer).transformed(inv) for t in texts]
-        any_changed = False
-        for ax_name in axes_to_expand:
-            if _expand_box_axis(
-                ax, extents, axis=ax_name, pad_mm=pad_mm,
-                owner_is_publiplots=owner_is_publiplots,
-            ):
-                any_changed = True
-        if not any_changed:
-            break
-
-
-def _expand_box_axis(
-    ax: Axes,
-    extents: list,
-    axis: str,
-    pad_mm: float,
-    owner_is_publiplots: bool,
-) -> bool:
-    """Expand one axis to fit extents. Return True if limits changed."""
-    autoscale_on = (ax.get_autoscaley_on() if axis == "y"
-                    else ax.get_autoscalex_on())
-    should_expand = owner_is_publiplots or autoscale_on
-
-    if axis == "y":
-        need_min = min(e.y0 for e in extents)
-        need_max = max(e.y1 for e in extents)
-        get_lim, set_lim = ax.get_ylim, ax.set_ylim
-    else:
-        need_min = min(e.x0 for e in extents)
-        need_max = max(e.x1 for e in extents)
-        get_lim, set_lim = ax.get_xlim, ax.set_xlim
-
-    cur_lo, cur_hi = get_lim()
-    pad_data = mm_to_data(pad_mm, ax, axis=axis)
-
-    inverted = cur_lo > cur_hi
-    cur_min = min(cur_lo, cur_hi)
-    cur_max = max(cur_lo, cur_hi)
-
-    if should_expand:
-        new_min = min(cur_min, need_min - pad_data)
-        new_max = max(cur_max, need_max + pad_data)
-        if new_min == cur_min and new_max == cur_max:
-            return False
-        if inverted:
-            set_lim(new_max, new_min)
-        else:
-            set_lim(new_min, new_max)
-        return True
-    else:
-        if need_min < cur_min or need_max > cur_max:
-            warnings.warn(
-                "pp.annotate: labels clipped; autoscale is off on this axis",
-                UserWarning,
-                stacklevel=3,
-            )
-        return False

--- a/src/publiplots/annotate/box_stats.py
+++ b/src/publiplots/annotate/box_stats.py
@@ -9,7 +9,7 @@ matches the most common journal style.
 from __future__ import annotations
 
 import warnings
-from typing import Iterable, List, Tuple
+from typing import ClassVar, FrozenSet, Iterable, List, Tuple
 
 from matplotlib.axes import Axes
 from matplotlib.text import Text
@@ -17,6 +17,7 @@ from matplotlib.text import Text
 from publiplots.annotate._cache import BoxStatsMeta, BoxStatsRecord
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
+    AnchorTuple,
     make_offset_transform,
 )
 from publiplots.annotate._shared import (
@@ -79,6 +80,29 @@ def _resolve_box_anchor(
         if anchor == "center":
             return px, py, 0.0, 0.0, "center", "center"
     raise ValueError(f"unreachable: unknown anchor {anchor!r}")
+
+
+class BoxAnchorResolver:
+    """Adapter to _resolve_box_anchor. Box-stats records carry per-stat
+    values inside `record.stats`; the custom strategy labels a single
+    chosen stat (default: "median") whose value is passed to the resolver
+    as stat_value."""
+    VALID_ANCHORS: ClassVar[FrozenSet[str]] = frozenset({
+        "top", "bottom", "left", "right", "center",
+    })
+    DEFAULT_ANCHOR: ClassVar[str] = "top"
+
+    # The custom strategy always uses the median by default; a callable
+    # label path can compute from record.stats directly. Pin the stat name
+    # the resolver receives.
+    STAT_FOR_POSITIONING: ClassVar[str] = "median"
+
+    def resolve(self, record, anchor, orient, offset_mm, ax) -> AnchorTuple:
+        stat_value = record.stats[self.STAT_FOR_POSITIONING]
+        return _resolve_box_anchor(
+            record, self.STAT_FOR_POSITIONING, stat_value,
+            anchor, orient, offset_mm, ax,
+        )
 
 
 def _box_stats_strategy(

--- a/src/publiplots/annotate/point_custom.py
+++ b/src/publiplots/annotate/point_custom.py
@@ -1,0 +1,26 @@
+"""Custom-text label strategy for pointplots.
+
+Parallels bar_custom; uses PointAnchorResolver. No foreign-axes
+introspection today — callers must plot via pp.pointplot to use
+kind="point_custom".
+"""
+from __future__ import annotations
+
+from publiplots.annotate._cache import PointRecord
+from publiplots.annotate._custom import _CustomStrategy
+from publiplots.annotate._shared import compute_axes_to_expand_directional
+from publiplots.annotate.point_values import PointAnchorResolver
+
+
+_point_custom_strategy = _CustomStrategy(
+    resolver=PointAnchorResolver(),
+    record_type=PointRecord,
+    meta_attr="_publiplots_point_meta",
+    records_attr="points",
+    introspect=None,
+    has_fit_check=False,
+    axes_to_expand=(
+        lambda anchor, orient, rotation:
+            compute_axes_to_expand_directional(anchor, orient, rotation)
+    ),
+)

--- a/src/publiplots/annotate/point_values.py
+++ b/src/publiplots/annotate/point_values.py
@@ -19,7 +19,12 @@ from publiplots.annotate._cache import PointRecord, PointValueMeta
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
     make_offset_transform,
-    mm_to_data,
+)
+from publiplots.annotate._shared import (
+    compute_axes_to_expand_directional,
+    ensure_renderer as _ensure_renderer,
+    format_value as _format_value,
+    maybe_expand_limits,
 )
 
 
@@ -66,21 +71,6 @@ def _resolve_point_anchor(
     if anchor == "center":
         return px, py, 0.0, 0.0, "center", "center"
     raise ValueError(f"unreachable: unknown anchor {anchor!r}")
-
-
-def _format_value(value: float, fmt: str) -> str:
-    if "{" in fmt and "}" in fmt:
-        return fmt.format(value)
-    return format(value, fmt)
-
-
-def _ensure_renderer(ax: Axes):
-    canvas = ax.figure.canvas
-    renderer = canvas.get_renderer() if hasattr(canvas, "get_renderer") else None
-    if renderer is None:
-        canvas.draw()
-        renderer = canvas.get_renderer()
-    return renderer
 
 
 def _point_values_strategy(
@@ -147,9 +137,13 @@ def _point_values_strategy(
         )
         texts.append(t)
 
-    _maybe_expand_point_limits(ax, texts, anchor, pad_mm=pad,
-                               owner_is_publiplots=meta.owner_is_publiplots,
-                               rotation=rotation)
+    maybe_expand_limits(
+        ax, texts,
+        axes_to_expand=compute_axes_to_expand_directional(
+            anchor, meta.orient, rotation,
+        ),
+        pad_mm=pad, owner_is_publiplots=meta.owner_is_publiplots,
+    )
     return texts
 
 
@@ -173,106 +167,3 @@ class _PatchShim:
 
     def get_edgecolor(self):
         return self._rgba
-
-
-_MAX_EXPAND_ITERS = 4
-
-
-def _maybe_expand_point_limits(
-    ax: Axes,
-    texts: List[Text],
-    anchor: str,
-    pad_mm: float,
-    owner_is_publiplots: bool,
-    rotation: float = 0.0,
-) -> None:
-    if not texts:
-        return
-
-    # Which axis matches the unrotated anchor direction?
-    # top/bottom → y; left/right → x; center → neither.
-    if anchor in ("top", "bottom"):
-        primary_axis = "y"
-    elif anchor in ("left", "right"):
-        primary_axis = "x"
-    else:
-        primary_axis = None
-
-    rotated = rotation % 360.0 != 0.0
-
-    if primary_axis is None and not rotated:
-        return
-
-    axes_to_expand = []
-    if primary_axis is not None:
-        axes_to_expand.append(primary_axis)
-    if rotated:
-        other = "x" if primary_axis == "y" else "y"
-        if primary_axis is None:
-            axes_to_expand.extend(["x", "y"])
-        elif other not in axes_to_expand:
-            axes_to_expand.append(other)
-
-    renderer = _ensure_renderer(ax)
-    for _ in range(_MAX_EXPAND_ITERS):
-        # Re-fetch inverted transform each iter — set_xlim/ylim invalidates it.
-        ax.figure.canvas.draw()
-        inv = ax.transData.inverted()
-        extents = [t.get_window_extent(renderer).transformed(inv) for t in texts]
-        any_changed = False
-        for ax_name in axes_to_expand:
-            if _expand_point_axis(
-                ax, extents, axis=ax_name, pad_mm=pad_mm,
-                owner_is_publiplots=owner_is_publiplots,
-            ):
-                any_changed = True
-        if not any_changed:
-            break
-
-
-def _expand_point_axis(
-    ax: Axes,
-    extents: list,
-    axis: str,
-    pad_mm: float,
-    owner_is_publiplots: bool,
-) -> bool:
-    """Expand one axis to fit extents. Return True if limits changed."""
-    autoscale_on = (ax.get_autoscaley_on() if axis == "y"
-                    else ax.get_autoscalex_on())
-    should_expand = owner_is_publiplots or autoscale_on
-
-    if axis == "y":
-        need_min = min(e.y0 for e in extents)
-        need_max = max(e.y1 for e in extents)
-        get_lim, set_lim = ax.get_ylim, ax.set_ylim
-    else:
-        need_min = min(e.x0 for e in extents)
-        need_max = max(e.x1 for e in extents)
-        get_lim, set_lim = ax.get_xlim, ax.set_xlim
-
-    cur_lo, cur_hi = get_lim()
-    pad_data = mm_to_data(pad_mm, ax, axis=axis)
-
-    inverted = cur_lo > cur_hi
-    cur_min = min(cur_lo, cur_hi)
-    cur_max = max(cur_lo, cur_hi)
-
-    if should_expand:
-        new_min = min(cur_min, need_min - pad_data)
-        new_max = max(cur_max, need_max + pad_data)
-        if new_min == cur_min and new_max == cur_max:
-            return False
-        if inverted:
-            set_lim(new_max, new_min)
-        else:
-            set_lim(new_min, new_max)
-        return True
-    else:
-        if need_min < cur_min or need_max > cur_max:
-            warnings.warn(
-                "pp.annotate: labels clipped; autoscale is off on this axis",
-                UserWarning,
-                stacklevel=3,
-            )
-        return False

--- a/src/publiplots/annotate/point_values.py
+++ b/src/publiplots/annotate/point_values.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import List, Tuple
+from typing import ClassVar, FrozenSet, List, Tuple
 
 from matplotlib.axes import Axes
 from matplotlib.text import Text
@@ -18,6 +18,7 @@ from matplotlib.text import Text
 from publiplots.annotate._cache import PointRecord, PointValueMeta
 from publiplots.annotate._color import resolve_color
 from publiplots.annotate._positioning import (
+    AnchorTuple,
     make_offset_transform,
 )
 from publiplots.annotate._shared import (
@@ -71,6 +72,19 @@ def _resolve_point_anchor(
     if anchor == "center":
         return px, py, 0.0, 0.0, "center", "center"
     raise ValueError(f"unreachable: unknown anchor {anchor!r}")
+
+
+class PointAnchorResolver:
+    """Adapter to _resolve_point_anchor. The `orient` arg is unused (points
+    have an orient on the meta for informational purposes, but the resolver
+    reads the marker's own (px, py) directly)."""
+    VALID_ANCHORS: ClassVar[FrozenSet[str]] = frozenset({
+        "top", "bottom", "left", "right", "center",
+    })
+    DEFAULT_ANCHOR: ClassVar[str] = "top"
+
+    def resolve(self, record, anchor, orient, offset_mm, ax) -> AnchorTuple:
+        return _resolve_point_anchor(record, anchor, offset_mm, ax)
 
 
 def _point_values_strategy(

--- a/src/publiplots/annotate/violin_custom.py
+++ b/src/publiplots/annotate/violin_custom.py
@@ -1,0 +1,28 @@
+"""Custom-text label strategy for violinplots.
+
+Shares BoxAnchorResolver + BoxStatsRecord with box_custom (violins and
+boxes both produce BoxStatsMeta). The distinction exists so users can
+request kind="violin_custom" for discoverability; future KDE-extent-
+aware anchoring can diverge this strategy without a breaking rename.
+"""
+from __future__ import annotations
+
+from publiplots.annotate._cache import BoxStatsRecord
+from publiplots.annotate._custom import _CustomStrategy
+from publiplots.annotate._shared import compute_axes_to_expand_directional
+from publiplots.annotate.box_stats import BoxAnchorResolver
+
+
+_violin_custom_strategy = _CustomStrategy(
+    resolver=BoxAnchorResolver(),
+    record_type=BoxStatsRecord,
+    meta_attr="_publiplots_box_meta",
+    records_attr="boxes",
+    introspect=None,
+    has_fit_check=False,
+    value_source=lambda r: r.stats.get("median", float("nan")),
+    axes_to_expand=(
+        lambda anchor, orient, rotation:
+            compute_axes_to_expand_directional(anchor, orient, rotation)
+    ),
+)

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -178,6 +178,10 @@ def boxplot(
         )
     resolved_edgecolor = edgecolor if edgecolor is not None else linecolor
 
+    # Preserve the caller's original DataFrame identity for downstream
+    # annotate builders that stash `source_frame` on the meta.
+    _source_data = data
+
     # Create figure via pp.subplots to install SubplotsAutoLayout; users who
     # want custom dimensions should compose with pp.subplots(axes_size=...)
     # before calling and pass ax=.
@@ -316,23 +320,26 @@ def boxplot(
     if title is not None:
         ax.set_title(title)
 
+    # Always attach the cache so follow-up pp.annotate(ax, ...) calls work.
+    from publiplots.annotate._builders import build_from_boxplot_call
+    if is_categorical(data[x]):
+        categorical_axis = x
+    elif is_categorical(data[y]):
+        categorical_axis = y
+    else:
+        categorical_axis = x
+    ax._publiplots_box_meta = build_from_boxplot_call(
+        ax=ax, data=data, x=x, y=y, hue=hue,
+        categorical_axis=categorical_axis,
+        palette=palette if isinstance(palette, dict) else None,
+        whis=whis,
+        source_frame=_source_data,
+    )
     if annotate:
-        from publiplots.annotate._builders import build_from_boxplot_call
         from publiplots.annotate import annotate as _annotate_fn
-        if is_categorical(data[x]):
-            categorical_axis = x
-        elif is_categorical(data[y]):
-            categorical_axis = y
-        else:
-            categorical_axis = x
-        ax._publiplots_box_meta = build_from_boxplot_call(
-            ax=ax, data=data, x=x, y=y, hue=hue,
-            categorical_axis=categorical_axis,
-            palette=palette if isinstance(palette, dict) else None,
-            whis=whis,
-        )
-        opts = annotate if isinstance(annotate, dict) else {}
-        _annotate_fn(ax, kind="box_stats", **opts)
+        opts = dict(annotate) if isinstance(annotate, dict) else {}
+        kind = opts.pop("kind", "box_stats")
+        _annotate_fn(ax, kind=kind, **opts)
 
     return ax
 

--- a/src/publiplots/plot/point.py
+++ b/src/publiplots/plot/point.py
@@ -219,6 +219,10 @@ def pointplot(
             "join parameter is deprecated. Use linestyle='none' instead for no connecting lines."
         )
 
+    # Preserve the caller's original DataFrame identity for downstream
+    # annotate builders that stash `source_frame` on the meta.
+    _source_data = data
+
     # Create figure via pp.subplots to install SubplotsAutoLayout; users who
     # want custom dimensions should compose with pp.subplots(axes_size=...)
     # before calling and pass ax=.
@@ -359,23 +363,28 @@ def pointplot(
             legend=legend,
         )
 
+    # Determine categorical axis (same logic as before).
+    if is_categorical(data[x]):
+        categorical_axis = x
+    elif is_categorical(data[y]):
+        categorical_axis = y
+    else:
+        categorical_axis = x
+
+    # Always attach the cache so follow-up pp.annotate(ax, ...) calls work.
+    from publiplots.annotate._builders import build_from_pointplot_call
+    ax._publiplots_point_meta = build_from_pointplot_call(
+        ax=ax, data=data, x=x, y=y, hue=hue,
+        categorical_axis=categorical_axis,
+        palette=palette if isinstance(palette, dict) else None,
+        errorbar=errorbar if isinstance(errorbar, str) else None,
+        source_frame=_source_data,
+    )
     if annotate:
-        from publiplots.annotate._builders import build_from_pointplot_call
         from publiplots.annotate import annotate as _annotate_fn
-        if is_categorical(data[x]):
-            categorical_axis = x
-        elif is_categorical(data[y]):
-            categorical_axis = y
-        else:
-            categorical_axis = x
-        ax._publiplots_point_meta = build_from_pointplot_call(
-            ax=ax, data=data, x=x, y=y, hue=hue,
-            categorical_axis=categorical_axis,
-            palette=palette if isinstance(palette, dict) else None,
-            errorbar=errorbar if isinstance(errorbar, str) else None,
-        )
-        opts = annotate if isinstance(annotate, dict) else {}
-        _annotate_fn(ax, kind="point_values", **opts)
+        opts = dict(annotate) if isinstance(annotate, dict) else {}
+        kind = opts.pop("kind", "point_values")
+        _annotate_fn(ax, kind=kind, **opts)
 
     return ax
 

--- a/src/publiplots/plot/violin.py
+++ b/src/publiplots/plot/violin.py
@@ -213,6 +213,10 @@ def violinplot(
     if orient is not None:
         raise DeprecationWarning("orient is deprecated. Use x and y instead.")
 
+    # Preserve the caller's original DataFrame identity for downstream
+    # annotate builders that stash `source_frame` on the meta.
+    _source_data = data
+
     # Create figure via pp.subplots to install SubplotsAutoLayout; users who
     # want custom dimensions should compose with pp.subplots(axes_size=...)
     # before calling and pass ax=.
@@ -315,22 +319,25 @@ def violinplot(
     if title is not None:
         ax.set_title(title)
 
+    # Always attach the cache so follow-up pp.annotate(ax, ...) calls work.
+    from publiplots.annotate._builders import build_from_violinplot_call
+    if is_categorical(data[x]):
+        categorical_axis = x
+    elif is_categorical(data[y]):
+        categorical_axis = y
+    else:
+        categorical_axis = x
+    ax._publiplots_box_meta = build_from_violinplot_call(
+        ax=ax, data=data, x=x, y=y, hue=hue,
+        categorical_axis=categorical_axis,
+        palette=palette if isinstance(palette, dict) else None,
+        source_frame=_source_data,
+    )
     if annotate:
-        from publiplots.annotate._builders import build_from_violinplot_call
         from publiplots.annotate import annotate as _annotate_fn
-        if is_categorical(data[x]):
-            categorical_axis = x
-        elif is_categorical(data[y]):
-            categorical_axis = y
-        else:
-            categorical_axis = x
-        ax._publiplots_box_meta = build_from_violinplot_call(
-            ax=ax, data=data, x=x, y=y, hue=hue,
-            categorical_axis=categorical_axis,
-            palette=palette if isinstance(palette, dict) else None,
-        )
-        opts = annotate if isinstance(annotate, dict) else {}
-        _annotate_fn(ax, kind="box_stats", **opts)
+        opts = dict(annotate) if isinstance(annotate, dict) else {}
+        kind = opts.pop("kind", "box_stats")
+        _annotate_fn(ax, kind=kind, **opts)
 
     return ax
 

--- a/tests/annotate/test_box_custom.py
+++ b/tests/annotate/test_box_custom.py
@@ -1,0 +1,154 @@
+"""Tests for the box_custom strategy."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.annotate._cache import BoxStatsRecord
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _simple_df():
+    # 3 samples per cat for stable quartiles
+    return pd.DataFrame({
+        "cat": pd.Categorical(
+            ["A"] * 3 + ["B"] * 3 + ["C"] * 3,
+            categories=["A", "B", "C"],
+        ),
+        "value": [1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0],
+        "n":     [10, 10, 10, 20, 20, 20, 30, 30, 30],
+    })
+
+
+def test_column_labels_from_cached_frame():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="box_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "20", "30"]
+
+
+def test_column_labels_with_fmt():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="box_custom", labels="n", fmt="n={:,}")
+    assert [t.get_text() for t in texts] == ["n=10", "n=20", "n=30"]
+
+
+def test_column_labels_with_data_override():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    other = _simple_df().assign(n=[99] * 3 + [88] * 3 + [77] * 3)
+    texts = pp.annotate(ax, kind="box_custom", labels="n", data=other)
+    assert [t.get_text() for t in texts] == ["99", "88", "77"]
+
+
+def test_column_labels_hue_split():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(
+            ["A"] * 6 + ["B"] * 6, categories=["A", "B"],
+        ),
+        "hue": pd.Categorical(
+            (["x"] * 3 + ["y"] * 3) * 2, categories=["x", "y"],
+        ),
+        "value": list(range(1, 13)),
+        "n": [11] * 3 + [22] * 3 + [33] * 3 + [44] * 3,
+    })
+    ax = pp.boxplot(data=df, x="cat", y="value", hue="hue")
+    texts = pp.annotate(ax, kind="box_custom", labels="n")
+    # Hue-outer, cat-inner: (x, A), (x, B), (y, A), (y, B).
+    assert [t.get_text() for t in texts] == ["11", "33", "22", "44"]
+
+
+def test_column_labels_intra_group_variance_warns_and_uses_first():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(
+            ["A"] * 3 + ["B"] * 3, categories=["A", "B"],
+        ),
+        "value": [1.0, 2.0, 3.0, 2.0, 3.0, 4.0],
+        "n": [10, 999, 10, 20, 20, 20],
+    })
+    ax = pp.boxplot(data=df, x="cat", y="value")
+    with pytest.warns(UserWarning, match="varies within group"):
+        texts = pp.annotate(ax, kind="box_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "20"]
+
+
+def test_callable_receives_box_record():
+    seen = []
+    def label(rec):
+        assert isinstance(rec, BoxStatsRecord)
+        seen.append(rec)
+        return str(rec.category)
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="box_custom", labels=label)
+    assert [t.get_text() for t in texts] == ["A", "B", "C"]
+    assert len(seen) == 3
+
+
+def test_callable_returning_none_skips_box():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(
+        ax, kind="box_custom",
+        labels=lambda r: None if r.category == "B" else str(r.category),
+    )
+    assert [t.get_text() for t in texts] == ["A", "C"]
+
+
+def test_callable_returning_non_string_raises_typeerror():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="draw_index=0"):
+        pp.annotate(ax, kind="box_custom", labels=lambda r: 42)
+
+
+def test_fmt_warns_when_labels_is_callable():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    with pytest.warns(UserWarning, match="fmt is ignored"):
+        pp.annotate(
+            ax, kind="box_custom",
+            labels=lambda r: str(r.category),
+            fmt="n={}",
+        )
+
+
+def test_missing_labels_raises():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(ValueError, match="labels"):
+        pp.annotate(ax, kind="box_custom")
+
+
+def test_foreign_axes_warns_and_returns_empty():
+    fig, ax = plt.subplots()
+    ax.boxplot([[1, 2, 3], [4, 5, 6]])
+    with pytest.warns(UserWarning, match="publiplots-owned axes"):
+        texts = pp.annotate(ax, kind="box_custom", labels="n")
+    assert texts == []
+
+
+def test_column_not_in_frame_raises_keyerror():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(KeyError, match="not_a_col"):
+        pp.annotate(ax, kind="box_custom", labels="not_a_col")
+
+
+def test_labels_wrong_type_raises():
+    ax = pp.boxplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="labels must be"):
+        pp.annotate(ax, kind="box_custom", labels=123)
+
+
+def test_box_record_is_publicly_importable():
+    from publiplots.annotate import BoxStatsRecord as Public
+    from publiplots.annotate._cache import BoxStatsRecord as Private
+    assert Public is Private
+
+
+def test_end_to_end_via_pp_boxplot_annotate():
+    ax = pp.boxplot(
+        data=_simple_df(), x="cat", y="value",
+        annotate={"kind": "box_custom", "labels": "n", "fmt": "n={}"},
+    )
+    assert [t.get_text() for t in ax.texts] == ["n=10", "n=20", "n=30"]

--- a/tests/annotate/test_boxplot_integration.py
+++ b/tests/annotate/test_boxplot_integration.py
@@ -40,7 +40,6 @@ def test_violinplot_without_annotate_still_attaches_meta():
     assert meta.source_frame is df
 
 
-@pytest.mark.skip(reason="strategy registered in Task 7")
 def test_boxplot_annotate_kind_forwarded():
     df = _box_df()
     ax = pp.boxplot(

--- a/tests/annotate/test_boxplot_integration.py
+++ b/tests/annotate/test_boxplot_integration.py
@@ -1,0 +1,62 @@
+"""Integration: pp.boxplot + pp.violinplot cache-building + end-to-end."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.annotate._cache import BoxStatsMeta
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _box_df():
+    return pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "A", "B", "B", "B", "C", "C", "C"]),
+        "value": [1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0],
+        "n":     [10, 10, 10, 20, 20, 20, 30, 30, 30],
+    })
+
+
+def test_boxplot_without_annotate_still_attaches_meta():
+    df = _box_df()
+    ax = pp.boxplot(data=df, x="cat", y="value")
+    meta = ax._publiplots_box_meta
+    assert isinstance(meta, BoxStatsMeta)
+    assert meta.source_frame is df
+    assert meta.group_keys == ("cat",)
+
+
+def test_violinplot_without_annotate_still_attaches_meta():
+    df = _box_df()
+    ax = pp.violinplot(data=df, x="cat", y="value")
+    meta = ax._publiplots_box_meta
+    assert isinstance(meta, BoxStatsMeta)
+    assert meta.source_frame is df
+
+
+@pytest.mark.skip(reason="strategy registered in Task 7")
+def test_boxplot_annotate_kind_forwarded():
+    df = _box_df()
+    ax = pp.boxplot(
+        data=df, x="cat", y="value",
+        annotate={"kind": "box_custom", "labels": "n", "fmt": "n={}"},
+    )
+    labels = [t.get_text() for t in ax.texts]
+    assert labels == ["n=10", "n=20", "n=30"]
+
+
+@pytest.mark.skip(reason="strategy registered in Task 8")
+def test_violinplot_annotate_kind_forwarded():
+    df = _box_df()
+    ax = pp.violinplot(
+        data=df, x="cat", y="value",
+        annotate={"kind": "violin_custom", "labels": "n", "fmt": "n={}"},
+    )
+    labels = [t.get_text() for t in ax.texts]
+    assert labels == ["n=10", "n=20", "n=30"]

--- a/tests/annotate/test_boxplot_integration.py
+++ b/tests/annotate/test_boxplot_integration.py
@@ -50,7 +50,6 @@ def test_boxplot_annotate_kind_forwarded():
     assert labels == ["n=10", "n=20", "n=30"]
 
 
-@pytest.mark.skip(reason="strategy registered in Task 8")
 def test_violinplot_annotate_kind_forwarded():
     df = _box_df()
     ax = pp.violinplot(

--- a/tests/annotate/test_cache.py
+++ b/tests/annotate/test_cache.py
@@ -7,7 +7,15 @@ import pandas as pd
 import pytest
 from matplotlib.patches import Rectangle
 
-from publiplots.annotate._cache import BarRecord, BarValueMeta, _introspect
+from publiplots.annotate._cache import (
+    BarRecord,
+    BarValueMeta,
+    BoxStatsMeta,
+    BoxStatsRecord,
+    PointRecord,
+    PointValueMeta,
+    _introspect,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -235,3 +243,72 @@ def test_bar_record_is_publicly_importable():
     from publiplots.annotate import BarRecord as PublicBarRecord
     from publiplots.annotate._cache import BarRecord as PrivateBarRecord
     assert PublicBarRecord is PrivateBarRecord
+
+
+def test_point_record_has_new_public_fields():
+    rec = PointRecord(
+        xy=(1.0, 2.0),
+        value=2.0,
+        err_low=None, err_high=None,
+        hue_color=None,
+        category="A",
+        hue_value=None,
+        hatch_value=None,
+        draw_index=3,
+        frame_row_index=7,
+    )
+    assert rec.category == "A"
+    assert rec.hue_value is None
+    assert rec.hatch_value is None
+    assert rec.draw_index == 3
+    assert rec.frame_row_index == 7
+
+
+def test_point_value_meta_has_source_frame_and_group_keys():
+    df = pd.DataFrame({"x": ["A"], "y": [1.0]})
+    meta = PointValueMeta(
+        orient="v",
+        points=[],
+        errorbar_kind=None,
+        hue_active=False,
+        owner_is_publiplots=True,
+        source_frame=df,
+        group_keys=("x",),
+        group_dims=("cat",),
+    )
+    assert meta.source_frame is df
+    assert meta.group_keys == ("x",)
+    assert meta.group_dims == ("cat",)
+
+
+def test_box_stats_record_has_new_public_fields():
+    rec = BoxStatsRecord(
+        center_pos=1.0,
+        cat_half_width=0.4,
+        stats={"median": 2.0},
+        hue_color=None,
+        category="A",
+        hue_value=None,
+        hatch_value=None,
+        draw_index=3,
+        frame_row_index=7,
+    )
+    assert rec.category == "A"
+    assert rec.draw_index == 3
+    assert rec.frame_row_index == 7
+
+
+def test_box_stats_meta_has_source_frame_and_group_keys():
+    df = pd.DataFrame({"x": ["A"], "y": [1.0]})
+    meta = BoxStatsMeta(
+        orient="v",
+        boxes=[],
+        hue_active=False,
+        owner_is_publiplots=True,
+        source_frame=df,
+        group_keys=("x",),
+        group_dims=("cat",),
+    )
+    assert meta.source_frame is df
+    assert meta.group_keys == ("x",)
+    assert meta.group_dims == ("cat",)

--- a/tests/annotate/test_dispatcher.py
+++ b/tests/annotate/test_dispatcher.py
@@ -51,8 +51,10 @@ def test_default_kind_is_bar_values():
 def test_registry_contains_known_strategies():
     from publiplots.annotate._dispatcher import _STRATEGIES
     assert set(_STRATEGIES.keys()) == {
-        "bar_values", "bar_custom", "box_stats", "box_custom",
+        "bar_values", "bar_custom",
+        "box_stats", "box_custom",
         "point_values", "point_custom",
+        "violin_custom",
     }
 
 

--- a/tests/annotate/test_dispatcher.py
+++ b/tests/annotate/test_dispatcher.py
@@ -51,8 +51,8 @@ def test_default_kind_is_bar_values():
 def test_registry_contains_known_strategies():
     from publiplots.annotate._dispatcher import _STRATEGIES
     assert set(_STRATEGIES.keys()) == {
-        "bar_values", "bar_custom", "box_stats", "point_values",
-        "point_custom",
+        "bar_values", "bar_custom", "box_stats", "box_custom",
+        "point_values", "point_custom",
     }
 
 

--- a/tests/annotate/test_dispatcher.py
+++ b/tests/annotate/test_dispatcher.py
@@ -52,6 +52,7 @@ def test_registry_contains_known_strategies():
     from publiplots.annotate._dispatcher import _STRATEGIES
     assert set(_STRATEGIES.keys()) == {
         "bar_values", "bar_custom", "box_stats", "point_values",
+        "point_custom",
     }
 
 

--- a/tests/annotate/test_point_custom.py
+++ b/tests/annotate/test_point_custom.py
@@ -143,3 +143,44 @@ def test_end_to_end_via_pp_pointplot_annotate():
         annotate={"kind": "point_custom", "labels": "n", "fmt": "n={}"},
     )
     assert [t.get_text() for t in ax.texts] == ["n=10", "n=20", "n=30"]
+
+
+def test_anchor_top_also_expands_xlim_for_edge_labels():
+    """Regression: ``anchor="top"`` on the leftmost/rightmost point's label
+    can still spill past the x-axis frame horizontally. The strategy must
+    expand the x-axis (not just the anchor-direction y-axis) so edge
+    labels don't clip the y/x frame."""
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C", "D"],
+                              categories=["A", "B", "C", "D"]),
+        "value": [0.62, 0.71, 0.83, 0.79],
+        "n": [120, 145, 98, 87],
+    })
+    ax = pp.pointplot(data=df, x="cat", y="value")
+    xlim_before = ax.get_xlim()
+
+    texts = pp.annotate(
+        ax, kind="point_custom",
+        labels="n", fmt="n={:,}",
+        anchor="top",
+    )
+    assert len(texts) == 4
+
+    ax.figure.canvas.draw()
+    renderer = ax.figure.canvas.get_renderer()
+    inv = ax.transData.inverted()
+    xlim_lo, xlim_hi = ax.get_xlim()
+
+    for t in texts:
+        bbox = t.get_window_extent(renderer).transformed(inv)
+        assert bbox.x0 >= xlim_lo, (
+            f"label {t.get_text()!r} x0={bbox.x0} clips left xlim={xlim_lo}"
+        )
+        assert bbox.x1 <= xlim_hi, (
+            f"label {t.get_text()!r} x1={bbox.x1} clips right xlim={xlim_hi}"
+        )
+    # xlim should have grown (leftmost/rightmost labels push outward).
+    assert (xlim_lo < xlim_before[0]) or (xlim_hi > xlim_before[1]), (
+        f"xlim unchanged {xlim_before} -> ({xlim_lo}, {xlim_hi}); "
+        "labels aren't triggering horizontal expansion"
+    )

--- a/tests/annotate/test_point_custom.py
+++ b/tests/annotate/test_point_custom.py
@@ -1,0 +1,145 @@
+"""Tests for the point_custom strategy."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.annotate._cache import PointRecord
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _simple_df():
+    return pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"], categories=["A", "B", "C"]),
+        "value": [1.0, 2.0, 3.0],
+        "n": [10, 20, 30],
+    })
+
+
+def test_column_labels_from_cached_frame():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="point_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "20", "30"]
+
+
+def test_column_labels_with_fmt():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="point_custom", labels="n", fmt="n={:,}")
+    assert [t.get_text() for t in texts] == ["n=10", "n=20", "n=30"]
+
+
+def test_column_labels_with_data_override():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    other = _simple_df().assign(n=[99, 88, 77])
+    texts = pp.annotate(ax, kind="point_custom", labels="n", data=other)
+    assert [t.get_text() for t in texts] == ["99", "88", "77"]
+
+
+def test_column_labels_hue_split():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hue": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+        "n": [11, 22, 33, 44],
+    })
+    ax = pp.pointplot(data=df, x="cat", y="value", hue="hue")
+    texts = pp.annotate(ax, kind="point_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["11", "33", "22", "44"]
+
+
+def test_column_labels_intra_group_variance_warns_and_uses_first():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B"], categories=["A", "B"]),
+        "value": [1.0, 2.0, 3.0],
+        "n": [10, 999, 30],
+    })
+    ax = pp.pointplot(data=df, x="cat", y="value")
+    with pytest.warns(UserWarning, match="varies within group"):
+        texts = pp.annotate(ax, kind="point_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "30"]
+
+
+def test_callable_receives_point_record():
+    seen = []
+    def label(rec):
+        assert isinstance(rec, PointRecord)
+        seen.append(rec)
+        return str(rec.category)
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="point_custom", labels=label)
+    assert [t.get_text() for t in texts] == ["A", "B", "C"]
+    assert len(seen) == 3
+
+
+def test_callable_returning_none_skips_point():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(
+        ax, kind="point_custom",
+        labels=lambda r: None if r.category == "B" else str(r.category),
+    )
+    assert [t.get_text() for t in texts] == ["A", "C"]
+
+
+def test_callable_returning_non_string_raises_typeerror():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="draw_index=0"):
+        pp.annotate(ax, kind="point_custom", labels=lambda r: 42)
+
+
+def test_fmt_warns_when_labels_is_callable():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    with pytest.warns(UserWarning, match="fmt is ignored"):
+        pp.annotate(
+            ax, kind="point_custom",
+            labels=lambda r: str(r.category),
+            fmt="n={}",
+        )
+
+
+def test_missing_labels_raises():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(ValueError, match="labels"):
+        pp.annotate(ax, kind="point_custom")
+
+
+def test_foreign_axes_warns_and_returns_empty():
+    """point_custom has introspect=None; foreign axes emit a UserWarning
+    and return an empty list (matching _custom.py's behavior)."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [1.0, 2.0, 3.0], "o")
+    with pytest.warns(UserWarning, match="publiplots-owned axes"):
+        texts = pp.annotate(ax, kind="point_custom", labels="n")
+    assert texts == []
+
+
+def test_column_not_in_frame_raises_keyerror():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(KeyError, match="not_a_col"):
+        pp.annotate(ax, kind="point_custom", labels="not_a_col")
+
+
+def test_labels_wrong_type_raises():
+    ax = pp.pointplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="labels must be"):
+        pp.annotate(ax, kind="point_custom", labels=123)
+
+
+def test_point_record_is_publicly_importable():
+    from publiplots.annotate import PointRecord as Public
+    from publiplots.annotate._cache import PointRecord as Private
+    assert Public is Private
+
+
+def test_end_to_end_via_pp_pointplot_annotate():
+    ax = pp.pointplot(
+        data=_simple_df(), x="cat", y="value",
+        annotate={"kind": "point_custom", "labels": "n", "fmt": "n={}"},
+    )
+    assert [t.get_text() for t in ax.texts] == ["n=10", "n=20", "n=30"]

--- a/tests/annotate/test_pointplot_integration.py
+++ b/tests/annotate/test_pointplot_integration.py
@@ -1,0 +1,47 @@
+"""Integration: pp.pointplot(..., annotate=...) cache-building + end-to-end."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.annotate._cache import PointValueMeta
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def test_pointplot_without_annotate_still_attaches_meta():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+    })
+    ax = pp.pointplot(data=df, x="cat", y="value")
+    meta = ax._publiplots_point_meta
+    assert isinstance(meta, PointValueMeta)
+    assert meta.source_frame is df
+    assert meta.group_keys == ("cat",)
+    assert meta.group_dims == ("cat",)
+    for i, p in enumerate(meta.points):
+        assert p.category in ("A", "B")
+        assert p.draw_index == i
+        assert p.frame_row_index is not None
+
+
+@pytest.mark.skip(reason="strategy registered in Task 6")
+def test_pointplot_annotate_kind_forwarded():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+        "n":    [10, 11, 20, 21],
+    })
+    ax = pp.pointplot(
+        data=df, x="cat", y="value",
+        annotate={"kind": "point_custom", "labels": "n", "fmt": "n={}"},
+    )
+    labels = [t.get_text() for t in ax.texts]
+    assert labels == ["n=10", "n=20"]

--- a/tests/annotate/test_pointplot_integration.py
+++ b/tests/annotate/test_pointplot_integration.py
@@ -32,7 +32,6 @@ def test_pointplot_without_annotate_still_attaches_meta():
         assert p.frame_row_index is not None
 
 
-@pytest.mark.skip(reason="strategy registered in Task 6")
 def test_pointplot_annotate_kind_forwarded():
     df = pd.DataFrame({
         "cat": pd.Categorical(["A", "A", "B", "B"]),

--- a/tests/annotate/test_positioning.py
+++ b/tests/annotate/test_positioning.py
@@ -227,3 +227,37 @@ def test_fit_check_tall_bar_inside_fits():
     renderer = fig.canvas.get_renderer()
     bbox = ax.patches[0].get_window_extent(renderer)
     assert fit_check(t, bbox, orient="v", anchor="inside", renderer=renderer) == "fits"
+
+
+def test_anchor_resolvers_conform_to_protocol():
+    """All three resolvers satisfy the AnchorResolver runtime protocol."""
+    from publiplots.annotate._positioning import (
+        AnchorResolver,
+        BarAnchorResolver,
+    )
+    from publiplots.annotate.box_stats import BoxAnchorResolver
+    from publiplots.annotate.point_values import PointAnchorResolver
+
+    assert isinstance(BarAnchorResolver(), AnchorResolver)
+    assert isinstance(PointAnchorResolver(), AnchorResolver)
+    assert isinstance(BoxAnchorResolver(), AnchorResolver)
+
+
+def test_anchor_resolver_vocabularies():
+    """Each resolver declares its anchor vocabulary + default as ClassVars."""
+    from publiplots.annotate._positioning import BarAnchorResolver
+    from publiplots.annotate.box_stats import BoxAnchorResolver
+    from publiplots.annotate.point_values import PointAnchorResolver
+
+    assert BarAnchorResolver.VALID_ANCHORS == frozenset({
+        "outside", "inside", "base", "center",
+    })
+    assert BarAnchorResolver.DEFAULT_ANCHOR == "outside"
+    assert PointAnchorResolver.VALID_ANCHORS == frozenset({
+        "top", "bottom", "left", "right", "center",
+    })
+    assert PointAnchorResolver.DEFAULT_ANCHOR == "top"
+    assert BoxAnchorResolver.VALID_ANCHORS == frozenset({
+        "top", "bottom", "left", "right", "center",
+    })
+    assert BoxAnchorResolver.DEFAULT_ANCHOR == "top"

--- a/tests/annotate/test_violin_custom.py
+++ b/tests/annotate/test_violin_custom.py
@@ -1,0 +1,147 @@
+"""Tests for the violin_custom strategy."""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import publiplots as pp
+from publiplots.annotate._cache import BoxStatsRecord
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _simple_df():
+    # 10 samples per cat for stable KDE
+    return pd.DataFrame({
+        "cat": pd.Categorical(
+            ["A"] * 10 + ["B"] * 10 + ["C"] * 10,
+            categories=["A", "B", "C"],
+        ),
+        "value": list(range(1, 31)),
+        "n":     [10] * 10 + [20] * 10 + [30] * 10,
+    })
+
+
+def test_column_labels_from_cached_frame():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="violin_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "20", "30"]
+
+
+def test_column_labels_with_fmt():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="violin_custom", labels="n", fmt="n={:,}")
+    assert [t.get_text() for t in texts] == ["n=10", "n=20", "n=30"]
+
+
+def test_column_labels_with_data_override():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    other = _simple_df().assign(n=[99] * 10 + [88] * 10 + [77] * 10)
+    texts = pp.annotate(ax, kind="violin_custom", labels="n", data=other)
+    assert [t.get_text() for t in texts] == ["99", "88", "77"]
+
+
+def test_column_labels_hue_split():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(
+            ["A"] * 20 + ["B"] * 20, categories=["A", "B"],
+        ),
+        "hue": pd.Categorical(
+            (["x"] * 10 + ["y"] * 10) * 2, categories=["x", "y"],
+        ),
+        "value": list(range(1, 41)),
+        "n": [11] * 10 + [22] * 10 + [33] * 10 + [44] * 10,
+    })
+    ax = pp.violinplot(data=df, x="cat", y="value", hue="hue")
+    texts = pp.annotate(ax, kind="violin_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["11", "33", "22", "44"]
+
+
+def test_column_labels_intra_group_variance_warns_and_uses_first():
+    df = pd.DataFrame({
+        "cat": pd.Categorical(
+            ["A"] * 10 + ["B"] * 10, categories=["A", "B"],
+        ),
+        "value": list(range(1, 21)),
+        "n": [10] * 9 + [999] + [20] * 10,
+    })
+    ax = pp.violinplot(data=df, x="cat", y="value")
+    with pytest.warns(UserWarning, match="varies within group"):
+        texts = pp.annotate(ax, kind="violin_custom", labels="n")
+    assert [t.get_text() for t in texts] == ["10", "20"]
+
+
+def test_callable_receives_box_record():
+    seen = []
+    def label(rec):
+        assert isinstance(rec, BoxStatsRecord)
+        seen.append(rec)
+        return str(rec.category)
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(ax, kind="violin_custom", labels=label)
+    assert [t.get_text() for t in texts] == ["A", "B", "C"]
+    assert len(seen) == 3
+
+
+def test_callable_returning_none_skips_violin():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    texts = pp.annotate(
+        ax, kind="violin_custom",
+        labels=lambda r: None if r.category == "B" else str(r.category),
+    )
+    assert [t.get_text() for t in texts] == ["A", "C"]
+
+
+def test_callable_returning_non_string_raises_typeerror():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="draw_index=0"):
+        pp.annotate(ax, kind="violin_custom", labels=lambda r: 42)
+
+
+def test_fmt_warns_when_labels_is_callable():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    with pytest.warns(UserWarning, match="fmt is ignored"):
+        pp.annotate(
+            ax, kind="violin_custom",
+            labels=lambda r: str(r.category),
+            fmt="n={}",
+        )
+
+
+def test_missing_labels_raises():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(ValueError, match="labels"):
+        pp.annotate(ax, kind="violin_custom")
+
+
+def test_foreign_axes_warns_and_returns_empty():
+    fig, ax = plt.subplots()
+    ax.violinplot([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    with pytest.warns(UserWarning, match="publiplots-owned axes"):
+        texts = pp.annotate(ax, kind="violin_custom", labels="n")
+    assert texts == []
+
+
+def test_column_not_in_frame_raises_keyerror():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(KeyError, match="not_a_col"):
+        pp.annotate(ax, kind="violin_custom", labels="not_a_col")
+
+
+def test_labels_wrong_type_raises():
+    ax = pp.violinplot(data=_simple_df(), x="cat", y="value")
+    with pytest.raises(TypeError, match="labels must be"):
+        pp.annotate(ax, kind="violin_custom", labels=123)
+
+
+def test_end_to_end_via_pp_violinplot_annotate():
+    ax = pp.violinplot(
+        data=_simple_df(), x="cat", y="value",
+        annotate={"kind": "violin_custom", "labels": "n", "fmt": "n={}"},
+    )
+    assert [t.get_text() for t in ax.texts] == ["n=10", "n=20", "n=30"]


### PR DESCRIPTION
## Summary

Adds ``kind="point_custom"`` / ``"box_custom"`` / ``"violin_custom"`` strategies to ``pp.annotate`` with the same ``labels=(column|callable)`` contract that ``bar_custom`` shipped in PR #140. Also:

- **Generic ``_CustomStrategy``** (in ``_custom.py``) — the label-resolution + per-record loop now lives in one class parameterized by ``(resolver, record_type, meta_attr, records_attr, introspect, has_fit_check, value_source, axes_to_expand)``. ``bar_custom`` is re-implemented atop it; the three new strategies are ~15-line instantiations each.
- **``AnchorResolver`` Protocol** with three adapters (``BarAnchorResolver``, ``PointAnchorResolver``, ``BoxAnchorResolver``) wrapping the existing private per-mark anchor resolvers.
- **Shared helpers** factored into ``_shared.py`` (``format_value``, ``format_column_value``, ``ensure_renderer``, ``build_column_label_table``, ``maybe_expand_limits``, ``compute_axes_to_expand_directional``) — removes ~200 lines of duplication across the six strategy files.
- **``PointRecord`` / ``BoxStatsRecord``** become frozen public dataclasses with the same ``source_frame`` / ``group_keys`` / ``category`` / ``hue_value`` / ``hatch_value`` / ``draw_index`` / ``frame_row_index`` contract ``BarRecord`` carries. Re-exported as ``publiplots.annotate.PointRecord`` / ``.BoxStatsRecord``.
- **``pp.pointplot`` / ``pp.boxplot`` / ``pp.violinplot``** now attach their meta unconditionally (like ``pp.barplot`` after PR #140) and honor ``annotate={"kind": ...}`` so callers can request custom strategies inline.

## Tests

- ~45 new tests (15 per new strategy) in ``test_point_custom.py`` / ``test_box_custom.py`` / ``test_violin_custom.py``, structurally parallel to ``test_bar_custom.py``.
- Integration tests in ``test_pointplot_integration.py`` / ``test_boxplot_integration.py`` verify the "meta attached unconditionally" invariant + the inline ``annotate={"kind": ...}`` path.
- 4 new ``test_cache.py`` tests for the extended ``PointRecord`` / ``BoxStatsRecord``.
- 2 ``test_positioning.py`` tests pinning the ``AnchorResolver`` protocol contract.

Suite counts: ``tests/annotate/`` ~230 passed; full publiplots suite ~810 passed; 0 skipped.

## Test plan
- [ ] ``uv run pytest tests/annotate/`` green
- [ ] ``uv run pytest`` full suite green
- [ ] ``cd docs && make html`` builds; inspect three new ``plot_17_annotate.html`` sub-sections (point_custom / box_custom / violin_custom)
- [ ] Spot-check error paths:
      ``pp.annotate(ax, kind="point_custom")`` → ``ValueError``;
      ``pp.annotate(ax, kind="box_custom", labels=lambda r: 42)`` → ``TypeError``;
      ``pp.annotate(ax, kind="box_custom", labels="nope")`` → ``KeyError``.

## Out of scope (follow-ups)
- Foreign-axes introspection for points / boxes / violins (today those three custom strategies warn + return ``[]`` on a non-publiplots-owned axes).
- Color-by-value callable (``color=lambda r: ...``).
- Unifying anchor vocabularies across mark types.