### PR TITLE
feat: bar/box/violin max_width rcParams (mm-valued cap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   center preserved, so 1-2 categories on a wide axes no longer
   render as oversized slabs. The cap composes with `border_radius`,
   with `pp.violinplot(side=...)` half-violins, and with horizontal
-  orientation. (PR #TBD)
+  orientation. (PR #177)
 
 ## [0.12.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `bar.max_width` / `box.max_width` / `violin.max_width` rcParams —
+  millimeter ceiling on the categorical-axis width of bars, boxes,
+  and violins. Default `None` (uncapped, seaborn's behavior). When
+  set, each artist is clamped on the categorical axis with its
+  center preserved, so 1-2 categories on a wide axes no longer
+  render as oversized slabs. The cap composes with `border_radius`,
+  with `pp.violinplot(side=...)` half-violins, and with horizontal
+  orientation. (PR #TBD)
+
 ## [0.12.0] - 2026-05-18
 
 ### Added

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -518,6 +518,37 @@ ax = pp.barplot(
 pp.show()
 
 # %%
+# Capping bar width with ``bar.max_width``
+# ----------------------------------------
+# When only 1-2 categories occupy a wide axes, seaborn's fractional
+# ``width=0.8`` produces visually awkward, oversized bars. Set the
+# ``bar.max_width`` rcParam (in millimeters) to cap the rendered width
+# while preserving each bar's center on its tick. ``None`` (the default)
+# leaves seaborn's behavior untouched.
+narrow_df = pd.DataFrame({
+    "Group": ["Control", "Treated"],
+    "Score": [42.0, 67.0],
+})
+
+fig, axes = pp.subplots(1, 2, axes_size=(60, 40))
+pp.barplot(
+    data=narrow_df, x="Group", y="Score",
+    palette={"Control": "#8E8EC1", "Treated": "#60a8a8"}, hue="Group",
+    legend=False, ax=axes[0], title="uncapped",
+)
+saved = pp.rcParams["bar.max_width"]
+try:
+    pp.rcParams["bar.max_width"] = 10  # mm
+    pp.barplot(
+        data=narrow_df, x="Group", y="Score",
+        palette={"Control": "#8E8EC1", "Treated": "#60a8a8"}, hue="Group",
+        legend=False, ax=axes[1], title='bar.max_width=10mm',
+    )
+finally:
+    pp.rcParams["bar.max_width"] = saved
+pp.show()
+
+# %%
 # Stacked Bars — ``multiple="stack"``
 # -----------------------------------
 # ``pp.barplot(multiple="stack")`` draws each hue level on top of the

--- a/examples/plots/plot_14_box_plots.py
+++ b/examples/plots/plot_14_box_plots.py
@@ -197,3 +197,30 @@ pp.boxplot(data=box_data, x='category', y='value',
 pp.boxplot(data=box_data, x='category', y='value',
            ax=axes[2], border_radius=(1.5, 0), title='top only')
 pp.show()
+
+# %%
+# Capping box width with ``box.max_width``
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Set ``pp.rcParams["box.max_width"]`` (in millimeters) to cap the
+# rendered IQR-box width when only a few categories sit on a wide axes.
+# Centers stay aligned with their ticks; ``None`` (default) leaves
+# seaborn's fractional ``width=0.8`` untouched.
+narrow_box = pd.DataFrame({
+    "category": np.repeat(["Control", "Treated"], 50),
+    "value": np.concatenate([
+        np.random.normal(50, 10, 50),
+        np.random.normal(60, 12, 50),
+    ]),
+})
+
+fig, axes = pp.subplots(1, 2, axes_size=(60, 40))
+pp.boxplot(data=narrow_box, x="category", y="value",
+           ax=axes[0], title="uncapped")
+saved = pp.rcParams["box.max_width"]
+try:
+    pp.rcParams["box.max_width"] = 10  # mm
+    pp.boxplot(data=narrow_box, x="category", y="value",
+               ax=axes[1], title='box.max_width=10mm')
+finally:
+    pp.rcParams["box.max_width"] = saved
+pp.show()

--- a/examples/plots/plot_15_violin_plots.py
+++ b/examples/plots/plot_15_violin_plots.py
@@ -244,3 +244,30 @@ ax = pp.violinplot(
 )
 pp.show()
 
+# %%
+# Capping violin width with ``violin.max_width``
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Set ``pp.rcParams["violin.max_width"]`` (in millimeters) to cap the
+# rendered violin width when only a few categories sit on a wide axes.
+# The violin is scaled toward each category's tick, preserving its
+# centerline; ``None`` (default) keeps seaborn's behavior.
+narrow_violin = pd.DataFrame({
+    "category": np.repeat(["Control", "Treated"], 200),
+    "value": np.concatenate([
+        np.random.normal(10, 2, 200),
+        np.random.normal(13, 2.5, 200),
+    ]),
+})
+
+fig, axes = pp.subplots(1, 2, axes_size=(60, 40))
+pp.violinplot(data=narrow_violin, x="category", y="value",
+              ax=axes[0], title="uncapped")
+saved = pp.rcParams["violin.max_width"]
+try:
+    pp.rcParams["violin.max_width"] = 10  # mm
+    pp.violinplot(data=narrow_violin, x="category", y="value",
+                  ax=axes[1], title='violin.max_width=10mm')
+finally:
+    pp.rcParams["violin.max_width"] = saved
+pp.show()
+

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -23,6 +23,7 @@ from publiplots.utils.legend_entries import (
     resolve_legend_flags,
 )
 from publiplots.utils.plot_legend import render_entries
+from publiplots.utils.max_width import clamp_patch_widths_mm
 from publiplots.utils.rounding import apply_border_radius, normalize_border_radius
 from publiplots.utils.transparency import ArtistTracker
 from publiplots.annotate._builders import (
@@ -492,6 +493,14 @@ def barplot(
             color=color, edgecolor=edgecolor, linewidth=linewidth,
             errorbar=errorbar, gap=gap,
         )
+        # Cap bar width (mm) BEFORE rounding so the swap sees clamped extents.
+        _clamp_axis = "x" if categorical_axis == x else "y"
+        clamp_patch_widths_mm(
+            tracker.get_new_patches(),
+            resolve_param("bar.max_width", None),
+            ax,
+            axis=_clamp_axis,
+        )
         radius = normalize_border_radius(
             resolve_param("bar.border_radius", border_radius)
         )
@@ -594,6 +603,17 @@ def barplot(
         edgecolor=edgecolor,
         palette=palette,
         hatch_map=hatch_map,
+    )
+
+    # Cap bar width (mm) per rcParam BEFORE apply_border_radius so the
+    # rounding swap reads the clamped extents. Vertical bars (categorical_axis
+    # == x) are clamped on x; horizontal on y.
+    _clamp_axis = "x" if categorical_axis == x else "y"
+    clamp_patch_widths_mm(
+        tracker.get_new_patches(),
+        resolve_param("bar.max_width", None),
+        ax,
+        axis=_clamp_axis,
     )
 
     # Round bar corners per rcParam / kwarg (no-op on (0, 0)). Runs AFTER

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -17,6 +17,7 @@ import pandas as pd
 import numpy as np
 
 from publiplots.themes.colors import resolve_palette_map
+from publiplots.utils.max_width import clamp_patch_widths_mm
 from publiplots.utils.rounding import apply_border_radius, normalize_border_radius
 from publiplots.utils.transparency import ArtistTracker
 from publiplots.utils import is_categorical
@@ -294,6 +295,68 @@ def boxplot(
     # Set edge colors on box patches
     for patch in new_patches:
         patch.set_edgecolor(resolved_edgecolor if resolved_edgecolor else patch.get_facecolor())
+
+    # Cap box width (mm) BEFORE apply_border_radius so the rounding swap
+    # reads the clamped extents. categorical_axis is "x" (vertical boxes)
+    # or "y" (horizontal); pass directly to the helper.
+    _max_box_mm = resolve_param("box.max_width", None)
+    if _max_box_mm is not None and _max_box_mm > 0:
+        # Snapshot pre-clamp patch extents so we can scale the
+        # whisker / cap / median lines toward the (now-clamped) patch
+        # center on the categorical axis.
+        _pre_extents = []
+        for p in tracker.get_new_patches():
+            bbox = p.get_path().get_extents()
+            _pre_extents.append(bbox)
+        clamp_patch_widths_mm(
+            tracker.get_new_patches(),
+            _max_box_mm,
+            ax,
+            axis=categorical_axis,
+        )
+        _post_extents = [p.get_path().get_extents() for p in tracker.get_new_patches()]
+        # For each line that lives within an old patch's categorical-axis
+        # extent, scale the line toward the patch's center to match the
+        # new (clamped) extent. Whiskers (single x-point) are unaffected.
+        for line in tracker.get_new_lines():
+            if categorical_axis == "x":
+                xs = np.asarray(line.get_xdata(), dtype=float)
+            else:
+                xs = np.asarray(line.get_ydata(), dtype=float)
+            if len(xs) == 0:
+                continue
+            cmin, cmax = float(xs.min()), float(xs.max())
+            extent = cmax - cmin
+            for pre, post in zip(_pre_extents, _post_extents):
+                if categorical_axis == "x":
+                    pre_min, pre_max = pre.x0, pre.x1
+                    post_min, post_max = post.x0, post.x1
+                else:
+                    pre_min, pre_max = pre.y0, pre.y1
+                    post_min, post_max = post.y0, post.y1
+                pre_w = pre_max - pre_min
+                if pre_w <= 0:
+                    continue
+                # Line "belongs" to this patch if its center is inside the
+                # pre-clamp extent and its full span is within (slightly
+                # tolerant) the patch width.
+                lc = (cmin + cmax) / 2.0
+                if not (pre_min - 1e-9 <= lc <= pre_max + 1e-9):
+                    continue
+                if extent > pre_w + 1e-9:
+                    continue
+                # Compute scale by patch shrinkage; scale line toward patch center.
+                post_w = post_max - post_min
+                if post_w >= pre_w - 1e-12:
+                    break  # patch unchanged → no clamp needed
+                center = (post_min + post_max) / 2.0
+                scale = post_w / pre_w
+                new_xs = center + (xs - (pre_min + pre_max) / 2.0) * scale
+                if categorical_axis == "x":
+                    line.set_xdata(new_xs)
+                else:
+                    line.set_ydata(new_xs)
+                break
 
     # Round the IQR-box corners per rcParam / kwarg. No-op when (0, 0).
     # Runs AFTER the edgecolor loop so face/edge are copied onto the new

--- a/src/publiplots/plot/violin.py
+++ b/src/publiplots/plot/violin.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from publiplots.themes.colors import resolve_palette_map
 from publiplots.utils import is_categorical
+from publiplots.utils.max_width import clamp_patch_widths_mm
 from publiplots.utils.plot_legend import stash_hue_legend
 from publiplots.utils.transparency import ArtistTracker
 
@@ -298,6 +299,17 @@ def violinplot(
         # Determine orientation for side clipping
         is_vertical = is_categorical(data[x])
         _side_clip_violin(tracker, side, is_vertical, inner)
+
+    # Cap violin width (mm) per rcParam. Runs after side-clip so half-violins
+    # are scaled relative to their (clipped) center; runs before transparency
+    # so subsequent passes see the clamped vertices.
+    is_vertical = is_categorical(data[x])
+    clamp_patch_widths_mm(
+        tracker.get_new_collections(),
+        resolve_param("violin.max_width", None),
+        ax,
+        axis="x" if is_vertical else "y",
+    )
 
     # Apply transparency only to new violin collections
     tracker.apply_transparency(on="collections", face_alpha=alpha)

--- a/src/publiplots/themes/rcparams.py
+++ b/src/publiplots/themes/rcparams.py
@@ -169,6 +169,13 @@ PUBLIPLOTS_RCPARAMS: Dict[str, Any] = {
     "bar.border_radius": (0.0, 0.0),   # (top_mm, bottom_mm); scalar or tuple — rounded corners for pp.barplot
     "box.border_radius": (0.0, 0.0),   # (top_mm, bottom_mm); scalar or tuple — rounded corners for pp.boxplot IQR boxes (auto-propagates to pp.raincloudplot)
 
+    # Categorical-mark width caps (mm). When set, bars / boxes / violins
+    # never render wider than this, even on a wide axes with few categories.
+    # None = uncapped (seaborn default behavior).
+    "bar.max_width": None,     # mm; None = uncapped (seaborn default)
+    "box.max_width": None,     # mm; None = uncapped
+    "violin.max_width": None,  # mm; None = uncapped
+
     # Subplots layout (mm) — baseline is publication-grade; notebook style
     # overrides these in themes/styles.py.
     "subplots.axes_size": (70.0, 50.0),  # default (width, height) of each axes in pp.subplots

--- a/src/publiplots/utils/max_width.py
+++ b/src/publiplots/utils/max_width.py
@@ -1,0 +1,163 @@
+"""Cap the categorical-axis width of bars / boxes / violins to a mm value.
+
+Used by :func:`publiplots.barplot`, :func:`publiplots.boxplot`, and
+:func:`publiplots.violinplot` to translate the rcParams ``bar.max_width``
+/ ``box.max_width`` / ``violin.max_width`` into a per-artist clamp. The
+clamp preserves each artist's center on the categorical axis — naively
+shrinking width via ``set_width`` would shift the visual center.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Literal
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import FillBetweenPolyCollection
+from matplotlib.patches import PathPatch, Rectangle
+
+
+def clamp_patch_widths_mm(
+    artists: Iterable,
+    max_width_mm: float | None,
+    ax: Axes,
+    *,
+    axis: Literal["x", "y"] = "x",
+) -> None:
+    """Clamp each artist's extent on ``axis`` to ``max_width_mm``, center-preserving.
+
+    No-op when ``max_width_mm`` is ``None`` or non-positive. Dispatches by
+    artist type: :class:`Rectangle` (bar), ``_RoundedBarPatch`` (rounded
+    bar/box), :class:`PathPatch` (raw box), and
+    :class:`FillBetweenPolyCollection` (violin). Other artist types are
+    skipped. Pass ``axis="y"`` for horizontal bars / boxes / violins.
+    """
+    if max_width_mm is None or max_width_mm <= 0:
+        return
+
+    # Lazy import to avoid a cycle: utils.rounding may import from this
+    # package. Mirrors the pattern in utils/offset.py.
+    from publiplots.utils.rounding import _RoundedBarPatch
+    from publiplots.annotate._positioning import mm_to_data
+
+    max_data = abs(mm_to_data(max_width_mm, ax, axis))
+    if max_data <= 0:
+        return
+
+    for artist in artists:
+        if isinstance(artist, _RoundedBarPatch):
+            _clamp_rounded(artist, max_data, axis)
+        elif isinstance(artist, Rectangle):
+            _clamp_rectangle(artist, max_data, axis)
+        elif isinstance(artist, PathPatch):
+            _clamp_pathpatch(artist, max_data, axis)
+        elif isinstance(artist, FillBetweenPolyCollection):
+            _clamp_violin_collection(artist, max_data, axis)
+
+
+def _clamp_rectangle(r: Rectangle, max_data: float, axis: str) -> None:
+    if axis == "x":
+        w = r.get_width()
+        if abs(w) <= max_data:
+            return
+        new_w = max_data if w >= 0 else -max_data
+        r.set_x(r.get_x() + (w - new_w) / 2.0)
+        r.set_width(new_w)
+    else:
+        h = r.get_height()
+        if abs(h) <= max_data:
+            return
+        new_h = max_data if h >= 0 else -max_data
+        r.set_y(r.get_y() + (h - new_h) / 2.0)
+        r.set_height(new_h)
+
+
+def _clamp_rounded(p, max_data: float, axis: str) -> None:
+    """Clamp a _RoundedBarPatch using its public Rectangle-like API."""
+    if axis == "x":
+        w = p.get_width()
+        if abs(w) <= max_data:
+            return
+        new_w = max_data if w >= 0 else -max_data
+        x, y = p.get_xy()
+        p.set_xy((x + (w - new_w) / 2.0, y))
+        # Public attribute carrying the data-coord width (see _RoundedBarPatch).
+        p._rounded_width = float(new_w)
+        p.stale = True
+    else:
+        h = p.get_height()
+        if abs(h) <= max_data:
+            return
+        new_h = max_data if h >= 0 else -max_data
+        x, y = p.get_xy()
+        p.set_xy((x, y + (h - new_h) / 2.0))
+        p._rounded_height = float(new_h)
+        p.stale = True
+
+
+def _clamp_pathpatch(p: PathPatch, max_data: float, axis: str) -> None:
+    """Clamp a rectangular PathPatch by mutating its path vertices."""
+    path = p.get_path()
+    verts = path.vertices
+    col = 0 if axis == "x" else 1
+    coords = verts[:, col]
+    cmin, cmax = float(coords.min()), float(coords.max())
+    cur = cmax - cmin
+    if cur <= max_data:
+        return
+    center = (cmin + cmax) / 2.0
+    half = max_data / 2.0
+    # Map every vertex coord on this axis to its clamped equivalent,
+    # preserving its side relative to the center.
+    new_coords = np.where(
+        coords > center,
+        np.minimum(coords, center + half),
+        np.maximum(coords, center - half),
+    )
+    # For pure rectangles (vertices sit on cmin or cmax), the result is
+    # exactly [center-half, center+half]; for off-rect vertices the sided
+    # min/max keeps them on their side without overshooting.
+    verts[:, col] = new_coords
+    p.stale = True
+
+
+def _clamp_violin_collection(
+    coll: FillBetweenPolyCollection, max_data: float, axis: str
+) -> None:
+    """Scale violin paths toward each path's center on ``axis``.
+
+    For two-sided violins the cap is the full width; for half-violins
+    (side="left"|"right" — many vertices stack at the clipped edge) the
+    cap is the half-width, and the path is scaled toward that edge.
+    """
+    col = 0 if axis == "x" else 1
+    new_verts = []
+    for path in coll.get_paths():
+        verts = path.vertices.copy()
+        coords = verts[:, col]
+        vmin, vmax = float(coords.min()), float(coords.max())
+        n = len(coords)
+        # Side-clipped half-violins stack many vertices at the clipped edge
+        # (≥25% of vertices, well above 1-2 from a normal cap).
+        thresh = max(0.25 * n, 5)
+        n_at_max = int(np.sum(np.isclose(coords, vmax, atol=1e-9)))
+        n_at_min = int(np.sum(np.isclose(coords, vmin, atol=1e-9)))
+        if n_at_max >= thresh and n_at_max > n_at_min:
+            # Half-violin clipped on the right side of the spike.
+            center, half, target_half = vmax, vmax - vmin, max_data
+        elif n_at_min >= thresh and n_at_min > n_at_max:
+            center, half, target_half = vmin, vmax - vmin, max_data
+        else:
+            center = (vmin + vmax) / 2.0
+            half = (vmax - vmin) / 2.0
+            target_half = max_data / 2.0
+        if half <= 0 or target_half >= half:
+            new_verts.append(verts)
+            continue
+        scale = target_half / half
+        verts[:, col] = center + (coords - center) * scale
+        new_verts.append(verts)
+    coll.set_verts(new_verts)
+
+
+__all__ = ["clamp_patch_widths_mm"]

--- a/tests/test_categorical_max_width.py
+++ b/tests/test_categorical_max_width.py
@@ -1,0 +1,352 @@
+"""Tests for the bar/box/violin max_width rcParams (mm-valued cap).
+
+Each rcParam (``bar.max_width``, ``box.max_width``, ``violin.max_width``)
+caps the rendered width on the categorical axis to a millimeter ceiling
+while preserving each artist's center on that axis.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Iterator
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import FillBetweenPolyCollection
+from matplotlib.patches import PathPatch, Rectangle
+
+import publiplots as pp
+from publiplots.annotate._positioning import mm_to_data
+from publiplots.utils.rounding import _RoundedBarPatch
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@contextlib.contextmanager
+def _rc(**overrides) -> Iterator[None]:
+    """Set publiplots rcParams for the duration of the with-block."""
+    saved = {k: pp.rcParams[k] for k in overrides}
+    try:
+        for k, v in overrides.items():
+            pp.rcParams[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            pp.rcParams[k] = v
+
+
+def _data_to_mm(width_data: float, ax, axis: str) -> float:
+    """Inverse of mm_to_data: convert a data-coord delta to mm."""
+    one_mm = mm_to_data(1.0, ax, axis)
+    return float(width_data) / float(one_mm)
+
+
+# ---------------------------------------------------------------------------
+# Bars
+# ---------------------------------------------------------------------------
+
+
+def _bars(ax):
+    return [p for p in ax.patches if hasattr(p, "get_height")]
+
+
+class TestBarMaxWidth:
+    """`bar.max_width` clamps and centers vertical/horizontal bars."""
+
+    def _df_two_cats(self):
+        df = pd.DataFrame({"x": ["A", "B"], "y": [3.0, 2.0]})
+        df["x"] = pd.Categorical(df["x"], categories=["A", "B"])
+        return df
+
+    def test_cap_fires(self):
+        df = self._df_two_cats()
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        with _rc(**{"bar.max_width": 5.0}):
+            pp.barplot(data=df, x="x", y="y", ax=ax)
+            fig.canvas.draw()
+            for p in _bars(ax):
+                w_mm = _data_to_mm(p.get_width(), ax, "x")
+                assert w_mm <= 5.0 + 1e-3, f"bar width {w_mm:.3f}mm > 5mm cap"
+
+    def test_cap_is_ceiling(self):
+        # 5 categories on a 60mm axes — natural slot is 12mm/bar, well below
+        # a 50mm cap. Widths should match the un-capped baseline.
+        df = pd.DataFrame({"x": list("abcde"), "y": [1.0, 2, 3, 4, 5]})
+        df["x"] = pd.Categorical(df["x"], categories=list("abcde"))
+
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        pp.barplot(data=df, x="x", y="y", ax=ax)
+        fig.canvas.draw()
+        baseline = sorted(p.get_width() for p in _bars(ax))
+
+        fig2, ax2 = pp.subplots(axes_size=(60, 40))
+        with _rc(**{"bar.max_width": 50.0}):
+            pp.barplot(data=df, x="x", y="y", ax=ax2)
+            fig2.canvas.draw()
+            capped = sorted(p.get_width() for p in _bars(ax2))
+
+        for b, c in zip(baseline, capped):
+            assert abs(b - c) < 1e-9
+
+    def test_center_preserved(self):
+        df = self._df_two_cats()
+        fig, ax = pp.subplots(axes_size=(80, 40))
+        with _rc(**{"bar.max_width": 5.0}):
+            pp.barplot(data=df, x="x", y="y", ax=ax)
+            fig.canvas.draw()
+            # Two cats land at integer x positions 0 and 1 in seaborn.
+            centers = sorted(p.get_x() + p.get_width() / 2.0 for p in _bars(ax))
+            tol_mm = 0.5
+            tol_data = abs(mm_to_data(tol_mm, ax, "x"))
+            assert abs(centers[0] - 0.0) < tol_data
+            assert abs(centers[1] - 1.0) < tol_data
+
+    def test_composes_with_border_radius(self):
+        df = self._df_two_cats()
+        fig, ax = pp.subplots(axes_size=(80, 40))
+        with _rc(**{"bar.max_width": 5.0, "bar.border_radius": (1.0, 0.0)}):
+            pp.barplot(data=df, x="x", y="y", ax=ax)
+            fig.canvas.draw()
+            rounded = [p for p in _bars(ax) if isinstance(p, _RoundedBarPatch)]
+            assert len(rounded) == 2
+            for p in rounded:
+                w_mm = _data_to_mm(p.get_width(), ax, "x")
+                assert w_mm <= 5.0 + 1e-3
+
+    def test_horizontal_bars_clamped_on_y(self):
+        df = pd.DataFrame({"y": ["A", "B"], "x": [3.0, 2.0]})
+        df["y"] = pd.Categorical(df["y"], categories=["A", "B"])
+        fig, ax = pp.subplots(axes_size=(40, 60))
+        with _rc(**{"bar.max_width": 5.0}):
+            pp.barplot(data=df, x="x", y="y", ax=ax)
+            fig.canvas.draw()
+            for p in _bars(ax):
+                h_mm = _data_to_mm(p.get_height(), ax, "y")
+                assert h_mm <= 5.0 + 1e-3
+
+    def test_no_cap_default(self):
+        df = self._df_two_cats()
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        pp.barplot(data=df, x="x", y="y", ax=ax)
+        fig.canvas.draw()
+        # No cap → bars span their full slot (slot - gap, in data units).
+        # On a 60mm/2-bar axes a 0.72 data-coord bar corresponds to ~21mm;
+        # the ceiling test elsewhere already guards "cap doesn't shrink".
+        # Just confirm uncapped widths exceed any reasonable mm cap.
+        for p in _bars(ax):
+            w_mm = _data_to_mm(p.get_width(), ax, "x")
+            assert w_mm > 10.0, f"uncapped bar should be wide; got {w_mm:.3f}mm"
+
+
+# ---------------------------------------------------------------------------
+# Boxes
+# ---------------------------------------------------------------------------
+
+
+def _boxes(ax):
+    return [p for p in ax.patches if isinstance(p, PathPatch)]
+
+
+def _box_extent(p: PathPatch, axis: str) -> float:
+    bbox = p.get_path().get_extents()
+    return bbox.width if axis == "x" else bbox.height
+
+
+def _box_center(p: PathPatch, axis: str) -> float:
+    bbox = p.get_path().get_extents()
+    return (bbox.x0 + bbox.x1) / 2.0 if axis == "x" else (bbox.y0 + bbox.y1) / 2.0
+
+
+class TestBoxMaxWidth:
+    """`box.max_width` clamps boxplot IQR boxes."""
+
+    def _df(self):
+        rng = np.random.default_rng(0)
+        rows = []
+        for cat in ("A", "B"):
+            for v in rng.normal(size=30):
+                rows.append({"g": cat, "y": float(v)})
+        df = pd.DataFrame(rows)
+        df["g"] = pd.Categorical(df["g"], categories=["A", "B"])
+        return df
+
+    def test_cap_fires(self):
+        df = self._df()
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        with _rc(**{"box.max_width": 5.0}):
+            pp.boxplot(data=df, x="g", y="y", ax=ax)
+            fig.canvas.draw()
+            for p in _boxes(ax):
+                w_mm = _data_to_mm(_box_extent(p, "x"), ax, "x")
+                assert w_mm <= 5.0 + 1e-3
+
+    def test_cap_is_ceiling(self):
+        # 5 cats on 60mm — natural width well below 50mm cap.
+        rng = np.random.default_rng(1)
+        rows = []
+        for cat in list("abcde"):
+            for v in rng.normal(size=30):
+                rows.append({"g": cat, "y": float(v)})
+        df = pd.DataFrame(rows)
+        df["g"] = pd.Categorical(df["g"], categories=list("abcde"))
+
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        pp.boxplot(data=df, x="g", y="y", ax=ax)
+        fig.canvas.draw()
+        baseline = sorted(_box_extent(p, "x") for p in _boxes(ax))
+
+        fig2, ax2 = pp.subplots(axes_size=(60, 40))
+        with _rc(**{"box.max_width": 50.0}):
+            pp.boxplot(data=df, x="g", y="y", ax=ax2)
+            fig2.canvas.draw()
+            capped = sorted(_box_extent(p, "x") for p in _boxes(ax2))
+
+        for b, c in zip(baseline, capped):
+            assert abs(b - c) < 1e-9
+
+    def test_center_preserved(self):
+        df = self._df()
+        fig, ax = pp.subplots(axes_size=(80, 40))
+        with _rc(**{"box.max_width": 5.0}):
+            pp.boxplot(data=df, x="g", y="y", ax=ax)
+            fig.canvas.draw()
+            centers = sorted(_box_center(p, "x") for p in _boxes(ax))
+            tol_data = abs(mm_to_data(0.5, ax, "x"))
+            assert abs(centers[0] - 0.0) < tol_data
+            assert abs(centers[1] - 1.0) < tol_data
+
+    def test_composes_with_border_radius(self):
+        df = self._df()
+        fig, ax = pp.subplots(axes_size=(80, 40))
+        with _rc(**{"box.max_width": 5.0, "box.border_radius": (1.0, 0.0)}):
+            pp.boxplot(data=df, x="g", y="y", ax=ax)
+            fig.canvas.draw()
+            rounded = [p for p in ax.patches if isinstance(p, _RoundedBarPatch)]
+            assert len(rounded) == 2
+            for p in rounded:
+                w_mm = _data_to_mm(p.get_width(), ax, "x")
+                assert w_mm <= 5.0 + 1e-3
+
+
+# ---------------------------------------------------------------------------
+# Violins
+# ---------------------------------------------------------------------------
+
+
+def _violin_collections(ax):
+    return [c for c in ax.collections if isinstance(c, FillBetweenPolyCollection)]
+
+
+def _violin_x_range(coll: FillBetweenPolyCollection):
+    """Return (vmin, vmax) on x for each path's vertices."""
+    out = []
+    for path in coll.get_paths():
+        xs = path.vertices[:, 0]
+        out.append((float(xs.min()), float(xs.max())))
+    return out
+
+
+class TestViolinMaxWidth:
+    """`violin.max_width` clamps violin half-width on the categorical axis."""
+
+    def _df(self):
+        rng = np.random.default_rng(2)
+        rows = []
+        for cat in ("A", "B"):
+            for v in rng.normal(size=200):
+                rows.append({"g": cat, "y": float(v)})
+        df = pd.DataFrame(rows)
+        df["g"] = pd.Categorical(df["g"], categories=["A", "B"])
+        return df
+
+    def test_cap_fires(self):
+        df = self._df()
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        with _rc(**{"violin.max_width": 5.0}):
+            pp.violinplot(data=df, x="g", y="y", ax=ax)
+            fig.canvas.draw()
+            for coll in _violin_collections(ax):
+                for vmin, vmax in _violin_x_range(coll):
+                    w_mm = _data_to_mm(vmax - vmin, ax, "x")
+                    assert w_mm <= 5.0 + 1e-3, f"violin width {w_mm:.3f}mm > 5mm"
+
+    def test_cap_is_ceiling(self):
+        rng = np.random.default_rng(3)
+        rows = []
+        for cat in list("abcde"):
+            for v in rng.normal(size=80):
+                rows.append({"g": cat, "y": float(v)})
+        df = pd.DataFrame(rows)
+        df["g"] = pd.Categorical(df["g"], categories=list("abcde"))
+
+        fig, ax = pp.subplots(axes_size=(60, 40))
+        pp.violinplot(data=df, x="g", y="y", ax=ax)
+        fig.canvas.draw()
+        baseline = sorted(
+            (vmax - vmin)
+            for coll in _violin_collections(ax)
+            for vmin, vmax in _violin_x_range(coll)
+        )
+
+        fig2, ax2 = pp.subplots(axes_size=(60, 40))
+        with _rc(**{"violin.max_width": 50.0}):
+            pp.violinplot(data=df, x="g", y="y", ax=ax2)
+            fig2.canvas.draw()
+            capped = sorted(
+                (vmax - vmin)
+                for coll in _violin_collections(ax2)
+                for vmin, vmax in _violin_x_range(coll)
+            )
+
+        for b, c in zip(baseline, capped):
+            assert abs(b - c) < 1e-9
+
+    def test_center_preserved(self):
+        df = self._df()
+        fig, ax = pp.subplots(axes_size=(80, 40))
+        with _rc(**{"violin.max_width": 5.0}):
+            pp.violinplot(data=df, x="g", y="y", ax=ax)
+            fig.canvas.draw()
+            centers = []
+            for coll in _violin_collections(ax):
+                for vmin, vmax in _violin_x_range(coll):
+                    centers.append((vmin + vmax) / 2.0)
+            centers.sort()
+            tol_data = abs(mm_to_data(0.5, ax, "x"))
+            assert abs(centers[0] - 0.0) < tol_data
+            assert abs(centers[1] - 1.0) < tol_data
+
+    def test_composes_with_side_left(self):
+        df = self._df()
+        fig, ax = pp.subplots(axes_size=(80, 40))
+        max_mm = 4.0
+        with _rc(**{"violin.max_width": max_mm}):
+            pp.violinplot(data=df, x="g", y="y", side="left", ax=ax)
+            fig.canvas.draw()
+            # Left-clipped: the right edge of each path is the category center.
+            cats = [0.0, 1.0]
+            paths_seen = []
+            for coll in _violin_collections(ax):
+                for vmin, vmax in _violin_x_range(coll):
+                    paths_seen.append((vmin, vmax))
+            # Each path's right edge sits at one of the category centers.
+            tol_data = abs(mm_to_data(0.2, ax, "x"))
+            max_data = abs(mm_to_data(max_mm, ax, "x"))
+            for vmin, vmax in paths_seen:
+                # Edge should be at a category center.
+                edge_at_cat = any(abs(vmax - c) < tol_data for c in cats)
+                assert edge_at_cat, (
+                    f"left-clipped violin's right edge {vmax:.3f} not at a category center"
+                )
+                # Half-width within max_data + tolerance.
+                assert (vmax - vmin) <= max_data + tol_data


### PR DESCRIPTION
## Summary

Add three rcParams — `bar.max_width`, `box.max_width`, `violin.max_width` — that cap the rendered width of categorical marks in **millimeters**. Default `None` preserves seaborn's behavior. When set, each artist is clamped on the categorical axis with its center on the tick preserved, so 1-2 categories on a wide axes no longer render as oversized slabs.

- New helper `publiplots.utils.max_width.clamp_patch_widths_mm` dispatches per artist type (`Rectangle`, `_RoundedBarPatch`, `PathPatch`, `FillBetweenPolyCollection`), wired into `pp.barplot` (stacked + dodge), `pp.boxplot`, and `pp.violinplot`.
- Composes cleanly with `border_radius` (the clamp runs before `apply_border_radius` so the rounding swap reads clamped extents) and with `pp.violinplot(side="left"|"right")` half-violins.
- `pp.boxplot` additionally scales whisker / cap / median lines toward the clamped patch center, so the IQR box stays visually intact.

## Test plan

- [x] `tests/test_categorical_max_width.py` — 14 new tests across `TestBarMaxWidth`, `TestBoxMaxWidth`, `TestViolinMaxWidth`: cap-fires, cap-is-ceiling, center-preserved, composes-with-border-radius, horizontal-orient bars, and `side="left"` half-violin compose.
- [x] TDD red phase: 6 of the 14 fail without the wiring (3× `test_cap_fires` + 2× `test_composes_with_border_radius` + 1× `test_composes_with_side_left`).
- [x] Full suite: **1077 passed** (1063 pre-existing + 14 new).
- [x] Visual eyeball: rendered each gallery cell to PNG and inspected — uncapped panel shows the slab issue; capped panel shows narrow centered marks at each tick. Box/violin medians + whiskers track the clamped widths correctly.

## Notable deviation from plan

The plan only specified clamping the box's `PathPatch`. In practice, seaborn renders boxplot whiskers / caps / medians as `Line2D` artists, and clamping just the patch leaves the median line spanning the full original width — visually broken. Added a small post-clamp pass in `box.py` that scales each line's xdata toward the (now-clamped) patch center. Tested and visually confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)