### PR TITLE
fix(annotate): render labels on rounded bars + rounded boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`build_from_barplot_call`, `build_from_stacked_barplot_call`,
   `build_from_histplot_call`) now pin the fallback alpha to 1.0.
   (PR #172, fixes #171)
+- `pp.annotate(kind='bar_values' | 'bar_custom' | 'box_stats')` now
+  renders labels when `pp.rcParams['bar.border_radius']` (or
+  `box.border_radius`) is non-zero. `apply_border_radius` swaps
+  matplotlib's `Rectangle` / `PathPatch` artists for publiplots'
+  custom `_RoundedBarPatch` class, and the annotate subsystem's
+  isinstance gates in `_cache._is_bar_rect`, the
+  stacked-barplot patch walker, and the boxplot patch walker
+  previously rejected those rounded patches — silently emitting
+  zero labels. The gates are widened to admit `_RoundedBarPatch`
+  alongside the original types. (PR #175, fixes #173)
 
 ## [0.11.3] - 2026-05-13
 

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -501,6 +501,27 @@ pp.barplot(
 pp.show()
 
 # %%
+# Rounded bars + annotations
+# --------------------------
+# ``annotate=`` works on rounded bars exactly as it does on flat ones.
+# ``border_radius`` swaps each ``Rectangle`` artist for a rounded
+# patch, and the annotate subsystem walks both kinds.
+fig, axes = pp.subplots(1, 2, axes_size=(45, 40))
+pp.barplot(
+    data=rounded_df, x='x', y='y', ax=axes[0],
+    border_radius=(1.5, 0),
+    annotate={"fmt": ".1f"},
+    title='annotate=value',
+)
+pp.barplot(
+    data=rounded_df, x='x', y='y', ax=axes[1],
+    border_radius=(1.5, 0),
+    annotate={"fmt": ".1f", "anchor": "inside", "rotation": 90},
+    title='annotate inside, rotated',
+)
+pp.show()
+
+# %%
 # Stacked Bars — ``multiple="stack"``
 # -----------------------------------
 # ``pp.barplot(multiple="stack")`` draws each hue level on top of the

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -503,21 +503,18 @@ pp.show()
 # %%
 # Rounded bars + annotations
 # --------------------------
-# ``annotate=`` works on rounded bars exactly as it does on flat ones.
+# ``annotate=`` works on rounded bars exactly as it does on flat ones —
 # ``border_radius`` swaps each ``Rectangle`` artist for a rounded
-# patch, and the annotate subsystem walks both kinds.
-fig, axes = pp.subplots(1, 2, axes_size=(45, 40))
-pp.barplot(
-    data=rounded_df, x='x', y='y', ax=axes[0],
+# patch, and the annotate subsystem walks both kinds. Combines well
+# with ``hue=x`` + ``annotate={"color": "hue"}`` for a label per
+# saturated category color.
+ax = pp.barplot(
+    data=rounded_df, x='x', y='y', hue='x',
+    palette='flare', legend=False,
     border_radius=(1.5, 0),
-    annotate={"fmt": ".1f"},
-    title='annotate=value',
-)
-pp.barplot(
-    data=rounded_df, x='x', y='y', ax=axes[1],
-    border_radius=(1.5, 0),
-    annotate={"fmt": ".1f", "anchor": "inside", "rotation": 90},
-    title='annotate inside, rotated',
+    annotate={"fmt": ".1f", "anchor": "inside",
+              "rotation": 90, "color": "hue"},
+    title='rounded + annotate(color="hue")',
 )
 pp.show()
 

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -512,8 +512,7 @@ ax = pp.barplot(
     data=rounded_df, x='x', y='y', hue='x',
     palette='flare', legend=False,
     border_radius=(1.5, 0),
-    annotate={"fmt": ".1f", "anchor": "inside",
-              "rotation": 90, "color": "hue"},
+    annotate={"fmt": ".1f", "color": "hue"},
     title='rounded + annotate(color="hue")',
 )
 pp.show()

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -366,6 +366,9 @@ def build_from_stacked_barplot_call(
         ``source_frame.iloc[record.frame_row_index]`` resolves correctly
         regardless of the caller's index kind.
     """
+    # Lazy import to avoid a cycle through utils.rounding.
+    from publiplots.utils.rounding import _RoundedBarPatch
+
     orient: Literal["v", "h"] = "v" if categorical_axis == x else "h"
 
     agg = _aggregate_means(
@@ -377,7 +380,7 @@ def build_from_stacked_barplot_call(
     # Rectangle per aggregated row via ax.bar, including legitimate
     # zero-valued segments (e.g. a group mean that happens to be 0).
     # Pairing with agg is 1:1 in deterministic draw order.
-    rects = [p for p in ax.patches if isinstance(p, Rectangle)]
+    rects = [p for p in ax.patches if isinstance(p, (Rectangle, _RoundedBarPatch))]
 
     bars: List[BarRecord] = []
     for i, (rect, row) in enumerate(zip(rects, agg)):
@@ -705,7 +708,10 @@ def build_from_boxplot_call(
 
     ``source_frame`` is required keyword-only; see ``_build_box_stats_meta``.
     """
-    patches = [p for p in ax.patches if isinstance(p, PathPatch)]
+    # Lazy import to avoid a cycle through utils.rounding.
+    from publiplots.utils.rounding import _RoundedBarPatch
+
+    patches = [p for p in ax.patches if isinstance(p, (PathPatch, _RoundedBarPatch))]
     return _build_box_stats_meta(
         ax, data, x, y, hue, categorical_axis, palette, whis, patches,
         source_frame=source_frame,

--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -155,7 +155,11 @@ def _is_bar_rect(p) -> bool:
     causing annotate strategies to skip every negative bar. Here we only
     reject *degenerate* zero-size rects (e.g. truly empty groups).
     """
-    if not isinstance(p, Rectangle):
+    # Lazy import to avoid a cycle: utils.rounding pulls in publiplots
+    # internals at import time.
+    from publiplots.utils.rounding import _RoundedBarPatch
+
+    if not isinstance(p, (Rectangle, _RoundedBarPatch)):
         return False
     return p.get_width() != 0 and p.get_height() != 0
 

--- a/tests/annotate/test_border_radius_annotate.py
+++ b/tests/annotate/test_border_radius_annotate.py
@@ -1,0 +1,116 @@
+"""Regression tests for #173 — annotate must work with border_radius set.
+
+When ``pp.rcParams['bar.border_radius']`` (or ``box.border_radius``) is
+non-zero, ``apply_border_radius`` swaps matplotlib's ``Rectangle`` /
+``PathPatch`` artists for publiplots' custom ``_RoundedBarPatch``. The
+annotate subsystem's isinstance gates previously rejected those rounded
+patches and silently emitted zero labels.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import publiplots as pp
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def _reset_border_radius():
+    """Restore zero border_radius after each test, even on failure."""
+    try:
+        yield
+    finally:
+        pp.rcParams["bar.border_radius"] = (0.0, 0.0)
+        pp.rcParams["box.border_radius"] = (0.0, 0.0)
+
+
+def _bar_df():
+    return pd.DataFrame({
+        "cat": pd.Categorical(["A", "B", "C"], categories=["A", "B", "C"]),
+        "value": [1.0, 2.0, 3.0],
+        "n": [10, 20, 30],
+    })
+
+
+def _stacked_df():
+    return pd.DataFrame({
+        "cat": pd.Categorical(["A", "A", "B", "B"], categories=["A", "B"]),
+        "hue": pd.Categorical(["x", "y", "x", "y"], categories=["x", "y"]),
+        "value": [1.0, 2.0, 3.0, 4.0],
+    })
+
+
+def _box_df(seed: int = 0):
+    rng = np.random.default_rng(seed)
+    rows = []
+    for g, base in zip(("A", "B", "C"), (1.0, 2.0, 3.0)):
+        for v in rng.normal(base, 0.5, 30):
+            rows.append({"g": g, "y": float(v)})
+    df = pd.DataFrame(rows)
+    df["g"] = df["g"].astype("category")
+    return df
+
+
+def test_bar_values_with_border_radius(_reset_border_radius):
+    """bar_values must label every rounded bar (was: silently 0 labels)."""
+    pp.rcParams["bar.border_radius"] = (1.0, 0.0)
+    fig, ax = plt.subplots()
+    pp.barplot(data=_bar_df(), x="cat", y="value", ax=ax)
+    pp.annotate(ax, kind="bar_values", color="hue")
+    assert len(ax.texts) == 3, (
+        f"expected 3 labels on rounded bars, got {len(ax.texts)}"
+    )
+    assert [t.get_text() for t in ax.texts] == ["1.00", "2.00", "3.00"]
+    plt.close(fig)
+
+
+def test_bar_custom_with_border_radius(_reset_border_radius):
+    """bar_custom must label every rounded bar with explicit labels."""
+    pp.rcParams["bar.border_radius"] = (1.0, 0.0)
+    fig, ax = plt.subplots()
+    pp.barplot(data=_bar_df(), x="cat", y="value", ax=ax)
+    pp.annotate(ax, kind="bar_custom", labels="n")
+    assert len(ax.texts) == 3
+    assert [t.get_text() for t in ax.texts] == ["10", "20", "30"]
+    plt.close(fig)
+
+
+def test_stacked_barplot_with_border_radius(_reset_border_radius):
+    """Stacked barplot patch walker must accept rounded patches."""
+    pp.rcParams["bar.border_radius"] = (1.0, 0.0)
+    fig, ax = plt.subplots()
+    pp.barplot(
+        data=_stacked_df(),
+        x="cat",
+        y="value",
+        hue="hue",
+        multiple="stack",
+        ax=ax,
+        annotate=True,
+    )
+    # 2 cats × 2 hues = 4 stacked segments, each gets a label.
+    assert len(ax.texts) == 4, (
+        f"expected 4 labels on rounded stacked bars, got {len(ax.texts)}"
+    )
+    plt.close(fig)
+
+
+def test_box_stats_with_border_radius(_reset_border_radius):
+    """box_stats must label every rounded box (was: silently 0 labels)."""
+    pp.rcParams["box.border_radius"] = (1.0, 0.0)
+    fig, ax = plt.subplots()
+    pp.boxplot(data=_box_df(), x="g", y="y", ax=ax)
+    pp.annotate(ax, kind="box_stats", stats=["median"])
+    # 3 boxes × 1 stat = 3 labels.
+    assert len(ax.texts) == 3, (
+        f"expected 3 labels on rounded boxes, got {len(ax.texts)}"
+    )
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Fixes #173.

- `pp.annotate(kind='bar_values' | 'bar_custom' | 'box_stats')` silently emitted zero labels whenever `pp.rcParams['bar.border_radius']` (or `box.border_radius`) was non-zero. Same bug applied to `multiple='stack'` barplots.
- Root cause: `apply_border_radius` swaps matplotlib's `Rectangle` / `PathPatch` artists for the custom `_RoundedBarPatch` class (a `Patch` subclass — not a Rectangle/PathPatch subclass). The annotate subsystem's three `isinstance` gates rejected those rounded patches.
- Fix widens each gate to admit `_RoundedBarPatch` alongside the original type, using a lazy top-of-function import per site (mirrors `utils/offset.py:40`, avoids a top-level import cycle). `_RoundedBarPatch` already exposes the geometry/color API the consumers need, so the change is drop-in.

Touched:
- `src/publiplots/annotate/_cache.py` — `_is_bar_rect`
- `src/publiplots/annotate/_builders.py` — stacked-barplot + boxplot patch walkers
- `tests/annotate/test_border_radius_annotate.py` — 4 new regression tests
- `CHANGELOG.md` — Fixed entry under `[Unreleased]`

## Test plan

- [x] 4 new regression tests fail on `main` (proves bug is real), pass after the fix
- [x] Full test suite green: `uv run pytest tests/ --no-cov` → **1060 passed**
- [x] `tests/test_border_radius.py` still green (the strict `type(p) is Rectangle` negation in the producer remains unaffected)
- [x] Visual eyeball: ran the issue's repro (`bar.border_radius = (1.0, 0)` + `pp.annotate(kind='bar_values')`); rounded bars now render labels `1.00 / 2.00 / 3.00` above each bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)