### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.10.12",
+  "version": "0.11.0",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-13
+
+### Added
+
+- `pp.JointGrid` and `pp.jointplot` — bivariate + marginal-distribution
+  composition (PR #145). Three-axes layout: large bivariate main panel
+  with thin top and right marginals, hidden top-right corner, shared
+  axes, and symmetric joint↔marginal gaps at any height.
+  - `pp.JointGrid(data, *, x, y, height=80, ratio=5, space=None)` —
+    the primitive. Exposes `fig`, `ax_joint`, `ax_marg_x`, `ax_marg_y`.
+    Methods `.plot_joint(fn, **kw)` / `.plot_marginals(fn, **kw)` /
+    `.plot(joint_fn, marginal_fn, **kw)` forward `data`+`x`/`y`+`ax=`
+    to any compatible `pp.*` plot function. Chainable.
+  - `pp.jointplot(data, *, x, y, kind='scatter', ...)` — convenience
+    wrapper. `kind` in `{'scatter', 'hex', 'kde', 'reg', 'resid'}`
+    maps to (joint_fn, marginal_fn). Returns the constructed
+    `JointGrid` so per-axes tweaks remain possible. `'hist'` is
+    deferred until publiplots ships a 2D-histogram primitive.
+  - **Sizing.** `height` is the total grid budget in mm (square);
+    matches seaborn's `JointGrid(height=)` modulo the unit. `ratio`
+    is the marginal-to-main split (default `5`, matching seaborn's
+    default). `space` is the inter-panel gap in mm — `None` (default)
+    auto-scales as `height * 0.025` so the gap reads well across
+    sizes; an explicit value is taken as absolute mm for cross-figure
+    consistency.
+  - **Joint-panel legend routing.** Continuous-hue colorbar entries
+    stashed by `pp.hexbinplot` (or any 2D plot with a colorbar) on the
+    joint panel are auto-routed to a figure-level band anchored on the
+    right marginal — keeping the joint↔right-marginal pair flush.
+    Zero layout cost when no colorbar is stashed.
+
+- `pp.subplots` per-position lock/auto reservations via tuples-with-None.
+  Tuples passed to `title_space`, `xlabel_space`, `ylabel_space`, or
+  `right` may now contain `None` entries to opt that position into
+  auto-measurement while locking the others (PR #145).
+
+      pp.subplots(2, 2, ...,
+          xlabel_space=(0.0, None),    # row 0 locked to 0; row 1 auto
+          ylabel_space=(None, 0.0),    # col 0 auto; col 1 locked to 0
+      )
+
+  Each `None` resolves to the rcParams default at the `pp.subplots`
+  boundary; `FigureLayout` still receives a tuple of floats and its
+  data invariants are unchanged. Locked indices are tracked in
+  `SubplotsAutoLayout` so the reactor preserves the layout's current
+  value at locked positions instead of remeasuring on draw.
+
+  Used by `pp.JointGrid` to lock the four inside-facing reservations
+  to 0 mm so the joint↔marginal gaps stay symmetric (the auto-measured
+  `tightbbox` baseline padding from corner-most count-axis tick labels
+  was previously inflating one gap by ~0.7 mm relative to the other).
+  Available to any user composing asymmetric grids that need a flush
+  edge somewhere.
+
+### Changed
+
+- **Bumped to 0.11.0 (minor).** The new `JointGrid` / `jointplot`
+  surfaces and the `tuples-with-None` extension to `pp.subplots`
+  collectively justify a minor bump under semver. Backward
+  compatibility on existing `pp.subplots` and all per-side reservation
+  forms (scalar / `None` / full-floats-tuple) is preserved bit-for-bit.
+
 ## [0.10.12] - 2026-05-13
 
 ### Changed
@@ -403,6 +465,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
   the title correctly regardless (PR #128).
 
+[0.11.0]: https://github.com/jorgebotas/publiplots/releases/tag/v0.11.0
+[0.10.12]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.12
+[0.10.11]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.11
 [0.10.10]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.10
 [0.10.9]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.9
 [0.10.8]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.10.12"
+version = "0.11.0"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/skills/legend-placement/SKILL.md
+++ b/skills/legend-placement/SKILL.md
@@ -154,4 +154,4 @@ for (r, c), panel in zip([(0, 0), (0, 1), (1, 0), (1, 1)], "ABCD"):
 
 ## Further reading
 
-For the full factory signature (every kwarg: `orientation`, `align`, `x_offset`, `y_offset`, `gap`, `column_spacing`, `vpad`, `max_width`, `figure`), see `src/publiplots/utils/legend_group.py`. For 14 worked examples covering every scope mode, see `examples/plots/plot_22_legend_placement.py`.
+For the full factory signature (every kwarg: `orientation`, `align`, `x_offset`, `y_offset`, `gap`, `column_spacing`, `vpad`, `max_width`, `figure`), see `src/publiplots/utils/legend_group.py`. For 14 worked examples covering every scope mode, see `examples/plots/plot_23_legend_placement.py`.

--- a/skills/publiplots-guide/SKILL.md
+++ b/skills/publiplots-guide/SKILL.md
@@ -29,8 +29,14 @@ By plot family:
 - **Matrix:** `heatmap`, `complex_heatmap`, `dendrogram`.
 - **Set:** `venn`, `upsetplot`.
 
+### Composition
+- `pp.JointGrid(data, *, x, y, height=80, ratio=5, space=None)` — three-axes composition: large bivariate main panel + thin top and right marginals (shared axes, hidden corner). Methods `.plot_joint(fn, **kw)` / `.plot_marginals(fn, **kw)` / `.plot(joint_fn, marginal_fn, **kw)` forward to any compatible `pp.*` plot function via `ax=`. Chainable.
+- `pp.jointplot(data, *, x, y, kind='scatter', height=80, ratio=5, space=None, **kw)` — convenience wrapper. `kind` ∈ `{'scatter', 'hex', 'kde', 'reg', 'resid'}`. Returns the constructed `JointGrid`.
+
 ### Layout
-- `pp.subplots(nrows, ncols, *, axes_size=(w_mm, h_mm), sharex, sharey, title_space, xlabel_space, ylabel_space, right, hspace, wspace, outer_pad, **fig_kw)` — the canonical factory. Returns `(fig, axes)` with `plt.subplots`-style squeezing.
+- `pp.subplots(nrows, ncols, *, axes_size=(w_mm, h_mm), width_ratios=None, height_ratios=None, sharex, sharey, title_space, xlabel_space, ylabel_space, right, hspace, wspace, outer_pad, **fig_kw)` — the canonical factory. Returns `(fig, axes)` with `plt.subplots`-style squeezing.
+- **Asymmetric grids** (since 0.10.x): pass `width_ratios=[r0, r1, ...]` (length `ncols`) or `height_ratios=[...]` (length `nrows`) to renormalize the per-cell budget across columns/rows. Equal ratios recover the uniform case bit-for-bit. Total grid budget stays `axes_size[0] * ncols` × `axes_size[1] * nrows`.
+- **Per-position lock/auto** (since 0.11): tuples passed to `title_space` / `xlabel_space` / `ylabel_space` / `right` may contain `None` entries to opt that position into auto-measurement while locking the others. Example: `xlabel_space=(0.0, None)` locks row 0 to 0 mm and lets row 1 grow with decoration. Each `None` resolves to the rcParams default at construction; the reactor preserves the locked positions on later draws. Used internally by `pp.JointGrid` to keep joint↔marginal gaps symmetric without sacrificing auto-measurement of the joint panel's own labels.
 
 ### Legend
 - `pp.legend(axes=None, collect=None, *, side='right', anchor=None, figure=None, orientation='auto', align='auto', x_offset, y_offset, gap=2, column_spacing=5, vpad, max_width)` — unified legend factory. See the `legend-placement` skill.
@@ -108,6 +114,18 @@ pp.scatterplot(data=df, x="x", y="y", hue="group",
                legend_kws={"inside": True, "loc": "upper right"}, ax=ax)
 ```
 
+**Bivariate + marginals.** `pp.jointplot` is the canonical one-call form; reach for the `pp.JointGrid` class when you need different plot types in joint vs marginal slots.
+
+```python
+# Convenience wrapper — picks joint+marginal fns from a kind alias.
+pp.jointplot(data=df, x="x", y="y", kind="hex")  # or 'scatter', 'kde', 'reg', 'resid'
+
+# Class API — mix any compatible pp.* functions.
+g = pp.JointGrid(data=df, x="x", y="y", height=80, ratio=5)
+g.plot_joint(pp.hexbinplot, gridsize=20)
+g.plot_marginals(pp.histplot, bins=30, kde=True)
+```
+
 **Save a figure.** No implicit tight-crop; the canvas is already mm-precise.
 
 ```python
@@ -143,12 +161,13 @@ pp.reset_style()
 
 ## When to read the code directly
 
-publiplots has 19 plot functions, each with plot-specific kwargs. When asked about a specific plot kind, Read `src/publiplots/plot/<kind>.py` for the signature:
+publiplots has 19 plot functions plus the `JointGrid` composition, each with kind-specific kwargs. When asked about a specific plot kind, Read `src/publiplots/plot/<kind>.py` for the signature:
 
 - Categorical: `src/publiplots/plot/{bar,box,violin,raincloud,strip,swarm,point}.py`.
 - Relational: `src/publiplots/plot/{scatter,line,regplot,residplot}.py`.
 - Distribution: `src/publiplots/plot/{hist,kdeplot,hexbin}.py`.
 - Matrix: `src/publiplots/plot/heatmap.py` (also `complex_heatmap` and `dendrogram` in the same file).
 - Set: `src/publiplots/plot/{venn,upset}.py`.
+- Composition: `src/publiplots/layout/jointgrid.py` (`JointGrid` class + `jointplot` wrapper).
 
-For the full `pp.legend()` signature and every `MultiAxesLegendGroup` option, see `src/publiplots/utils/legend_group.py`. For canonical legend patterns with running code, the authoritative reference is `examples/plots/plot_22_legend_placement.py` (14 worked sections).
+For the full `pp.legend()` signature and every `MultiAxesLegendGroup` option, see `src/publiplots/utils/legend_group.py`. For canonical legend patterns with running code, the authoritative reference is `examples/plots/plot_23_legend_placement.py` (14 worked sections). For JointGrid usage patterns, see `examples/plots/plot_08_jointgrid.py` (7 worked sections covering all 5 `kind=` aliases plus the class API).

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.10.12"
+__version__ = "0.11.0"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.10.12"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` → `[0.11.0]` in CHANGELOG with the new `pp.JointGrid` / `pp.jointplot` composition surface and the per-position lock/auto extension to `pp.subplots` from PR #145.
- Bumps `pyproject.toml`, `src/publiplots/__init__.py`, and `.claude-plugin/plugin.json` from `0.10.12` → `0.11.0`.
- Regenerates `uv.lock`.
- Updates the Claude Code plugin skills (`publiplots-guide/SKILL.md`, `legend-placement/SKILL.md`) so the agent surface knows about `pp.JointGrid`, `pp.jointplot`, the new `width_ratios` / `height_ratios` and tuples-with-None reservation forms, and the renumbered gallery files.

## Why a minor bump?

`0.10.x → 0.11.0` reflects the new **composition primitive** (`pp.JointGrid`) and the **additive layout API** (per-position lock/auto via tuples-with-None on `pp.subplots`). Backward compatibility on every existing `pp.subplots` form (scalar / `None` / full-floats-tuple per-side reservations) is preserved bit-for-bit; no deprecations.

## Release notes

**Added**
- `pp.JointGrid` and `pp.jointplot` — bivariate + marginal composition. 5 `kind=` aliases (`scatter`, `hex`, `kde`, `reg`, `resid`); class API with `.plot_joint` / `.plot_marginals` for custom mixes; symmetric joint↔marginal gaps at any height; auto-routed colorbars on the right marginal anchor.
- `pp.subplots` per-position lock/auto via tuples-with-None on the four per-side reservations (`title_space`, `xlabel_space`, `ylabel_space`, `right`). Used internally by `JointGrid`; available to anyone composing asymmetric grids.

## Test plan

- [x] `uv lock` resolves cleanly; `publiplots v0.10.12 → v0.11.0`.
- [x] `python -c "import publiplots; print(publiplots.__version__)"` → `0.11.0`; `pp.JointGrid` / `pp.jointplot` importable.
- [x] Matches the shape of prior release PRs (`#149` v0.10.11, `#142` v0.10.10) — same 7 files, same sections.
- [ ] On merge: tag `v0.11.0` on main, publish GitHub release pointing at the new CHANGELOG anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)