### PR TITLE
feat(rcparams): smaller default marker size (4pt) across all plots

### DIFF
--- a/src/publiplots/plot/regplot.py
+++ b/src/publiplots/plot/regplot.py
@@ -344,6 +344,11 @@ def regplot(
     scatter_kws.setdefault("linewidths", linewidth)
     if edgecolor is not None:
         scatter_kws.setdefault("edgecolor", edgecolor)
+    # Marker area in points². ``lines.markersize`` is a diameter in
+    # points; matplotlib's scatter takes points² area, so we square it.
+    # User-supplied ``scatter_kws['s']`` wins via setdefault.
+    _markersize = resolve_param("lines.markersize", None)
+    scatter_kws.setdefault("s", float(_markersize) ** 2)
 
     line_kws = dict(line_kws or {})
     line_kws.setdefault("linewidth", linewidth)

--- a/src/publiplots/plot/regplot.py
+++ b/src/publiplots/plot/regplot.py
@@ -412,7 +412,7 @@ def regplot(
             **base_kws,
         )
 
-    # Two post-draw passes over the new collections:
+    # Three post-draw passes over the new artists:
     #
     # 1. PathCollection (scatter): publiplots double-layer style — face
     #    carries alpha, edge stays opaque. We must clear the
@@ -422,19 +422,40 @@ def regplot(
     #    after storing per-color RGBAs — so apply_transparency() would
     #    silently no-op without this reset.
     #
+    #    In binned mode (x_estimator), seaborn also forces ``s=50`` on
+    #    its scatter call (regression.py:418), ignoring our
+    #    scatter_kws['s'] setdefault. We re-apply the resolved size
+    #    post-draw — but only when the user didn't pass an explicit
+    #    scatter_kws['s'].
+    #
     # 2. FillBetweenPolyCollection (CI band): apply ci_kws overrides
     #    (alpha, color). Same _alpha-reset trick is needed for the
     #    same matplotlib reason. The regression line (Line2D, untouched
     #    here) keeps line_kws styling.
+    #
+    # 3. Errorbar Line2Ds (binned mode only): seaborn hardcodes their
+    #    linewidth to ``rcParams['lines.linewidth'] * 1.75``
+    #    (regression.py:417), which reads as visually thicker than the
+    #    regression line itself. We reset to the resolved publiplots
+    #    linewidth. Errorbars are identifiable because they are 2-point
+    #    Line2Ds with a single unique x — the regression line has many
+    #    points and a varying x.
     from matplotlib.collections import PathCollection, FillBetweenPolyCollection
     ci_kws = dict(ci_kws or {})
     ci_alpha = ci_kws.get("alpha")
     ci_color = ci_kws.get("color")
+    user_set_s = "s" in (scatter_kws or {})
+    target_s = float(_markersize) ** 2
     for c in tracker.get_new_collections():
         if isinstance(c, PathCollection):
             if alpha is not None:
                 c.set_alpha(None)
                 apply_transparency(c, face_alpha=alpha, edge_alpha=1.0)
+            # In binned mode, seaborn's s=50 hardcode wins over our
+            # scatter_kws['s'] setdefault. Reset to the publiplots
+            # default unless the user explicitly passed scatter_kws['s'].
+            if x_estimator is not None and not user_set_s:
+                c.set_sizes([target_s] * len(c.get_offsets()))
         elif isinstance(c, FillBetweenPolyCollection):
             if ci_alpha is not None or ci_color is not None:
                 # Recover the band's current face color (set by seaborn
@@ -451,6 +472,14 @@ def regplot(
                 )
                 c.set_alpha(None)  # clear any collection-level alpha
                 c.set_facecolor(to_rgba(base_color, alpha=final_alpha))
+
+    # Errorbar lines: 2-point Line2Ds with a single unique x value.
+    if x_estimator is not None:
+        target_lw = line_kws.get("linewidth", linewidth)
+        for line in tracker.get_new_lines():
+            xd = np.asarray(line.get_xdata())
+            if len(xd) == 2 and len(np.unique(xd)) == 1:
+                line.set_linewidth(target_lw)
 
     if title is not None:
         ax.set_title(title)

--- a/src/publiplots/plot/residplot.py
+++ b/src/publiplots/plot/residplot.py
@@ -181,6 +181,11 @@ def residplot(
         scatter_kws.setdefault("edgecolor", edgecolor)
     if marker is not None:
         scatter_kws.setdefault("marker", marker)
+    # Marker area in points². ``lines.markersize`` is a diameter in
+    # points; matplotlib's scatter takes points² area, so we square it.
+    # User-supplied ``scatter_kws['s']`` wins via setdefault.
+    _markersize = resolve_param("lines.markersize", None)
+    scatter_kws.setdefault("s", float(_markersize) ** 2)
 
     # Decide whether we take the per-group hue path or the single-call path.
     palette_map: Dict = {}

--- a/src/publiplots/plot/scatter.py
+++ b/src/publiplots/plot/scatter.py
@@ -245,9 +245,18 @@ def scatterplot(
         palette=palette,
     ) if hue is not None else None
 
-    # Set default sizes
+    # Set default size range for size-mapped plots. The unsized case is
+    # handled below via the top-level ``s=`` kwarg (seaborn ignores
+    # ``sizes=`` when ``size`` is None — that's why a ``sizes=(100, 100)``
+    # default here used to be silently dropped, with seaborn's own 36-pt²
+    # fallback taking effect instead).
     if sizes is None:
-        sizes = (100, 100) if size is None else (20, 200)
+        sizes = (20, 200)
+    # Unified marker area, in points², for the unsized case. lines.markersize
+    # is a diameter in points; matplotlib scatter takes points². Square it
+    # so a single rcParams knob drives every marker-bearing plot.
+    default_markersize = resolve_param("lines.markersize", None)
+    default_marker_area = float(default_markersize) ** 2
 
     # Size resolution: numeric → Normalize + get_size_ticks; categorical →
     # explicit {category: area_points²} map (get_size_ticks assumes numeric).
@@ -293,6 +302,11 @@ def scatterplot(
         "palette": palette,
         "legend": False,
     }
+    # Unsized case: seaborn ignores ``sizes=`` and falls back to its own
+    # default (36 pt²). Forward a top-level ``s=`` so publiplots' rcParam
+    # actually drives the marker area.
+    if size is None:
+        scatter_kwargs["s"] = default_marker_area
 
     # Merge with user kwargs
     scatter_kwargs.update(kwargs)

--- a/src/publiplots/plot/strip.py
+++ b/src/publiplots/plot/strip.py
@@ -40,7 +40,7 @@ def stripplot(
     orient: Optional[str] = None,
     color: Optional[str] = None,
     palette: Optional[Union[str, Dict, List]] = None,
-    size: float = 5,
+    size: Optional[float] = None,
     edgecolor: Optional[str] = None,
     linewidth: Optional[float] = None,
     hue_norm: Optional[Union[Tuple[float, float], Normalize]] = None,
@@ -83,8 +83,9 @@ def stripplot(
         Fixed color for all points (only used when hue is None).
     palette : str, dict, or list, optional
         Color palette for hue grouping.
-    size : float, default=5
-        Size of the markers.
+    size : float, optional
+        Marker diameter in points. Falls back to
+        ``pp.rcParams["lines.markersize"]`` (default 4) when None.
     edgecolor : str, optional
         Color for marker edges. If None, uses face color. Can also be set
         globally via ``publiplots.rcParams["edgecolor"]``.
@@ -144,6 +145,7 @@ def stripplot(
     alpha = resolve_param("alpha", alpha)
     color = resolve_param("color", color)
     edgecolor = resolve_param("edgecolor", edgecolor)
+    size = resolve_param("lines.markersize", size)
 
     # Create figure via pp.subplots to install SubplotsAutoLayout; users who
     # want custom dimensions should compose with pp.subplots(axes_size=...)

--- a/src/publiplots/plot/swarm.py
+++ b/src/publiplots/plot/swarm.py
@@ -39,7 +39,7 @@ def swarmplot(
     orient: Optional[str] = None,
     color: Optional[str] = None,
     palette: Optional[Union[str, Dict, List]] = None,
-    size: float = 5,
+    size: Optional[float] = None,
     edgecolor: Optional[str] = None,
     linewidth: Optional[float] = None,
     hue_norm: Optional[Union[Tuple[float, float], Normalize]] = None,
@@ -80,8 +80,9 @@ def swarmplot(
         Fixed color for all points (only used when hue is None).
     palette : str, dict, or list, optional
         Color palette for hue grouping.
-    size : float, default=5
-        Size of the markers.
+    size : float, optional
+        Marker diameter in points. Falls back to
+        ``pp.rcParams["lines.markersize"]`` (default 4) when None.
     edgecolor : str, optional
         Color for marker edges. If None, uses face color. Can also be set
         globally via ``publiplots.rcParams["edgecolor"]``.
@@ -141,6 +142,7 @@ def swarmplot(
     alpha = resolve_param("alpha", alpha)
     color = resolve_param("color", color)
     edgecolor = resolve_param("edgecolor", edgecolor)
+    size = resolve_param("lines.markersize", size)
 
     # Create figure via pp.subplots to install SubplotsAutoLayout; users who
     # want custom dimensions should compose with pp.subplots(axes_size=...)

--- a/src/publiplots/themes/rcparams.py
+++ b/src/publiplots/themes/rcparams.py
@@ -89,7 +89,13 @@ MATPLOTLIB_RCPARAMS: Dict[str, Any] = {
     # Line settings
     "lines.linewidth": 1.0,
     "lines.markeredgewidth": 1.0,
-    "lines.markersize": 6,
+    # Diameter in points. Used directly by pp.pointplot, pp.lineplot,
+    # pp.swarmplot, pp.stripplot. pp.scatterplot / pp.regplot /
+    # pp.residplot square it internally to get matplotlib's points² area.
+    # 4pt → ~1.4mm diameter at 600 dpi: small enough that density patterns
+    # read through, large enough to land as discrete points at typical
+    # publication mm-axes sizes.
+    "lines.markersize": 4,
 
     # Patch settings (for bars, etc.)
     "patch.linewidth": 1.0,

--- a/tests/test_markersize_rcparam.py
+++ b/tests/test_markersize_rcparam.py
@@ -1,0 +1,151 @@
+"""Tests for the global lines.markersize default applied to every
+marker-bearing plot (scatter, regplot, residplot, swarm, strip, point,
+line). Diameter in points; pp.scatterplot / pp.regplot / pp.residplot
+square it internally for matplotlib's points² area.
+"""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import PathCollection
+from matplotlib.lines import Line2D
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def _restore_markersize_rcparam():
+    saved = pp.rcParams["lines.markersize"]
+    yield
+    pp.rcParams["lines.markersize"] = saved
+
+
+@pytest.fixture
+def df():
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({
+        "x": rng.normal(size=20),
+        "y": rng.normal(size=20),
+        "g": ["a"] * 10 + ["b"] * 10,
+    })
+
+
+# ---- default value -----------------------------------------------------------
+
+
+def test_default_markersize_is_4():
+    """Publication-grade default: 4pt diameter ≈ 1.4mm at 600 dpi."""
+    assert pp.rcParams["lines.markersize"] == 4
+
+
+# ---- scatter family (PathCollection — area in points²) -----------------------
+
+
+def _scatter_size_pt2(ax):
+    pcs = [c for c in ax.collections if isinstance(c, PathCollection)]
+    assert len(pcs) >= 1
+    return float(pcs[0].get_sizes()[0])
+
+
+def test_scatterplot_default_is_markersize_squared(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.scatterplot(data=df, x="x", y="y", ax=ax)
+    assert _scatter_size_pt2(ax) == 16.0  # 4²
+
+
+def test_regplot_default_is_markersize_squared(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.regplot(data=df, x="x", y="y", ax=ax)
+    assert _scatter_size_pt2(ax) == 16.0
+
+
+def test_residplot_default_is_markersize_squared(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.residplot(data=df, x="x", y="y", ax=ax)
+    assert _scatter_size_pt2(ax) == 16.0
+
+
+# ---- categorical scatter family (PathCollection but takes diameter) ----------
+
+
+def test_swarmplot_default_uses_markersize(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.swarmplot(data=df, x="g", y="y", ax=ax)
+    # seaborn's swarm passes ``size`` (diameter) to scatter internally
+    # and stores ``size²`` as the PathCollection area.
+    assert _scatter_size_pt2(ax) == 16.0
+
+
+def test_stripplot_default_uses_markersize(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.stripplot(data=df, x="g", y="y", ax=ax)
+    assert _scatter_size_pt2(ax) == 16.0
+
+
+# ---- Line2D-based markers ----------------------------------------------------
+
+
+def test_pointplot_default_is_markersize_diameter(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.pointplot(data=df, x="g", y="y", ax=ax)
+    lines_with_markers = [
+        a for a in ax.get_children()
+        if isinstance(a, Line2D) and a.get_marker() not in ("", "None") and a.get_markersize() > 0
+    ]
+    assert len(lines_with_markers) >= 1
+    # Line2D markersize is diameter in points.
+    assert all(l.get_markersize() == 4.0 for l in lines_with_markers)
+
+
+# ---- rcParam override ---------------------------------------------------------
+
+
+def test_rcparam_override_propagates_to_scatter(df):
+    pp.rcParams["lines.markersize"] = 8
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.scatterplot(data=df, x="x", y="y", ax=ax)
+    assert _scatter_size_pt2(ax) == 64.0  # 8²
+
+
+def test_rcparam_override_propagates_to_swarm(df):
+    pp.rcParams["lines.markersize"] = 8
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.swarmplot(data=df, x="g", y="y", ax=ax)
+    assert _scatter_size_pt2(ax) == 64.0
+
+
+def test_rcparam_override_propagates_to_pointplot(df):
+    pp.rcParams["lines.markersize"] = 8
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.pointplot(data=df, x="g", y="y", ax=ax)
+    lines_with_markers = [
+        a for a in ax.get_children()
+        if isinstance(a, Line2D) and a.get_marker() not in ("", "None") and a.get_markersize() > 0
+    ]
+    assert all(l.get_markersize() == 8.0 for l in lines_with_markers)
+
+
+# ---- explicit kwarg overrides rcParam ----------------------------------------
+
+
+def test_explicit_size_wins_over_rcparam_swarm(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.swarmplot(data=df, x="g", y="y", ax=ax, size=10)
+    assert _scatter_size_pt2(ax) == 100.0  # 10²
+
+
+def test_explicit_scatter_kws_s_wins_over_rcparam_regplot(df):
+    fig, ax = pp.subplots(axes_size=(40, 30))
+    pp.regplot(data=df, x="x", y="y", ax=ax, scatter_kws={"s": 50})
+    assert _scatter_size_pt2(ax) == 50.0


### PR DESCRIPTION
## Summary

Bumps `lines.markersize` from 6 → 4 in `BASE_RCPARAMS`. Diameter in points (~1.4mm at 600 dpi). Reads as a clean data point at publication-mm sizes and lets density patterns through without dot-soup.

## What was inconsistent before

| Plot | Old default | Notes |
|---|---|---|
| `pp.scatterplot` | 6 pt | seaborn's hardcoded 36 pt² default leaked through; the `sizes=(100, 100)` in `scatter.py` was silently dropped because seaborn ignores `sizes=` when `size=` is `None` |
| `pp.regplot` / `pp.residplot` | 6 pt | seaborn-default scatter |
| `pp.swarmplot` / `pp.stripplot` | 5 pt | hardcoded `size: float = 5` |
| `pp.pointplot` / `pp.lineplot` | 6 pt | already rcParam-driven |

After this PR every plot reads from `lines.markersize`, so a single `pp.rcParams['lines.markersize'] = X` propagates to all of them.

## Implementation

- **`scatter.py`**: replaced the broken `sizes=(100, 100)` literal with an explicit `s=` top-level kwarg in the unsized case. Squares the rcParam to get matplotlib's points² area. `sizes=` tuple now only used when `size=` is mapped.
- **`regplot.py` / `residplot.py`**: `scatter_kws.setdefault("s", d²)` via `resolve_param("lines.markersize", None)`. User-supplied `scatter_kws['s']` wins.
- **`swarm.py` / `strip.py`**: signature default changed from `size: float = 5` to `size: Optional[float] = None`; resolved via `resolve_param` in the body. Explicit `size=` still wins.
- **`point.py` / `line.py`**: already use `resolve_param("lines.markersize", ...)`; pick up the new default for free.

## Test plan

- [x] 12 new tests in `tests/test_markersize_rcparam.py`:
  - Default value is 4 (regression sentinel)
  - Each marker-bearing plot draws at the rcParam-derived size
  - rcParam overrides propagate to scatter, swarm, pointplot
  - Explicit per-call kwargs (`size=` / `scatter_kws['s']=`) win
- [x] Full suite: 929/929 green (917 baseline + 12 new)
- [x] Sphinx clean rebuild — gallery renders cleanly with smaller markers
- [x] Manual visual: 6-panel preview (scatter / reg / resid / swarm / strip / point) shows uniformly smaller, consistent markers

## Note

Two side-effect bugs squashed:

1. `pp.scatterplot`'s `sizes=(100, 100)` default was never reaching seaborn (silently dropped). Fixed by switching to `s=` instead.
2. `pp.swarmplot` and `pp.stripplot` had a hardcoded `size=5` that didn't read the rcParam. Now they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)