### PR TITLE
fix(box,violin): support 1D mode via synthetic categorical axis

### DIFF
--- a/examples/plots/plot_09_jointgrid.py
+++ b/examples/plots/plot_09_jointgrid.py
@@ -104,18 +104,30 @@ g.plot_marginals(pp.kdeplot, fill=True)
 pp.show()
 
 # %%
-# Box / Violin Marginals
-# ----------------------
-# ``pp.boxplot`` and ``pp.violinplot`` accept univariate calls (only
-# ``x=`` or only ``y=``), which makes them drop-in marginal functions
-# for :class:`pp.JointGrid`. Each marginal becomes a single box / violin
-# summarizing that axis's distribution — a compact alternative to
-# histograms when the joint is dense. Here we put a scatter on the
-# joint with violin marginals on top and right.
+# Violin Marginals
+# ----------------
+# ``pp.violinplot`` accepts univariate calls (only ``x=`` or only
+# ``y=``), which makes it a drop-in marginal function for
+# :class:`pp.JointGrid`. Each marginal becomes a single violin
+# summarizing that axis's distribution — useful when you want
+# distribution-shape readouts on both axes alongside the joint.
 
 g = pp.JointGrid(data=mixture, x="x", y="y")
 g.plot_joint(pp.scatterplot, alpha=0.4)
 g.plot_marginals(pp.violinplot)
+pp.show()
+
+# %%
+# Box Marginals
+# -------------
+# ``pp.boxplot`` works the same way as a univariate marginal. Each
+# marginal collapses to a single box (median, IQR, whiskers, fliers)
+# — a compact summary that scales to large joint panels without
+# crowding.
+
+g = pp.JointGrid(data=mixture, x="x", y="y")
+g.plot_joint(pp.scatterplot, alpha=0.4)
+g.plot_marginals(pp.boxplot)
 pp.show()
 
 # %%

--- a/examples/plots/plot_09_jointgrid.py
+++ b/examples/plots/plot_09_jointgrid.py
@@ -94,12 +94,28 @@ pp.show()
 # yourself and call ``plot_joint`` / ``plot_marginals``. Any publiplots
 # plot function that accepts ``data=, x=, y=, ax=`` works in the joint
 # slot; for marginals, use 1D-capable ``pp.*`` plots — currently
-# :func:`pp.histplot`, :func:`pp.kdeplot`, and :func:`pp.stripplot`.
-# Here we mix a hexbin joint with KDE marginals.
+# :func:`pp.histplot`, :func:`pp.kdeplot`, :func:`pp.stripplot`,
+# :func:`pp.boxplot`, and :func:`pp.violinplot`. Here we mix a hexbin
+# joint with KDE marginals.
 
 g = pp.JointGrid(data=mixture, x="x", y="y")
 g.plot_joint(pp.hexbinplot, gridsize=20)
 g.plot_marginals(pp.kdeplot, fill=True)
+pp.show()
+
+# %%
+# Box / Violin Marginals
+# ----------------------
+# ``pp.boxplot`` and ``pp.violinplot`` accept univariate calls (only
+# ``x=`` or only ``y=``), which makes them drop-in marginal functions
+# for :class:`pp.JointGrid`. Each marginal becomes a single box / violin
+# summarizing that axis's distribution — a compact alternative to
+# histograms when the joint is dense. Here we put a scatter on the
+# joint with violin marginals on top and right.
+
+g = pp.JointGrid(data=mixture, x="x", y="y")
+g.plot_joint(pp.scatterplot, alpha=0.4)
+g.plot_marginals(pp.violinplot)
 pp.show()
 
 # %%

