### PR TITLE
docs(plotting): list pp.hexbinplot under Distribution

### DIFF
--- a/docs/source/api/plotting.rst
+++ b/docs/source/api/plotting.rst
@@ -37,6 +37,7 @@ Distribution
 
    publiplots.histplot
    publiplots.kdeplot
+   publiplots.hexbinplot
 
 Matrix
 ------


### PR DESCRIPTION
## Summary

\`pp.hexbinplot\` shipped in v0.10.10 as the 2D sibling of \`pp.histplot\`, but the API reference page (\`docs/source/api/plotting.rst\`) wasn't updated alongside the implementation — so it never appeared in the auto-generated reference index even though the docstring is complete.

This one-line fix adds \`publiplots.hexbinplot\` to the Distribution autosummary block, right next to \`publiplots.histplot\` and \`publiplots.kdeplot\` so the 1D / 2D density triplet is grouped together.

## Test plan

- [x] Inspected diff — single line addition, no other changes
- [ ] Render docs locally (\`cd docs && make html\`) and verify \`hexbinplot\` appears under Distribution in the generated API index

🤖 Generated with [Claude Code](https://claude.com/claude-code)