### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-18
+
 ### Added
 
 - `pp.legend(rows=, cols=, span=, ax=)` — grid-scope kwargs for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.11.3"
+version = "0.12.0"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/skills/publiplots-guide/SKILL.md
+++ b/skills/publiplots-guide/SKILL.md
@@ -39,7 +39,7 @@ By plot family:
 - **Per-position lock/auto** (since 0.11): tuples passed to `title_space` / `xlabel_space` / `ylabel_space` / `right` may contain `None` entries to opt that position into auto-measurement while locking the others. Example: `xlabel_space=(0.0, None)` locks row 0 to 0 mm and lets row 1 grow with decoration. Each `None` resolves to the rcParams default at construction; the reactor preserves the locked positions on later draws. Used internally by `pp.JointGrid` to keep joint↔marginal gaps symmetric without sacrificing auto-measurement of the joint panel's own labels.
 
 ### Legend
-- `pp.legend(axes=None, collect=None, *, side='right', anchor=None, figure=None, orientation='auto', align='auto', x_offset, y_offset, gap=2, column_spacing=5, vpad, max_width)` — unified legend factory. See the `legend-placement` skill.
+- `pp.legend(axes=None, collect=None, *, side='right', anchor=None, figure=None, rows=None, cols=None, span=None, ax=None, orientation='auto', align='auto', x_offset, y_offset, gap=2, column_spacing=5, vpad, max_width)` — unified legend factory. Since 0.12.0, `rows=`/`cols=`/`span=`/`ax=` are mutually-exclusive grid-scope shortcuts that resolve over the `pp.subplots` axes matrix to a row, column, or arbitrary axes subset. See the `legend-placement` skill.
 - `pp.MultiAxesLegendGroup` — underlying class, rarely needed directly.
 - `pp.LegendBuilder`, `pp.HandlerRectangle`, `pp.HandlerMarker`, `pp.HandlerLineMarker`, `pp.RectanglePatch`, `pp.MarkerPatch`, `pp.LineMarkerPatch`, `pp.get_legend_handler_map`, `pp.create_legend_handles` — low-level handle machinery.
 

--- a/src/publiplots/__init__.py
+++ b/src/publiplots/__init__.py
@@ -14,7 +14,7 @@ publiplots applies its publication-grade rcParams on import. Use
 :func:`publiplots.reset_style` to revert to matplotlib defaults.
 """
 
-__version__ = "0.11.3"
+__version__ = "0.12.0"
 __author__ = "Jorge Botas"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025, Jorge Botas"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.11.3"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

Cuts publiplots 0.12.0. Bundles one new public-API addition (PR #166) and two annotate-subsystem bugfixes (PRs #172, #175). Minor bump per semver since the legend grid-scope kwargs grow the public API.

### Added
- `pp.legend(rows=, cols=, span=, ax=)` grid-scope kwargs (#166)

### Fixed
- `pp.annotate(color="hue")` now renders opaque text when the bar fill is translucent (#172, fixes #171)
- `pp.annotate(kind='bar_*' | 'box_stats')` now renders labels on rounded bars/boxes (#175, fixes #173)

### Skill refresh
- `skills/publiplots-guide/SKILL.md`: `pp.legend` signature now lists the new `rows=/cols=/span=/ax=` kwargs.
- `skills/legend-placement/SKILL.md`: already documents the grid-scope kwargs (landed with #166); no further changes needed.

## Test plan

- [x] `uv run pytest tests/` — 1063 passed
- [x] CHANGELOG `[Unreleased]` → `[0.12.0] - 2026-05-18` (Unreleased section preserved as empty placeholder)
- [x] `__version__` and `pyproject.toml` bumped to 0.12.0; `uv.lock` regenerated
- [x] Both annotate fixes visually verified in the gallery (rounded-bars cell in `plot_01_bar_plots.py`, hue==x cell in `plot_23_annotate.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)