### PR TITLE
chore(release): v0.10.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.12] - 2026-05-13
+
+### Changed
+
+- **Default marker diameter dropped from 6pt to 4pt** across every
+  marker-bearing plot (PR #152). 4pt ≈ 1.4mm at 600 dpi — small
+  enough that density patterns read through, large enough to land
+  as a discrete data point at publication-mm sizes. The new default
+  is driven by ``pp.rcParams["lines.markersize"]``, so a single
+  rcParam override now propagates to ``pp.scatterplot``,
+  ``pp.regplot``, ``pp.residplot``, ``pp.swarmplot``,
+  ``pp.stripplot``, ``pp.pointplot``, and ``pp.lineplot``.
+  - Previously every plot picked its own size: 5pt (swarm/strip
+    hardcode), 6pt (point/line via rcParam), 6pt (scatter — but its
+    own ``sizes=(100, 100)`` literal was silently dropped because
+    seaborn ignores ``sizes=`` when ``size=`` is None, so seaborn's
+    36 pt² fallback won). Two latent bugs fixed as part of the
+    rewiring (see "Fixed" below).
+  - The scatter family squares the rcParam internally to get
+    matplotlib's points² area; everything else uses it as a
+    diameter directly.
+  - User-supplied ``size=`` (swarm/strip), ``scatter_kws['s']=``
+    (regplot/residplot), or ``s=`` (scatterplot) still wins via
+    ``setdefault``.
+
+### Fixed
+
+- ``pp.scatterplot``'s default size now actually reaches the canvas
+  (PR #152). The previous ``sizes=(100, 100)`` literal at
+  ``scatter.py:250`` was dropped silently because seaborn ignores
+  ``sizes=`` when ``size=`` is None — seaborn's 36 pt² fallback won
+  unnoticed. Replaced with a top-level ``s=`` kwarg that seaborn
+  honors.
+
+- ``pp.swarmplot`` / ``pp.stripplot`` defaults now read from
+  ``pp.rcParams["lines.markersize"]`` instead of being hardcoded
+  to 5 (PR #152). Signature default changed from ``size: float = 5``
+  to ``size: Optional[float] = None``.
+
+- ``pp.regplot(x_estimator=, x_bins=)`` errorbar linewidth and
+  binned-point area no longer follow seaborn's hardcoded
+  ``rcParams['lines.linewidth'] * 1.75`` (errorbar) / ``s=50``
+  (point) values — both are now driven by publiplots conventions
+  (PR #152). Errorbars are reset to ``rcParams['lines.linewidth']``
+  and binned points to ``rcParams['lines.markersize']²`` post-draw,
+  with user overrides via ``line_kws['linewidth']`` and
+  ``scatter_kws['s']`` preserved.
+
 ## [0.10.11] - 2026-05-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.11"
+version = "0.10.12"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/skills/legend-placement/SKILL.md
+++ b/skills/legend-placement/SKILL.md
@@ -154,4 +154,4 @@ for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
 
 ## Further reading
 
-For the full factory signature (every kwarg: `orientation`, `align`, `x_offset`, `y_offset`, `gap`, `column_spacing`, `vpad`, `max_width`, `figure`), see `src/publiplots/utils/legend_group.py`. For 14 worked examples covering every scope mode, see `examples/plots/plot_17_legend_placement.py`.
+For the full factory signature (every kwarg: `orientation`, `align`, `x_offset`, `y_offset`, `gap`, `column_spacing`, `vpad`, `max_width`, `figure`), see `src/publiplots/utils/legend_group.py`. For 14 worked examples covering every scope mode, see `examples/plots/plot_22_legend_placement.py`.

--- a/skills/publiplots-guide/SKILL.md
+++ b/skills/publiplots-guide/SKILL.md
@@ -18,9 +18,16 @@ publiplots is a publication-ready plotting library with a seaborn-shaped API but
 ## Public API surface (`pp.*`)
 
 ### Plots
-`barplot`, `scatterplot`, `pointplot`, `lineplot`, `boxplot`, `swarmplot`, `stripplot`, `violinplot`, `raincloudplot`, `venn`, `upsetplot`, `heatmap`, `complex_heatmap`, `dendrogram`.
+`barplot`, `scatterplot`, `pointplot`, `lineplot`, `regplot`, `residplot`, `boxplot`, `swarmplot`, `stripplot`, `violinplot`, `raincloudplot`, `histplot`, `kdeplot`, `hexbinplot`, `venn`, `upsetplot`, `heatmap`, `complex_heatmap`, `dendrogram`.
 
 All accept `data=`, `x=`, `y=`, `hue=`, `palette=`, `ax=`, `title=`, `legend_kws={}`. None accept `figsize=` — it raises `TypeError` (see `src/publiplots/layout/subplots.py::reject_figsize`).
+
+By plot family:
+- **Categorical:** `barplot`, `boxplot`, `violinplot`, `raincloudplot`, `stripplot`, `swarmplot`, `pointplot`.
+- **Relational:** `scatterplot`, `lineplot`, `regplot`, `residplot`.
+- **Distribution:** `histplot`, `kdeplot`, `hexbinplot`.
+- **Matrix:** `heatmap`, `complex_heatmap`, `dendrogram`.
+- **Set:** `venn`, `upsetplot`.
 
 ### Layout
 - `pp.subplots(nrows, ncols, *, axes_size=(w_mm, h_mm), sharex, sharey, title_space, xlabel_space, ylabel_space, right, hspace, wspace, outer_pad, **fig_kw)` — the canonical factory. Returns `(fig, axes)` with `plt.subplots`-style squeezing.
@@ -136,11 +143,12 @@ pp.reset_style()
 
 ## When to read the code directly
 
-publiplots has ~15 plot functions, each with plot-specific kwargs. When asked about a specific plot kind, Read `src/publiplots/plot/<kind>.py` for the signature:
+publiplots has 19 plot functions, each with plot-specific kwargs. When asked about a specific plot kind, Read `src/publiplots/plot/<kind>.py` for the signature:
 
-- Heatmaps: `src/publiplots/plot/heatmap.py` (plus `complex_heatmap` and `dendrogram` in the same file).
-- Distributions: `src/publiplots/plot/{violin,box,swarm,strip,raincloud}.py`.
-- Set diagrams: `src/publiplots/plot/{venn,upset}.py`.
-- Relational: `src/publiplots/plot/{scatter,line,point,bar}.py`.
+- Categorical: `src/publiplots/plot/{bar,box,violin,raincloud,strip,swarm,point}.py`.
+- Relational: `src/publiplots/plot/{scatter,line,regplot,residplot}.py`.
+- Distribution: `src/publiplots/plot/{hist,kdeplot,hexbin}.py`.
+- Matrix: `src/publiplots/plot/heatmap.py` (also `complex_heatmap` and `dendrogram` in the same file).
+- Set: `src/publiplots/plot/{venn,upset}.py`.
 
-For the full `pp.legend()` signature and every `MultiAxesLegendGroup` option, see `src/publiplots/utils/legend_group.py`. For canonical legend patterns with running code, the authoritative reference is `examples/plots/plot_17_legend_placement.py` (14 worked sections).
+For the full `pp.legend()` signature and every `MultiAxesLegendGroup` option, see `src/publiplots/utils/legend_group.py`. For canonical legend patterns with running code, the authoritative reference is `examples/plots/plot_22_legend_placement.py` (14 worked sections).

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.11"
+__version__ = "0.10.12"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.11"
+version = "0.10.12"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

Promotes `[Unreleased]` → `[0.10.12]` in the CHANGELOG and bumps the version in the four canonical places (`pyproject.toml`, `src/publiplots/__init__.py`, `.claude-plugin/plugin.json`, `uv.lock` regenerated).

### What's in 0.10.12

- **#152** — smaller default marker diameter (6pt → 4pt) across every marker-bearing plot. Single rcParam (`lines.markersize`) now drives `pp.scatterplot`, `pp.regplot`, `pp.residplot`, `pp.swarmplot`, `pp.stripplot`, `pp.pointplot`, `pp.lineplot`. Two latent bugs fixed in the rewiring (scatterplot's `sizes=(100, 100)` was silently dropped; swarm/strip had hardcoded `size=5`). Plus binned-mode regplot errorbar lw + point size now follow publiplots conventions instead of seaborn's hardcoded `lw*1.75` and `s=50`.

## Test plan

- [x] `uv lock` runs clean: publiplots 0.10.11 → 0.10.12
- [x] All 4 version-bearing files updated to 0.10.12
- [x] CHANGELOG entry mirrors the v0.10.11 / v0.10.10 prose style

🤖 Generated with [Claude Code](https://claude.com/claude-code)