### PR TITLE
chore(release): v0.11.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-05-13
+
+### Fixed
+
+- `pp.boxplot` and `pp.violinplot` now accept univariate calls
+  (only `x=` or only `y=`). Previously these raised `KeyError: None`
+  from the annotate-meta cache builder when the missing axis was
+  looked up by `None`. Both functions now synthesize a constant
+  categorical column for the missing axis so the existing 2D code
+  path handles 1D as a degenerate single-category case — `annotate`,
+  `hue`, `dodge`, side-clip, and the legend stash all keep working
+  in 1D unchanged. The synthetic-side ticks and tick labels are
+  dropped post-draw while the spine is preserved so the standalone
+  1D frame stays closed (PR #157).
+
+### Added
+
+- `pp.JointGrid.plot_marginals(pp.boxplot)` and
+  `pp.JointGrid.plot_marginals(pp.violinplot)` are now first-class
+  compositions, unblocked by the 1D-mode fix above. Both forward
+  `data` + `x`/`y` + `ax=` to the marginal axes via the existing
+  `JointGrid` plumbing. New gallery sections demonstrate the
+  combinations:
+  - `examples/plots/plot_14_box_plots.py` — "Univariate (1D) Box
+    Plot" section.
+  - `examples/plots/plot_15_violin_plots.py` — "Univariate (1D)
+    Violin Plot" section.
+  - `examples/plots/plot_09_jointgrid.py` — "Box Marginals" and
+    "Violin Marginals" sections; the "Custom Composition" docstring
+    now lists `pp.boxplot` and `pp.violinplot` alongside `pp.histplot`
+    and `pp.kdeplot` as 1D-capable marginal functions.
+  - Note: `pp.jointplot(kind=)` does not yet expose `kind="box"` /
+    `kind="violin"` aliases — only the explicit
+    `JointGrid.plot_marginals(pp.boxplot)` /
+    `JointGrid.plot_marginals(pp.violinplot)` form works in 0.11.2.
+
 ## [0.11.1] - 2026-05-13
 
 ### Added
@@ -517,6 +553,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls in `examples/plots/plot_12_heatmap.py` — auto-layout positions
   the title correctly regardless (PR #128).
 
+[0.11.2]: https://github.com/jorgebotas/publiplots/releases/tag/v0.11.2
+[0.11.1]: https://github.com/jorgebotas/publiplots/releases/tag/v0.11.1
 [0.11.0]: https://github.com/jorgebotas/publiplots/releases/tag/v0.11.0
 [0.10.12]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.12
 [0.10.11]: https://github.com/jorgebotas/publiplots/releases/tag/v0.10.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.11.1"
+version = "0.11.2"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/skills/publiplots-guide/SKILL.md
+++ b/skills/publiplots-guide/SKILL.md
@@ -23,7 +23,7 @@ publiplots is a publication-ready plotting library with a seaborn-shaped API but
 All accept `data=`, `x=`, `y=`, `hue=`, `palette=`, `ax=`, `title=`, `legend_kws={}`. None accept `figsize=` — it raises `TypeError` (see `src/publiplots/layout/subplots.py::reject_figsize`).
 
 By plot family:
-- **Categorical:** `barplot`, `boxplot`, `violinplot`, `raincloudplot`, `stripplot`, `swarmplot`, `pointplot`.
+- **Categorical:** `barplot`, `boxplot`, `violinplot`, `raincloudplot`, `stripplot`, `swarmplot`, `pointplot`. Since 0.11.2, `boxplot` and `violinplot` also accept univariate calls (only `x=` or only `y=`) — they synthesize a constant categorical column for the missing axis, so all 2D features (`annotate`, `hue`, `dodge`, side-clip, legends) keep working in 1D, and both are usable as `pp.JointGrid.plot_marginals(...)` functions.
 - **Relational:** `scatterplot`, `lineplot`, `errorbarplot`, `regplot`, `residplot`.
 - **Distribution:** `histplot`, `kdeplot`, `hexbinplot`.
 - **Matrix:** `heatmap`, `complex_heatmap`, `dendrogram`.
@@ -124,7 +124,15 @@ pp.jointplot(data=df, x="x", y="y", kind="hex")  # or 'scatter', 'kde', 'reg', '
 g = pp.JointGrid(data=df, x="x", y="y", height=80, ratio=5)
 g.plot_joint(pp.hexbinplot, gridsize=20)
 g.plot_marginals(pp.histplot, bins=30, kde=True)
+
+# Box / violin marginals (since 0.11.2) — explicit class API only;
+# pp.jointplot has no kind="box" / kind="violin" alias yet.
+g = pp.JointGrid(data=df, x="x", y="y")
+g.plot_joint(pp.scatterplot)
+g.plot_marginals(pp.violinplot)   # or pp.boxplot
 ```
+
+Valid `pp.JointGrid.plot_marginals(...)` functions (1D-capable): `pp.histplot`, `pp.kdeplot`, `pp.boxplot`, `pp.violinplot`. The marginal function must accept `data=`, `x=` *or* `y=` (not both), and `ax=`.
 
 **Save a figure.** No implicit tight-crop; the canvas is already mm-precise.
 

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

- **`pp.boxplot` / `pp.violinplot` 1D mode** (PR #157) — both functions now accept univariate calls (only `x=` or only `y=`). Previously crashed with `KeyError: None` from the annotate-meta cache builder. Synthesizes a constant categorical column for the missing axis so the existing 2D code path handles 1D as a degenerate single-category case (`annotate`, `hue`, `dodge`, side-clip, legend stash all work in 1D unchanged). Synthetic-side ticks are dropped post-draw; the spine stays so the standalone 1D frame closes cleanly.
- **`pp.JointGrid` box / violin marginals** — `pp.JointGrid.plot_marginals(pp.boxplot)` and `pp.JointGrid.plot_marginals(pp.violinplot)` are now first-class compositions, unblocked by the 1D fix above. New gallery sections in `plot_09_jointgrid.py` ("Box Marginals" + "Violin Marginals"), `plot_14_box_plots.py` ("Univariate (1D) Box Plot"), and `plot_15_violin_plots.py` ("Univariate (1D) Violin Plot") showcase the patterns.
- **Plugin skill refresh** — `skills/publiplots-guide/SKILL.md` notes 1D acceptance on the Categorical-family inventory and adds the box/violin marginal idiom to the canonical "Bivariate + marginals" snippet, with an explicit caveat that `pp.jointplot(kind=)` does not yet expose `kind="box"` / `kind="violin"` aliases — only the explicit `JointGrid.plot_marginals(...)` form works.
- **v0.11.2 patch release** — strictly additive + a bug fix, no breaking changes.

## Out of scope

- `pp.jointplot(kind="box")` / `kind="violin"` aliases. Tracked as a follow-up; the explicit `JointGrid.plot_marginals(...)` form covers the use case.
- `pp.histplot` 2D mode (still pending).

## Commits

1. `chore(changelog): v0.11.2` — promote `[Unreleased]` to `[0.11.2]`, add Fixed + Added sections, refresh footer comparison links (also adds the missing `[0.11.1]` link).
2. `docs(skills): refresh publiplots-guide for v0.11.2` — Categorical-family note + canonical idiom update (own commit per the durable rule that release PRs must keep plugin discovery in sync with the public API).
3. `chore(release): v0.11.2` — version bump in `pyproject.toml`, `src/publiplots/__init__.py`, `.claude-plugin/plugin.json`, `uv.lock`.

## Test plan

- [x] `uv lock` resolves cleanly; `publiplots v0.11.1 -> v0.11.2`.
- [x] `uv run python -c "import publiplots; print(publiplots.__version__)"` -> `0.11.2`.
- [x] `uv run pytest tests/ -q` — **1007 passed, 1 failed, 1 skipped** in 163s. The single failure (`tests/test_residplot.py::test_lowess_true_adds_line`) is a pre-existing environmental issue (statsmodels not installed in the dev extra path) and reproduces identically on `origin/main`. All box, violin, and jointgrid tests pass — including the new 1D-mode coverage from PR #157.
- [x] Three commits, in order (`chore(changelog)` -> `docs(skills)` -> `chore(release)`).
- [ ] On merge: tag `v0.11.2` on main, publish GitHub release pointing at the new CHANGELOG anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)