### PR TITLE
fix(annotate): strip face alpha in bar.hue_color fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     use only. In CI runs it would silently mask drift; CI must NEVER
     set this variable.
 
+### Fixed
+
+- `pp.annotate(color="hue")` now renders opaque label text when the
+  bar fill is translucent (e.g. the default `alpha=0.1` outline
+  style). Previously, when palette lookup fell back to the bar's
+  facecolor — most notably when `hue == x` collapses `hue_value` to
+  `None` in seaborn — the bar's alpha leaked into the label color,
+  producing 10%-opacity text. The three bar-record builders
+  (`build_from_barplot_call`, `build_from_stacked_barplot_call`,
+  `build_from_histplot_call`) now pin the fallback alpha to 1.0.
+  (PR #172, fixes #171)
+
 ## [0.11.3] - 2026-05-13
 
 ### Added

--- a/examples/plots/plot_23_annotate.py
+++ b/examples/plots/plot_23_annotate.py
@@ -74,6 +74,31 @@ ax = pp.barplot(
 pp.show()
 
 # %%
+# Hue-colored labels when ``hue == x``
+# ------------------------------------
+# A common idiom is ``hue=x`` to color each category from a palette
+# while keeping the categorical axis. ``annotate={"color": "hue"}``
+# resolves to the saturated palette color per bar — the bar's
+# default ``alpha=0.1`` outline fill does not leak into the label.
+tau_df = pd.DataFrame({
+    "tau": ["-1", "-0.5", "0", "0.5", "1"],
+    "value": [0.04, 0.05, 0.06, 0.05, 0.03],
+})
+tau_palette = {
+    "-1": "#440154", "-0.5": "#3b528b", "0": "#21918c",
+    "0.5": "#5ec962", "1": "#fde725",
+}
+
+ax = pp.barplot(
+    data=tau_df, x="tau", y="value", hue="tau",
+    order=list(tau_palette), palette=tau_palette, legend=False,
+    annotate={"fmt": "{:.1%}", "anchor": "inside",
+              "rotation": 90, "color": "hue"},
+    title='hue == x with annotate={"color": "hue"}',
+)
+pp.show()
+
+# %%
 # Horizontal orientation
 # ----------------------
 df_h = df.rename(columns={"category": "c", "value": "v"})

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -284,7 +284,11 @@ def build_from_barplot_call(
             if key is not None and key in palette:
                 hue_color = to_rgba(palette[key])
         if hue_color is None:
-            hue_color = tuple(rect.get_facecolor())
+            # Strip face alpha (publiplots' default bar style is alpha=0.1
+            # outline) so labels referencing this color render opaquely
+            # rather than inheriting the bar's translucency.
+            r, g, b, _ = rect.get_facecolor()
+            hue_color = (r, g, b, 1.0)
         bars.append(BarRecord(
             patch=rect,
             value=float(row["mean"]),
@@ -406,7 +410,9 @@ def build_from_stacked_barplot_call(
             if key is not None and key in palette:
                 hue_color = to_rgba(palette[key])
         if hue_color is None:
-            hue_color = tuple(rect.get_facecolor())
+            # Strip face alpha — see note on the dodged-builder fallback.
+            r, g, b, _ = rect.get_facecolor()
+            hue_color = (r, g, b, 1.0)
         bars.append(BarRecord(
             patch=rect,
             value=float(value),
@@ -484,7 +490,9 @@ def build_from_histplot_call(
             if best_level is not None:
                 hue_color = to_rgba(palette[best_level])
         if hue_color is None:
-            hue_color = tuple(rect.get_facecolor())
+            # Strip face alpha — see note on the dodged-builder fallback.
+            r, g, b, _ = rect.get_facecolor()
+            hue_color = (r, g, b, 1.0)
         bars.append(BarRecord(
             patch=rect,
             value=float(value),

--- a/tests/annotate/test_hue_color_alpha.py
+++ b/tests/annotate/test_hue_color_alpha.py
@@ -1,0 +1,105 @@
+"""Regression: annotate(color='hue') must render opaque text when palette
+lookup falls back to the bar's translucent facecolor.
+
+Bug #171: when hue == x, seaborn collapses the hue dimension internally
+so `row['hue_value']` is None for every bar; palette lookup fails and
+hue_color falls back to `rect.get_facecolor()`. With publiplots' default
+outline-style (alpha=0.1) the bar's alpha leaked into the label color,
+producing 10%-opacity text. The three bar-record builders now pin the
+fallback alpha to 1.0.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.colors import to_rgba
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def test_barplot_hue_eq_x_color_hue_renders_opaque_labels():
+    """Exact repro from #171: hue == x with a palette dict + color='hue'.
+
+    `hue_value` collapses to None inside the builder so palette lookup
+    misses; the fallback used to inherit the bar's alpha=0.1.
+    """
+    df = pd.DataFrame([
+        {"tau": "-1", "value": 0.04},
+        {"tau": "-0.5", "value": 0.05},
+        {"tau": "0", "value": 0.06},
+    ])
+    palette = {"-1": "#440154", "-0.5": "#21918c", "0": "#fde725"}
+    ax = pp.barplot(
+        data=df, x="tau", y="value", hue="tau",
+        order=["-1", "-0.5", "0"], palette=palette,
+        legend=False,
+        annotate={"fmt": "{:.1%}", "anchor": "inside",
+                  "rotation": 90, "color": "hue"},
+    )
+    meta = ax._publiplots_bar_meta
+    # Sanity: this is the fallback branch (hue_value is None for all bars).
+    assert all(b.hue_value is None for b in meta.bars)
+    # Every bar's hue_color must be fully opaque despite the alpha=0.1 fill.
+    for b in meta.bars:
+        assert b.hue_color is not None
+        assert b.hue_color[3] == 1.0, (
+            f"hue_color alpha={b.hue_color[3]} (expected 1.0)"
+        )
+    # And the labels themselves render opaque.
+    assert len(ax.texts) == 3
+    for t in ax.texts:
+        assert to_rgba(t.get_color())[3] == 1.0
+
+
+def test_stacked_barplot_palette_none_fallback_strips_alpha():
+    """Stacked path: ``multiple='stack'`` requires hue != x, so we force
+    the fallback by re-invoking ``build_from_stacked_barplot_call`` with
+    ``palette=None`` against an already-drawn stacked axes (the legitimate
+    foreign-axes-style fallback path the patch covers)."""
+    from publiplots.annotate._builders import build_from_stacked_barplot_call
+    df = pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "h": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+    })
+    ax = pp.barplot(
+        data=df, x="cat", y="value", hue="h",
+        multiple="stack", legend=False,
+    )
+    # Re-build meta with palette=None to exercise the fallback branch.
+    meta = build_from_stacked_barplot_call(
+        ax=ax, data=df, x="cat", y="value", hue="h",
+        categorical_axis="cat", palette=None,
+        multiple="stack", source_frame=df,
+    )
+    assert len(meta.bars) > 0
+    for b in meta.bars:
+        assert b.hue_color is not None
+        assert b.hue_color[3] == 1.0
+
+
+def test_histplot_no_hue_fallback_strips_alpha():
+    """histplot path: with hue=None, palette_map is None so the builder's
+    `palette is not None and palette` guard fails and the fallback fires.
+    """
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"x": rng.normal(0.0, 1.0, 200)})
+    ax = pp.histplot(
+        data=df, x="x", bins=5,
+        annotate={"color": "hue"},
+    )
+    meta = ax._publiplots_bar_meta
+    assert len(meta.bars) > 0
+    for b in meta.bars:
+        assert b.hue_color is not None
+        assert b.hue_color[3] == 1.0
+    for t in ax.texts:
+        assert to_rgba(t.get_color())[3] == 1.0


### PR DESCRIPTION
Fixes #171.

## Summary

- Three of the four bar-record builders fall back to ``rect.get_facecolor()`` when palette lookup fails (notably when ``hue == x`` collapses ``hue_value`` to ``None``, or no palette was supplied).
- Under the default ``alpha=0.1`` outline style, the fallback inherited that 0.1 alpha — so any annotation referencing ``bar.hue_color`` (e.g. ``annotate=color=\"hue\"``) rendered translucent text.
- This change strips the face alpha and pins it at ``1.0`` in each fallback path. Hue-color is conceptually a *label* color, not a *patch* style, so opaque is the right default.

## Test plan

- [x] Repro script in #171 now produces opaque, hue-tinted labels.
- [x] ``pytest tests/annotate/`` — 232 passed.
- [x] End-to-end smoke on a real downstream user (teddy ``compare-tau.py`` 7×13-tau panel grid): labels render solid in the expected palette colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)