### PR TITLE
fix(annotate): use va='baseline' for above-mark labels

### DIFF
--- a/src/publiplots/annotate/_positioning.py
+++ b/src/publiplots/annotate/_positioning.py
@@ -103,10 +103,15 @@ def resolve_anchor(
         x_center = (left + right) / 2.0
         ha = "center"
 
+        # Labels sitting ABOVE a mark use va="baseline" (not "bottom") so the
+        # glyph baseline — not the bbox bottom — anchors to the offset point.
+        # A digit-only string has no descenders, so va="bottom" leaves ~3px of
+        # invisible descender slack between glyph ink and the bar; va="baseline"
+        # eliminates that, matching the visual gap of horizontal "outside" labels.
         if anchor == "outside":
             if is_positive:
                 edge = bar.err_high if bar.err_high is not None else top
-                return x_center, edge, 0.0, +offset_mm, ha, "bottom"
+                return x_center, edge, 0.0, +offset_mm, ha, "baseline"
             else:
                 edge = bar.err_low if bar.err_low is not None else bottom
                 return x_center, edge, 0.0, -offset_mm, ha, "top"
@@ -114,14 +119,14 @@ def resolve_anchor(
             if is_positive:
                 return x_center, top, 0.0, -offset_mm, ha, "top"
             else:
-                return x_center, bottom, 0.0, +offset_mm, ha, "bottom"
+                return x_center, bottom, 0.0, +offset_mm, ha, "baseline"
         if anchor == "base":
             if ax.get_yscale() == "log":
                 base = ax.get_ylim()[0]
             else:
                 base = 0.0
             if is_positive:
-                return x_center, base, 0.0, +offset_mm, ha, "bottom"
+                return x_center, base, 0.0, +offset_mm, ha, "baseline"
             else:
                 return x_center, base, 0.0, -offset_mm, ha, "top"
         if anchor == "center":

--- a/src/publiplots/annotate/box_stats.py
+++ b/src/publiplots/annotate/box_stats.py
@@ -52,11 +52,14 @@ def _resolve_box_anchor(
     don't rescale with ``sharey=True`` — only the mm padding needs to
     live in display space.
     """
+    # va="baseline" for "above-mark" anchors: see _positioning.resolve_anchor
+    # for the rationale (digit-only labels have invisible descender slack
+    # under va="bottom"; va="baseline" matches the horizontal-anchor gap).
     if orient == "v":
         px = box.center_pos
         py = stat_value
         if anchor == "top":
-            return px, py, 0.0, +offset_mm, "center", "bottom"
+            return px, py, 0.0, +offset_mm, "center", "baseline"
         if anchor == "bottom":
             return px, py, 0.0, -offset_mm, "center", "top"
         if anchor == "right":
@@ -70,7 +73,7 @@ def _resolve_box_anchor(
         px = stat_value
         py = box.center_pos
         if anchor == "top":
-            return px, py + box.cat_half_width, 0.0, +offset_mm, "center", "bottom"
+            return px, py + box.cat_half_width, 0.0, +offset_mm, "center", "baseline"
         if anchor == "bottom":
             return px, py - box.cat_half_width, 0.0, -offset_mm, "center", "top"
         if anchor == "right":

--- a/src/publiplots/annotate/point_values.py
+++ b/src/publiplots/annotate/point_values.py
@@ -56,9 +56,13 @@ def _resolve_point_anchor(
     px, py = point.xy
 
     if anchor == "top":
+        # va="baseline" (not "bottom"): for digit-only labels the bbox bottom
+        # sits ~3px below the glyph baseline (descender slack). va="baseline"
+        # anchors the visible glyph bottom directly to the offset point so the
+        # gap matches the horizontal "right" anchor.
         if point.err_high is not None:
-            return px, point.err_high, 0.0, +offset_mm, "center", "bottom"
-        return px, py, 0.0, +_MARKER_CLEARANCE_MM + offset_mm, "center", "bottom"
+            return px, point.err_high, 0.0, +offset_mm, "center", "baseline"
+        return px, py, 0.0, +_MARKER_CLEARANCE_MM + offset_mm, "center", "baseline"
     if anchor == "bottom":
         if point.err_low is not None:
             return px, point.err_low, 0.0, -offset_mm, "center", "top"

--- a/tests/annotate/test_bar_values.py
+++ b/tests/annotate/test_bar_values.py
@@ -107,7 +107,7 @@ def test_inside_fallback_to_outside_when_text_too_big():
     # Label should sit at or above the bar top, not inside the 0.001 height band.
     t = texts[0]
     _, y = t.get_position()
-    assert t.get_va() == "bottom"
+    assert t.get_va() == "baseline"
     assert y >= 0.001
 
 
@@ -173,3 +173,48 @@ def test_foreign_locked_limits_warn_on_clip():
                              color="auto", pad=1.0)
     clip_warnings = [w for w in rec if "clipped" in str(w.message)]
     assert clip_warnings
+
+
+def test_outside_top_uses_va_baseline_not_bottom():
+    """Regression: vertical anchor='outside' on a positive bar must use
+    va='baseline' (not 'bottom').
+
+    With va='bottom', matplotlib aligns the bbox bottom — which sits the
+    full font descender depth below the baseline — to the offset point.
+    For digit-only labels like "0.80" with no descenders, that descender
+    space is invisible vertical air, making the visual gap above the bar
+    look larger than the gap beside a horizontal bar's outside-right
+    label. va='baseline' anchors the glyph baseline directly to the
+    offset point, so the bbox bottom sits ~3px closer to the bar than
+    the offset distance — proof the slack is gone.
+    """
+    import pandas as pd  # noqa: PLC0415
+    import publiplots as pp  # noqa: PLC0415
+
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"]),
+        "value": [0.80, 0.75, 0.88],
+    })
+
+    offset_mm = 1.0
+    ax = pp.barplot(
+        data=df, x="cat", y="value",
+        annotate={"fmt": ".2f", "anchor": "outside", "offset": offset_mm},
+    )
+    ax.figure.canvas.draw()
+    renderer = ax.figure.canvas.get_renderer()
+    fig_dpi = ax.figure.dpi
+    offset_px = offset_mm * fig_dpi / 25.4
+
+    for t, bar in zip(ax.texts, ax._publiplots_bar_meta.bars):
+        assert t.get_va() == "baseline"
+        bbox = t.get_window_extent(renderer)
+        bar_top = bar.patch.get_window_extent(renderer).y1
+        # va='bottom' would put bbox.y0 ≈ bar_top + offset_px (full slack).
+        # va='baseline' puts bbox.y0 ≈ bar_top + offset_px - descender_depth,
+        # so it sits *below* what va='bottom' would give. Require at least
+        # 1.5px of separation to confirm the descender slack collapsed.
+        assert bbox.y0 < bar_top + offset_px - 1.5, (
+            f"bbox.y0 ({bbox.y0:.2f}) is too close to bar_top + offset "
+            f"({bar_top + offset_px:.2f}) — va probably regressed to 'bottom'"
+        )

--- a/tests/annotate/test_box_stats.py
+++ b/tests/annotate/test_box_stats.py
@@ -106,7 +106,7 @@ def test_boxplot_annotate_anchor_top():
         assert y == pytest.approx(box.stats["median"])
         bb = t.get_window_extent(renderer).transformed(ax.transData.inverted())
         assert bb.y0 > box.stats["median"]
-        assert t.get_va() == "bottom"
+        assert t.get_va() == "baseline"
 
 
 def test_boxplot_annotate_anchor_center_on_median():

--- a/tests/annotate/test_point_values.py
+++ b/tests/annotate/test_point_values.py
@@ -124,7 +124,7 @@ def test_pointplot_annotate_default_anchor_is_top():
     for text, point in zip(ax.texts, meta.points):
         _, y = text.get_position()
         assert y >= point.err_high
-        assert text.get_va() == "bottom"
+        assert text.get_va() == "baseline"
 
 
 def test_pointplot_annotate_anchor_bottom_flips_below():

--- a/tests/annotate/test_positioning.py
+++ b/tests/annotate/test_positioning.py
@@ -40,7 +40,7 @@ def test_vertical_positive_outside_no_errorbar():
     x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="outside", orient="v",
                                           offset_mm=0.0, ax=ax)
     assert ha == "center"
-    assert va == "bottom"
+    assert va == "baseline"
     assert x == pytest.approx(1.0)
     assert y == pytest.approx(5.0)  # top of bar
 
@@ -72,7 +72,7 @@ def test_vertical_positive_base():
     x, y, dx, dy, ha, va = resolve_anchor(bar, anchor="base", orient="v",
                                           offset_mm=0.0, ax=ax)
     assert ha == "center"
-    assert va == "bottom"
+    assert va == "baseline"
     assert y == pytest.approx(0.0)
 
 

--- a/tests/annotate/test_rotation.py
+++ b/tests/annotate/test_rotation.py
@@ -111,8 +111,8 @@ def _simple_hbar_df():
 @pytest.mark.parametrize("rotation", [0.0, 45.0, 90.0, 180.0, 270.0])
 def test_barplot_annotate_rotation_preserves_anchor_geometry(rotation):
     """For anchor='outside' on a positive vertical bar, resolve_anchor returns
-    (ha='center', va='bottom'). matplotlib applies these to the post-rotation
-    bbox, so the anchor stays at the bbox's lower edge at any rotation — the
+    (ha='center', va='baseline'). matplotlib applies these to the post-rotation
+    bbox, so the anchor stays at the glyph baseline at any rotation — the
     label always extends "up" from the bar top in the post-rotation frame,
     which visually places it above the bar (or beside it, when rotated).
     """
@@ -122,7 +122,7 @@ def test_barplot_annotate_rotation_preserves_anchor_geometry(rotation):
     for t in ax.texts:
         assert t.get_rotation() == pytest.approx(rotation)
         assert t.get_ha() == "center"
-        assert t.get_va() == "bottom"
+        assert t.get_va() == "baseline"
 
 
 def test_barplot_annotate_rotation_90_bbox_sits_above_bar_top():
@@ -285,11 +285,11 @@ def _point_df():
 
 
 def test_pointplot_annotate_rotation_90_preserves_anchor():
-    """Default point_values anchor='top' returns (ha='center', va='bottom')."""
+    """Default point_values anchor='top' returns (ha='center', va='baseline')."""
     ax = pp.pointplot(data=_point_df(), x="time", y="v",
                       errorbar="se", annotate={"rotation": 90})
     assert len(ax.texts) == 3
     for t in ax.texts:
         assert t.get_rotation() == pytest.approx(90.0)
         assert t.get_ha() == "center"
-        assert t.get_va() == "bottom"
+        assert t.get_va() == "baseline"


### PR DESCRIPTION
## Summary

- The vertical anchor for "outside" / "base" labels above bars (and "top" above points/boxes) used `va="bottom"`, which aligns the bbox bottom to the offset point.
- For digit-only labels like `"0.90"`, the bbox bottom sits ~3px below the glyph baseline (descender room) — invisible vertical slack that made the top gap look noticeably larger than the horizontal "outside" gap on the same plot.
- Switched to `va="baseline"` so the glyph baseline anchors directly to the offset point, collapsing the slack so vertical and horizontal "outside" labels share one tight visual gap.

## Before / after

The visual gap above the vertical bars now matches the gap to the right of the horizontal bars (1mm @ 150dpi ≈ 5.9px in both orientations). The user-reported `multiple="gain"` example renders all "outside top" labels at the same tight gap as their "inside top" counterparts.

## Test plan

- [x] `pytest tests/annotate/` — 232 passed
- [x] `pytest tests/` — 827 passed
- [x] New regression test `test_outside_top_uses_va_baseline_not_bottom` asserts the bbox bottom now sits below `bar_top + offset_px` (proving the descender slack collapsed)
- [x] Visual confirmation: outside-top vs outside-right gaps look identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)