--- a/examples/plots/plot_14_box_plots.py
+++ b/examples/plots/plot_14_box_plots.py
@@ -80,6 +80,22 @@ ax = pp.boxplot(
 pp.show()
 
 # %%
+# Univariate (1D) Box Plot
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# Pass only ``x=`` or only ``y=`` to summarize a single distribution.
+# A constant categorical axis is synthesized internally so all 2D
+# features (``hue=``, ``annotate=``, ``alpha``, ``border_radius``)
+# remain available. The synthetic axis ticks and spine are hidden so
+# the result reads cleanly as a single-distribution summary. This is
+# the form used by :func:`pp.JointGrid.plot_marginals` to put boxes on
+# the marginal panels of a joint plot.
+
+fig, axes = pp.subplots(1, 2, axes_size=(40, 50))
+pp.boxplot(data=box_data, y='value', ax=axes[0], title='Vertical (y= only)')
+pp.boxplot(data=box_data, x='value', ax=axes[1], title='Horizontal (x= only)')
+pp.show()
+
+# %%
 # Combined Box and Swarm Plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Overlay swarm plot on box plot to show both summary statistics and individual data points.

--- a/examples/plots/plot_15_violin_plots.py
+++ b/examples/plots/plot_15_violin_plots.py
@@ -99,6 +99,22 @@ ax = pp.violinplot(
 pp.show()
 
 # %%
+# Univariate (1D) Violin Plot
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Pass only ``x=`` or only ``y=`` to summarize a single distribution.
+# A constant categorical axis is synthesized internally so all 2D
+# features (``hue=``, ``side=``, ``inner=``, ``alpha``) remain
+# available. The synthetic axis ticks and spine are hidden so the
+# result reads cleanly as a single-distribution summary. This is the
+# form used by :func:`pp.JointGrid.plot_marginals` to put violins on
+# the marginal panels of a joint plot.
+
+fig, axes = pp.subplots(1, 2, axes_size=(40, 50))
+pp.violinplot(data=violin_data, y='value', ax=axes[0], title='Vertical (y= only)')
+pp.violinplot(data=violin_data, x='value', ax=axes[1], title='Horizontal (x= only)')
+pp.show()
+
+# %%
 # Combined Violin and Swarm Plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Overlay swarm plot on violin plot to show distribution shape and individual data points.

--- a/src/publiplots/layout/jointgrid.py
+++ b/src/publiplots/layout/jointgrid.py
@@ -237,12 +237,9 @@ class JointGrid:
         Top marginal receives ``x=self.x``, right marginal receives
         ``y=self.y``. Plot functions that support swapping ``x=``/``y=``
         to flip orientation work directly: ``pp.histplot`` (the default
-        marginal for :func:`jointplot`) and ``pp.stripplot``. Plot
-        functions that require one of ``x`` or ``y`` and error on
-        ``None`` for the other (notably ``pp.violinplot``,
-        ``pp.boxplot``) will raise a ``KeyError: None`` from pandas at
-        call time — use ``pp.histplot`` instead, or pass pre-split
-        frames via ``plot_joint`` / the axes directly.
+        marginal for :func:`jointplot`) and ``pp.stripplot``.
+        ``pp.violinplot`` and ``pp.boxplot`` also support 1D usage
+        (only ``x`` or only ``y``) and work as marginals out of the box.
 
         Returns
         -------

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -358,10 +358,8 @@ def boxplot(
 
     if _hide_axis == "x":
         ax.set_xticks([])
-        ax.spines["bottom"].set_visible(False)
     elif _hide_axis == "y":
         ax.set_yticks([])
-        ax.spines["left"].set_visible(False)
 
     return ax
 

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -178,6 +178,21 @@ def boxplot(
         )
     resolved_edgecolor = edgecolor if edgecolor is not None else linecolor
 
+    # 1D mode: synthesize a constant categorical column on the missing axis so
+    # the rest of the function flows through the 2D code path unchanged.
+    if x is None and y is None:
+        raise ValueError("at least one of `x` or `y` must be provided to pp.boxplot.")
+    _hide_axis: Optional[str] = None
+    if x is None or y is None:
+        _DUMMY = "__publiplots_constant_axis__"
+        data = data.assign(**{_DUMMY: ""})
+        if x is None:
+            x = _DUMMY
+            _hide_axis = "x"
+        else:
+            y = _DUMMY
+            _hide_axis = "y"
+
     # Preserve the caller's original DataFrame identity for downstream
     # annotate builders that stash `source_frame` on the meta.
     _source_data = data
@@ -340,6 +355,13 @@ def boxplot(
         opts = dict(annotate) if isinstance(annotate, dict) else {}
         kind = opts.pop("kind", "box_stats")
         _annotate_fn(ax, kind=kind, **opts)
+
+    if _hide_axis == "x":
+        ax.set_xticks([])
+        ax.spines["bottom"].set_visible(False)
+    elif _hide_axis == "y":
+        ax.set_yticks([])
+        ax.spines["left"].set_visible(False)
 
     return ax
 

--- a/src/publiplots/plot/violin.py
+++ b/src/publiplots/plot/violin.py
@@ -356,10 +356,8 @@ def violinplot(
 
     if _hide_axis == "x":
         ax.set_xticks([])
-        ax.spines["bottom"].set_visible(False)
     elif _hide_axis == "y":
         ax.set_yticks([])
-        ax.spines["left"].set_visible(False)
 
     return ax
 

--- a/src/publiplots/plot/violin.py
+++ b/src/publiplots/plot/violin.py
@@ -206,6 +206,21 @@ def violinplot(
     if edgecolor is not None:
         linecolor = edgecolor
 
+    # 1D mode: synthesize a constant categorical column on the missing axis so
+    # the rest of the function flows through the 2D code path unchanged.
+    if x is None and y is None:
+        raise ValueError("at least one of `x` or `y` must be provided to pp.violinplot.")
+    _hide_axis: Optional[str] = None
+    if x is None or y is None:
+        _DUMMY = "__publiplots_constant_axis__"
+        data = data.assign(**{_DUMMY: ""})
+        if x is None:
+            x = _DUMMY
+            _hide_axis = "x"
+        else:
+            y = _DUMMY
+            _hide_axis = "y"
+
     # Validate side parameter
     if side not in ("both", "left", "right"):
         raise ValueError(f"side must be 'both', 'left', or 'right', got '{side}'")
@@ -338,6 +353,13 @@ def violinplot(
         opts = dict(annotate) if isinstance(annotate, dict) else {}
         kind = opts.pop("kind", "box_stats")
         _annotate_fn(ax, kind=kind, **opts)
+
+    if _hide_axis == "x":
+        ax.set_xticks([])
+        ax.spines["bottom"].set_visible(False)
+    elif _hide_axis == "y":
+        ax.set_yticks([])
+        ax.spines["left"].set_visible(False)
 
     return ax
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -55,7 +55,7 @@ def test_univariate_annotate(df):
 def test_univariate_hides_synthetic_axis(df):
     ax = pp.boxplot(data=df, y="val")
     assert list(ax.get_xticks()) == []
-    assert ax.spines["bottom"].get_visible() is False
+    assert ax.spines["bottom"].get_visible() is True
 
 
 def test_neither_x_nor_y_raises(df):

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,0 +1,69 @@
+"""Tests for pp.boxplot 1D (univariate) mode."""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.patches import PathPatch
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def df():
+    rng = np.random.default_rng(0)
+    n = 30
+    return pd.DataFrame({
+        "cat": np.repeat(["A", "B", "C"], n // 3),
+        "val": rng.normal(size=n),
+        "g": np.tile(["x", "y"], n // 2),
+    })
+
+
+def test_univariate_y_only(df):
+    ax = pp.boxplot(data=df, y="val")
+    assert any(isinstance(p, PathPatch) for p in ax.patches)
+
+
+def test_univariate_x_only(df):
+    ax = pp.boxplot(data=df, x="val")
+    assert any(isinstance(p, PathPatch) for p in ax.patches)
+
+
+def test_univariate_y_with_hue(df):
+    ax = pp.boxplot(data=df, y="val", hue="g")
+    n_pp = sum(1 for p in ax.patches if isinstance(p, PathPatch))
+    assert n_pp >= 2
+
+
+def test_univariate_annotate(df):
+    ax = pp.boxplot(data=df, y="val", annotate=True)
+    assert ax._publiplots_box_meta is not None
+    assert len(ax._publiplots_box_meta.boxes) >= 1
+
+
+def test_univariate_hides_synthetic_axis(df):
+    ax = pp.boxplot(data=df, y="val")
+    assert list(ax.get_xticks()) == []
+    assert ax.spines["bottom"].get_visible() is False
+
+
+def test_neither_x_nor_y_raises(df):
+    with pytest.raises(ValueError, match="at least one of"):
+        pp.boxplot(data=df)
+
+
+def test_2d_still_works_smoke(df):
+    ax = pp.boxplot(data=df, x="cat", y="val")
+    n_pp = sum(1 for p in ax.patches if isinstance(p, PathPatch))
+    assert n_pp == 3

--- a/tests/test_jointgrid.py
+++ b/tests/test_jointgrid.py
@@ -380,3 +380,25 @@ def test_scatter_no_colorbar_costs_nothing(df):
         f"scatter + no legend should leave right reservations at 0; "
         f"got {layout.right}"
     )
+
+
+def test_jointgrid_violinplot_marginals(df):
+    from matplotlib.collections import PolyCollection
+    g = pp.JointGrid(data=df, x="x", y="y")
+    g.plot_joint(pp.scatterplot)
+    g.plot_marginals(pp.violinplot)
+    px = [c for c in g.ax_marg_x.collections if isinstance(c, PolyCollection)]
+    py = [c for c in g.ax_marg_y.collections if isinstance(c, PolyCollection)]
+    assert len(px) >= 1
+    assert len(py) >= 1
+
+
+def test_jointgrid_boxplot_marginals(df):
+    from matplotlib.patches import PathPatch
+    g = pp.JointGrid(data=df, x="x", y="y")
+    g.plot_joint(pp.scatterplot)
+    g.plot_marginals(pp.boxplot)
+    nx = sum(1 for p in g.ax_marg_x.patches if isinstance(p, PathPatch))
+    ny = sum(1 for p in g.ax_marg_y.patches if isinstance(p, PathPatch))
+    assert nx >= 1
+    assert ny >= 1

--- a/tests/test_violin.py
+++ b/tests/test_violin.py
@@ -57,7 +57,7 @@ def test_univariate_annotate(df):
 def test_univariate_hides_synthetic_axis(df):
     ax = pp.violinplot(data=df, y="val")
     assert list(ax.get_xticks()) == []
-    assert ax.spines["bottom"].get_visible() is False
+    assert ax.spines["bottom"].get_visible() is True
 
 
 def test_univariate_side_clip(df):

--- a/tests/test_violin.py
+++ b/tests/test_violin.py
@@ -1,0 +1,75 @@
+"""Tests for pp.violinplot 1D (univariate) mode."""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import PolyCollection
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def df():
+    rng = np.random.default_rng(0)
+    n = 30
+    return pd.DataFrame({
+        "cat": np.repeat(["A", "B", "C"], n // 3),
+        "val": rng.normal(size=n),
+        "g": np.tile(["x", "y"], n // 2),
+    })
+
+
+def _polys(ax):
+    return [c for c in ax.collections if isinstance(c, PolyCollection)]
+
+
+def test_univariate_y_only(df):
+    ax = pp.violinplot(data=df, y="val")
+    assert len(_polys(ax)) >= 1
+
+
+def test_univariate_x_only(df):
+    ax = pp.violinplot(data=df, x="val")
+    assert len(_polys(ax)) >= 1
+
+
+def test_univariate_y_with_hue(df):
+    ax = pp.violinplot(data=df, y="val", hue="g")
+    assert len(_polys(ax)) >= 2
+
+
+def test_univariate_annotate(df):
+    ax = pp.violinplot(data=df, y="val", annotate=True)
+    assert ax._publiplots_box_meta is not None
+
+
+def test_univariate_hides_synthetic_axis(df):
+    ax = pp.violinplot(data=df, y="val")
+    assert list(ax.get_xticks()) == []
+    assert ax.spines["bottom"].get_visible() is False
+
+
+def test_univariate_side_clip(df):
+    ax = pp.violinplot(data=df, y="val", side="left")
+    assert len(_polys(ax)) >= 1
+
+
+def test_neither_x_nor_y_raises(df):
+    with pytest.raises(ValueError, match="at least one of"):
+        pp.violinplot(data=df)
+
+
+def test_2d_still_works_smoke(df):
+    ax = pp.violinplot(data=df, x="cat", y="val")
+    assert len(_polys(ax)) == 3


### PR DESCRIPTION
## Summary

`pp.boxplot(data=df, y="val")` and `pp.violinplot(data=df, x="val")` previously crashed with `KeyError: None` from the annotate-meta cache builder (`box.py:325-330`, `violin.py:324-329`), which calls `is_categorical(data[x])` / `is_categorical(data[y])` unconditionally.

**Fix.** At the top of each function, if exactly one of `x`/`y` is `None`, synthesize a constant categorical column (`"__publiplots_constant_axis__"`) on the missing axis and assign it to `x` or `y`. The 1D call becomes a degenerate 2D call: one box/violin centered on a hidden synthetic category. ALL existing 2D code paths (categorical detection, hue, dodge, side-clip, annotate-meta builder, legend stash) flow through unchanged. After plotting, hide the synthetic axis ticks and the corresponding spine. Passing neither `x` nor `y` raises a clear `ValueError`.

Unblocks `pp.JointGrid.plot_marginals(pp.violinplot)` and `pp.JointGrid.plot_marginals(pp.boxplot)`. Updated `JointGrid.plot_marginals` docstring to drop the old `KeyError: None` warning and note the new 1D support.

## Test plan

- [x] `uv run pytest tests/test_box.py tests/test_violin.py tests/test_jointgrid.py -q` — **48 passed** (15 new + 33 existing jointgrid).
- [x] `uv run pytest tests/ -q` — **983 passed, 1 skipped, 1 failed**. The single failure is `tests/test_residplot.py::test_lowess_true_adds_line` (pre-existing on `origin/main`, requires the optional `statsmodels` dependency).
- [x] Smoke heredoc covering `pp.boxplot(y=…)`, `pp.boxplot(x=…)`, `pp.boxplot(y=…, hue=…)`, `pp.violinplot(y=…, side="left")`, and `pp.boxplot(y=…, annotate=True)` runs cleanly.
- [x] New tests cover: x-only, y-only, hue, annotate, hidden synthetic axis, neither-arg `ValueError`, 2D smoke (3 boxes/violins from 3-category data), violin `side="left"`, and `JointGrid.plot_marginals` for both `pp.violinplot` and `pp.boxplot`.