### PR TITLE
fix(histplot): raise NotImplementedError for kde= in 2D

### DIFF
--- a/src/publiplots/plot/hist.py
+++ b/src/publiplots/plot/hist.py
@@ -139,7 +139,9 @@ def histplot(
     shrink : float, default=1
         Bar width as a fraction of the bin width.
     kde : bool, default=False
-        Overlay a kernel density estimate per hue level.
+        Overlay a 1D kernel density estimate per hue level. Not
+        supported in 2D mode (raises ``NotImplementedError``); use
+        :func:`publiplots.kdeplot` for 2D KDE contours.
     kde_kws : dict, optional
         Extra keyword arguments forwarded to the KDE estimator (see
         :func:`seaborn.histplot`).
@@ -317,6 +319,12 @@ def histplot(
                 f"histplot: element={element!r} is not supported in 2D "
                 "mode (use the default 'bars')."
             )
+        if kde:
+            raise NotImplementedError(
+                "histplot: kde= is not supported in 2D mode. "
+                "Use publiplots.kdeplot for 2D KDE contours, or layer "
+                "pp.kdeplot(..., ax=ax) on top of the histplot manually."
+            )
 
         sns_kwargs = {
             "data": data,
@@ -339,10 +347,6 @@ def histplot(
             "legend": False,
             "cbar": False,
         }
-        if kde:
-            sns_kwargs["kde"] = True
-            if kde_kws:
-                sns_kwargs["kde_kws"] = kde_kws
         # cmap is mutually exclusive with hue in seaborn 2D.
         if hue is None:
             sns_kwargs["cmap"] = cmap_resolved

--- a/tests/test_hist.py
+++ b/tests/test_hist.py
@@ -476,6 +476,11 @@ def test_2d_element_step_raises(df_2d):
         pp.histplot(data=df_2d, x="x", y="y", element="step")
 
 
+def test_2d_kde_raises(df_2d):
+    with pytest.raises(NotImplementedError, match="kdeplot"):
+        pp.histplot(data=df_2d, x="x", y="y", kde=True)
+
+
 def test_2d_alpha_default_is_one(df_2d):
     from matplotlib.collections import QuadMesh
     ax = pp.histplot(data=df_2d, x="x", y="y")


### PR DESCRIPTION
## Summary

In v0.12.0, ``pp.histplot(x=, y=, kde=True)`` silently did nothing — seaborn's ``histplot`` does not draw 2D KDE contours from ``kde=True`` (that's a ``kdeplot`` feature). The kwarg was being forwarded but produced no contour artist, leaving users to wonder if they had the wrong syntax.

This PR matches the existing 2D guards (``annotate=``, ``element != "bars"``) and raises ``NotImplementedError`` with a pointer to ``pp.kdeplot`` for 2D KDE contours.

## Test plan

- [x] New test ``test_2d_kde_raises`` asserts ``NotImplementedError`` with ``"kdeplot"`` in the message.
- [x] ``uv run pytest tests/test_hist.py -q`` → 51 passed (was 50).
- [x] 1D ``kde=True`` path unchanged — covered by existing ``test_kde_adds_lines`` / ``test_kde_single_group``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)