### PR TITLE
fix(rounding): orient- and sign-aware border_radius for bars and boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-05-19
+
+### Fixed
+
+- `pp.barplot(border_radius=...)` and `pp.boxplot(border_radius=...)`
+  now round the **free end** of horizontal bars and boxes (the
+  end opposite the baseline / zero line) instead of the long top
+  and bottom edges. Previously, `_RoundedBarPatch` always applied
+  `top_mm` to the bbox's y-extreme corners and `bottom_mm` to the
+  y-baseline corners — correct for vertical orientations (and
+  sign-aware via matplotlib's signed `height`), but visually wrong
+  for horizontal bars/boxes where the user expected end-cap
+  rounding. `apply_border_radius` now accepts `orient="v" | "h"`
+  and rotates the corner mapping 90° for horizontal plots, so
+  `border_radius=(top_mm, bottom_mm)` consistently means
+  (free-end, base-end) regardless of orientation or sign. The
+  signed-width path also correctly handles negative-valued
+  horizontal bars (free end = visually-left). `pp.raincloudplot`
+  inherits the fix via its internal `pp.boxplot` call. (Fixes
+  the case where `border_radius` on `seaborn.barplot(orient='h')`
+  bars rounded the long sides instead of the end caps.)
+
 ## [0.12.0] - 2026-05-18
 
 ### Added

--- a/examples/plots/plot_01_bar_plots.py
+++ b/examples/plots/plot_01_bar_plots.py
@@ -501,6 +501,33 @@ pp.barplot(
 pp.show()
 
 # %%
+# Rounded horizontal bars — orientation- and sign-aware
+# -----------------------------------------------------
+# ``border_radius=(top_mm, bottom_mm)`` is interpreted as
+# **(free-end, base-end)**: the "top" radius lands on the end opposite
+# the baseline / zero line. For a horizontal barplot (categorical on
+# ``y``, numeric on ``x``), that's the **right end** for positive
+# values and the **left end** for negative values. The baseline end
+# stays square. This means the same ``border_radius=(1.5, 0)`` recipe
+# produces visually consistent "rounded tip, flat base" bars whether
+# the layout is vertical or horizontal — and whether values are
+# positive or negative.
+signed_df = pd.DataFrame({
+    'x': ['A', 'B', 'C', 'D'],
+    'y': [1.5, -0.8, 2.1, -1.4],
+})
+fig, axes = pp.subplots(1, 2, axes_size=(45, 35))
+pp.barplot(
+    data=signed_df, x='x', y='y', ax=axes[0],
+    border_radius=(1.5, 0), title='vertical, mixed sign',
+)
+pp.barplot(
+    data=signed_df, x='y', y='x', ax=axes[1],
+    border_radius=(1.5, 0), title='horizontal, mixed sign',
+)
+pp.show()
+
+# %%
 # Rounded bars + annotations
 # --------------------------
 # ``annotate=`` works on rounded bars exactly as it does on flat ones —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.12.0"
+version = "0.12.1"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/plot/bar.py
+++ b/src/publiplots/plot/bar.py
@@ -495,7 +495,9 @@ def barplot(
         radius = normalize_border_radius(
             resolve_param("bar.border_radius", border_radius)
         )
-        apply_border_radius(tracker.get_new_patches(), radius, ax)
+        apply_border_radius(
+            tracker.get_new_patches(), radius, ax, orient=_split.orient,
+        )
         tracker.apply_transparency(on="patches", face_alpha=alpha, edge_alpha=1.0)
         # Reuse the dodge path's four-case legend dispatcher — the legend
         # treatment is identical whether bars are dodged or stacked.
@@ -605,7 +607,9 @@ def barplot(
     radius = normalize_border_radius(
         resolve_param("bar.border_radius", border_radius)
     )
-    apply_border_radius(tracker.get_new_patches(), radius, ax)
+    apply_border_radius(
+        tracker.get_new_patches(), radius, ax, orient=_split.orient,
+    )
 
     # Apply differential transparency to face vs edge
     tracker.apply_transparency(on="patches", face_alpha=alpha, edge_alpha=1.0)

--- a/src/publiplots/plot/box.py
+++ b/src/publiplots/plot/box.py
@@ -304,7 +304,12 @@ def boxplot(
     radius = normalize_border_radius(
         resolve_param("box.border_radius", border_radius)
     )
-    apply_border_radius(tracker.get_new_patches(), radius, ax)
+    apply_border_radius(
+        tracker.get_new_patches(),
+        radius,
+        ax,
+        orient="v" if categorical_axis == "x" else "h",
+    )
 
     # Apply transparency to box patch faces
     tracker.apply_transparency(on="patches", face_alpha=alpha)

--- a/src/publiplots/utils/rounding.py
+++ b/src/publiplots/utils/rounding.py
@@ -3,7 +3,10 @@
 This module provides a plot-agnostic helper that swaps
 :class:`matplotlib.patches.Rectangle` patches (e.g. from
 ``seaborn.barplot``) for :class:`_RoundedBarPatch` instances with
-independent top / bottom corner radii.
+independent per-corner radii. The user-facing API is
+``(top_mm, bottom_mm)`` — interpreted as (free-end, base-end) and
+rotated by orientation so that horizontal bars round their end caps
+rather than their long edges.
 
 **Units**: radii are specified in millimeters and resolved to data
 coordinates **at draw time** using the parent axes' ``transData``,
@@ -72,7 +75,7 @@ def normalize_border_radius(
 
 
 class _RoundedBarPatch(Patch):
-    """Rectangle-shaped patch with independent top / bottom corner radii.
+    """Rectangle-shaped patch with independent per-corner radii.
 
     Radii are carried as **points**, not data units. Each call to
     :meth:`get_path` (triggered by the renderer every draw) converts
@@ -92,11 +95,18 @@ class _RoundedBarPatch(Patch):
     xy : tuple of float
         Lower-left corner ``(x, y)`` in data coords.
     width, height : float
-        Rectangle width and height in data coords.
-    top_pts, bottom_pts : float
-        Corner radii in points. Use
-        :func:`normalize_border_radius` + the ``_MM_TO_POINTS``
-        constant to convert from user-facing mm input.
+        Rectangle width and height in data coords (signed; matplotlib
+        stores negative values for negative-valued bars).
+    top_pts, bottom_pts : float, optional
+        Convenience pair: top corners (TL+TR) and bottom corners
+        (BL+BR) get the same radius respectively. Used by callers
+        that don't care about per-corner control. When
+        ``corner_pts`` is also given, ``corner_pts`` wins.
+    corner_pts : tuple of 4 floats, keyword-only, optional
+        Per-corner radii in points, in order
+        ``(top_left, top_right, bottom_right, bottom_left)``. Use
+        :func:`apply_border_radius` to translate user-facing
+        ``(top_mm, bottom_mm)`` + orientation into this 4-tuple.
     **kwargs
         Forwarded to :class:`matplotlib.patches.Patch` (e.g. facecolor,
         edgecolor, linewidth, hatch, alpha, zorder, transform,
@@ -108,16 +118,28 @@ class _RoundedBarPatch(Patch):
         xy: Tuple[float, float],
         width: float,
         height: float,
-        top_pts: float,
-        bottom_pts: float,
+        top_pts: float = 0.0,
+        bottom_pts: float = 0.0,
+        *,
+        corner_pts: Optional[Tuple[float, float, float, float]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._rounded_xy = (float(xy[0]), float(xy[1]))
         self._rounded_width = float(width)
         self._rounded_height = float(height)
-        self._top_pts = float(top_pts)
-        self._bottom_pts = float(bottom_pts)
+        if corner_pts is not None:
+            tl, tr, br, bl = corner_pts
+            self._corner_pts = (
+                float(tl), float(tr), float(br), float(bl),
+            )
+        else:
+            t = float(top_pts)
+            b = float(bottom_pts)
+            self._corner_pts = (t, t, b, b)
+        # Kept for back-compat with code reading these attrs.
+        self._top_pts = self._corner_pts[0]
+        self._bottom_pts = self._corner_pts[3]
 
     # Bar-like getters for compatibility with code that walks
     # ax.patches and checks hasattr(p, "get_height") to filter bars
@@ -202,68 +224,87 @@ class _RoundedBarPatch(Patch):
         return (dpx, dpy)
 
     def get_path(self) -> Path:
-        """Build the rounded-rectangle path in data coords."""
+        """Build the rounded-rectangle path in data coords.
+
+        Corner radii are stored per-corner (TL, TR, BR, BL); each
+        corner's x- and y-radii in data coords are computed
+        independently and clamped to half of the (unsigned) side
+        length so curves never overshoot. Width/height are taken with
+        sign — for matplotlib bars built with negative values, this
+        means ``y1 < y0`` and the "top" corners (TL/TR) end up at the
+        visually-lower edge, which is exactly what we want: the
+        free-end of the bar.
+        """
         x0, y0 = self._rounded_xy
         w = self._rounded_width
         h = self._rounded_height
         x1, y1 = x0 + w, y0 + h
 
         dpx, dpy = self._data_per_point()
-        t_rx = self._top_pts * dpx
-        t_ry = self._top_pts * dpy
-        b_rx = self._bottom_pts * dpx
-        b_ry = self._bottom_pts * dpy
-
-        # Clamp to half the shorter side so curves never overshoot.
         half_w = abs(w) / 2.0
         half_h = abs(h) / 2.0
-        t_rx = min(max(t_rx, 0.0), half_w)
-        t_ry = min(max(t_ry, 0.0), half_h)
-        b_rx = min(max(b_rx, 0.0), half_w)
-        b_ry = min(max(b_ry, 0.0), half_h)
+
+        def _xy(pts: float) -> Tuple[float, float]:
+            rx = min(max(pts * dpx, 0.0), half_w)
+            ry = min(max(pts * dpy, 0.0), half_h)
+            return rx, ry
+
+        tl_rx, tl_ry = _xy(self._corner_pts[0])
+        tr_rx, tr_ry = _xy(self._corner_pts[1])
+        br_rx, br_ry = _xy(self._corner_pts[2])
+        bl_rx, bl_ry = _xy(self._corner_pts[3])
 
         # A corner is only drawn when BOTH x- and y-radii are positive.
-        draw_b = b_rx > 0 and b_ry > 0
-        draw_t = t_rx > 0 and t_ry > 0
+        draw_tl = tl_rx > 0 and tl_ry > 0
+        draw_tr = tr_rx > 0 and tr_ry > 0
+        draw_br = br_rx > 0 and br_ry > 0
+        draw_bl = bl_rx > 0 and bl_ry > 0
+
+        # Signed radii: when w<0 (negative horizontal bar) or h<0
+        # (negative vertical bar), the "right" of the bbox is
+        # numerically less than its "left" / etc., so we walk along
+        # the edge using signed deltas instead of plain subtraction.
+        sx = 1.0 if w >= 0 else -1.0
+        sy = 1.0 if h >= 0 else -1.0
 
         verts: list = []
         codes: list = []
 
         # Start on the left edge, just above the bottom-left corner.
-        start = (x0, y0 + b_ry) if draw_b else (x0, y0)
+        start = (x0, y0 + sy * bl_ry) if draw_bl else (x0, y0)
         verts.append(start)
         codes.append(Path.MOVETO)
 
         # Bottom-left corner.
-        if draw_b:
-            verts.extend([(x0, y0), (x0 + b_rx, y0)])
+        if draw_bl:
+            verts.extend([(x0, y0), (x0 + sx * bl_rx, y0)])
             codes.extend([Path.CURVE3, Path.CURVE3])
 
         # Bottom edge → bottom-right.
-        verts.append((x1 - b_rx if draw_b else x1, y0))
+        verts.append((x1 - sx * br_rx if draw_br else x1, y0))
         codes.append(Path.LINETO)
 
         # Bottom-right corner.
-        if draw_b:
-            verts.extend([(x1, y0), (x1, y0 + b_ry)])
+        if draw_br:
+            verts.extend([(x1, y0), (x1, y0 + sy * br_ry)])
             codes.extend([Path.CURVE3, Path.CURVE3])
 
         # Right edge → top-right.
-        verts.append((x1, y1 - t_ry if draw_t else y1))
+        verts.append((x1, y1 - sy * tr_ry if draw_tr else y1))
         codes.append(Path.LINETO)
 
         # Top-right corner.
-        if draw_t:
-            verts.extend([(x1, y1), (x1 - t_rx, y1)])
+        if draw_tr:
+            verts.extend([(x1, y1), (x1 - sx * tr_rx, y1)])
             codes.extend([Path.CURVE3, Path.CURVE3])
 
         # Top edge → top-left.
-        verts.append((x0 + t_rx if draw_t else x0, y1))
+        verts.append((x0 + sx * tl_rx if draw_tl else x0, y1))
         codes.append(Path.LINETO)
 
         # Top-left corner.
-        if draw_t:
-            verts.extend([(x0, y1), (x0, y1 - t_ry)])
+        if draw_tl:
+            verts.extend([(x0, y1), (x0, y1 - sy * tl_ry)])
             codes.extend([Path.CURVE3, Path.CURVE3])
 
         # Close back to start.
@@ -277,6 +318,7 @@ def apply_border_radius(
     patches: Sequence[Patch],
     radius_mm: Tuple[float, float],
     ax: Axes,
+    orient: str = "v",
 ) -> None:
     """Swap ``Rectangle`` / ``PathPatch`` bars for rounded-corner patches.
 
@@ -318,11 +360,21 @@ def apply_border_radius(
         ``sns.boxplot``. Rectangle and rectangular PathPatch inputs
         are handled; other types are skipped.
     radius_mm : tuple of float
-        ``(top_mm, bottom_mm)`` — corner radii in millimeters. Use
-        :func:`normalize_border_radius` to coerce user input to this
-        canonical form.
+        ``(top_mm, bottom_mm)`` in user-facing terms: ``top_mm`` is
+        the radius of the **free end** of the bar (visually at the
+        end opposite the baseline / zero line) and ``bottom_mm`` is
+        the radius of the **base end**. For vertical bars the free
+        end is the y-extreme (visually top for positive values,
+        bottom for negative); for horizontal bars it is the x-extreme
+        (right for positive, left for negative). Sign-awareness comes
+        for free from matplotlib's signed width/height storage.
     ax : Axes
         Axes to re-add the new patches to.
+    orient : {"v", "h"}, default "v"
+        Plot orientation. ``"v"`` rounds the y-extreme corners with
+        ``top_mm`` and the y-baseline corners with ``bottom_mm``;
+        ``"h"`` rotates the mapping 90° so ``top_mm`` lands on the
+        x-extreme corners and ``bottom_mm`` on the x-baseline corners.
 
     Returns
     -------
@@ -335,6 +387,17 @@ def apply_border_radius(
 
     top_pts = max(top_mm, 0.0) * _MM_TO_POINTS
     bottom_pts = max(bottom_mm, 0.0) * _MM_TO_POINTS
+
+    # Map (top_mm, bottom_mm) onto (TL, TR, BR, BL) per orientation.
+    # Sign-awareness then comes from the patch's signed width/height.
+    if orient == "v":
+        corner_pts = (top_pts, top_pts, bottom_pts, bottom_pts)
+    elif orient == "h":
+        corner_pts = (bottom_pts, top_pts, top_pts, bottom_pts)
+    else:
+        raise ValueError(
+            f"orient must be 'v' or 'h', got {orient!r}"
+        )
 
     # Iterate over a materialized copy — we mutate ax.patches via
     # rect.remove() + ax.add_patch() below.
@@ -369,8 +432,7 @@ def apply_border_radius(
             xy=(x, y),
             width=w,
             height=h,
-            top_pts=top_pts,
-            bottom_pts=bottom_pts,
+            corner_pts=corner_pts,
             facecolor=patch.get_facecolor(),
             edgecolor=patch.get_edgecolor(),
             linewidth=patch.get_linewidth(),

--- a/tests/test_border_radius.py
+++ b/tests/test_border_radius.py
@@ -294,6 +294,191 @@ def test_boxplot_horizontal_orient_radius():
 
 
 # ---------------------------------------------------------------------------
+# Orientation- and sign-aware corner placement
+# ---------------------------------------------------------------------------
+#
+# `border_radius=(top_mm, bottom_mm)` is interpreted as (free-end, base-end).
+# `_RoundedBarPatch._corner_pts` carries per-corner radii in points, ordered
+# (TL, TR, BR, BL). The mapping that `apply_border_radius` performs is:
+#   vertical:   (TL, TR, BR, BL) = (top, top, bottom, bottom)
+#   horizontal: (TL, TR, BR, BL) = (bottom, top, top, bottom)
+# Sign-awareness then comes for free from matplotlib's signed width/height
+# storage — the patch's bbox extents flip and the "TR" / "TL" labels
+# correspond to the visually-free vs visually-base corners regardless.
+
+# Index of each corner in `_corner_pts` for readability in assertions.
+_TL, _TR, _BR, _BL = 0, 1, 2, 3
+
+
+def _free_base_corners(orient: str, sign: float):
+    """Return (free_idx_pair, base_idx_pair) into _corner_pts.
+
+    The "free" pair is the two corners at the extreme end of the bar
+    (visually opposite the baseline); the "base" pair sits on the
+    baseline. Determined by orientation + sign of the bar value.
+    """
+    if orient == "v":
+        # Vertical positive: free = top edge (TL, TR); base = bottom (BL, BR).
+        # Vertical negative: matplotlib stores h<0 so y1 < y0; the patch's
+        # "TR/TL" corners (at y1) end up visually below — still the free
+        # end. Pair labels relative to _corner_pts don't change with sign.
+        return (_TL, _TR), (_BL, _BR)
+    else:  # "h"
+        # Horizontal: free = right edge of bbox (TR, BR); base = left (TL, BL).
+        return (_TR, _BR), (_TL, _BL)
+
+
+def _rounded(ax):
+    return [p for p in ax.patches if isinstance(p, _RoundedBarPatch)]
+
+
+def test_apply_border_radius_orient_v_default():
+    """orient='v' (default) maps (top, bottom) -> (TL=top, TR=top, BR=bot, BL=bot)."""
+    fig, ax = plt.subplots()
+    rect = Rectangle((0, 0), 1, 2)
+    ax.add_patch(rect)
+    apply_border_radius([rect], (1.5, 0.5), ax)  # default orient="v"
+    new = ax.patches[0]
+    assert isinstance(new, _RoundedBarPatch)
+    tl, tr, br, bl = new._corner_pts
+    assert tl == tr > 0  # top corners share top_mm
+    assert br == bl > 0  # bottom corners share bottom_mm
+    assert tl > br  # top_mm=1.5 > bottom_mm=0.5
+    plt.close(fig)
+
+
+def test_apply_border_radius_orient_h_rotates_90():
+    """orient='h' maps (top, bottom) -> (TL=bot, TR=top, BR=top, BL=bot)."""
+    fig, ax = plt.subplots()
+    rect = Rectangle((0, 0), 2, 1)
+    ax.add_patch(rect)
+    apply_border_radius([rect], (1.5, 0.5), ax, orient="h")
+    new = ax.patches[0]
+    assert isinstance(new, _RoundedBarPatch)
+    tl, tr, br, bl = new._corner_pts
+    # Right-edge corners (TR, BR) carry top_mm (the free-end radius).
+    assert tr == br > 0
+    # Left-edge corners (TL, BL) carry bottom_mm (the base-end radius).
+    assert tl == bl > 0
+    assert tr > tl  # top_mm=1.5 > bottom_mm=0.5
+    plt.close(fig)
+
+
+def test_apply_border_radius_invalid_orient_raises():
+    fig, ax = plt.subplots()
+    rect = Rectangle((0, 0), 1, 1)
+    ax.add_patch(rect)
+    with pytest.raises(ValueError, match="orient"):
+        apply_border_radius([rect], (1.0, 0.0), ax, orient="diagonal")
+    plt.close(fig)
+
+
+def test_barplot_horizontal_symmetric_radius():
+    """Horizontal pp.barplot with symmetric radius rounds all 4 corners."""
+    df = pd.DataFrame({"g": ["a", "b"], "v": [1.0, 2.0]})
+    fig, ax = plt.subplots()
+    # Categorical on y → horizontal bars.
+    pp.barplot(data=df, x="v", y="g", ax=ax, border_radius=1.5)
+    rounded = _rounded(ax)
+    assert len(rounded) == 2
+    for p in rounded:
+        assert all(c > 0 for c in p._corner_pts), (
+            f"symmetric radius should round all 4 corners, got "
+            f"{p._corner_pts}"
+        )
+    plt.close(fig)
+
+
+def test_barplot_horizontal_asymmetric_radius_rounds_free_end_only():
+    """border_radius=(1.5, 0) on horizontal positive bars → right corners only."""
+    df = pd.DataFrame({"g": ["a", "b"], "v": [1.0, 2.0]})
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="v", y="g", ax=ax, border_radius=(1.5, 0))
+    rounded = _rounded(ax)
+    assert len(rounded) == 2
+    free, base = _free_base_corners("h", sign=1.0)
+    for p in rounded:
+        cps = p._corner_pts
+        for fi in free:
+            assert cps[fi] > 0, (
+                f"horizontal positive: free-end corner {fi} should be "
+                f"rounded, got {cps}"
+            )
+        for bi in base:
+            assert cps[bi] == 0, (
+                f"horizontal positive: base-end corner {bi} should be "
+                f"flat, got {cps}"
+            )
+    plt.close(fig)
+
+
+def test_barplot_horizontal_negative_values_round_free_end():
+    """Negative-valued horizontal bars: free end is the LEFT (x1 < x0).
+
+    The patch's "TR/BR" labels in _corner_pts always point to the
+    free-end (top_mm) per the orient='h' mapping. Sign awareness is
+    delivered by matplotlib's signed width — width<0 makes the bbox's
+    x1 numerically smaller than x0 and the rounding visually lands at
+    the lower-x edge.
+    """
+    df = pd.DataFrame({"g": ["a", "b"], "v": [-1.0, -2.0]})
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="v", y="g", ax=ax, border_radius=(1.5, 0))
+    rounded = _rounded(ax)
+    assert len(rounded) == 2
+    free, base = _free_base_corners("h", sign=-1.0)
+    for p in rounded:
+        cps = p._corner_pts
+        # Width should be negative (bar extends from 0 to negative x).
+        assert p.get_width() < 0, (
+            f"expected negative-width bar; got width={p.get_width()}"
+        )
+        for fi in free:
+            assert cps[fi] > 0
+        for bi in base:
+            assert cps[bi] == 0
+    plt.close(fig)
+
+
+def test_barplot_vertical_negative_values_round_free_end():
+    """Negative vertical bars: free end is at the visual bottom (y1 < y0)."""
+    df = pd.DataFrame({"g": ["a", "b"], "v": [-1.0, -2.0]})
+    fig, ax = plt.subplots()
+    pp.barplot(data=df, x="g", y="v", ax=ax, border_radius=(1.5, 0))
+    rounded = _rounded(ax)
+    assert len(rounded) == 2
+    free, base = _free_base_corners("v", sign=-1.0)
+    for p in rounded:
+        cps = p._corner_pts
+        assert p.get_height() < 0, (
+            f"expected negative-height bar; got height={p.get_height()}"
+        )
+        # Free corners (TL, TR) carry top_mm = 1.5; base (BL, BR) flat.
+        for fi in free:
+            assert cps[fi] > 0
+        for bi in base:
+            assert cps[bi] == 0
+    plt.close(fig)
+
+
+def test_boxplot_horizontal_asymmetric_radius_rounds_right_end():
+    """Horizontal boxplot with (1.5, 0) rounds the right end only."""
+    df = pd.DataFrame({"g": ["a"] * 20, "v": list(range(20))})
+    fig, ax = plt.subplots()
+    pp.boxplot(data=df, x="v", y="g", ax=ax, border_radius=(1.5, 0))
+    fig.canvas.draw()
+    rounded = _rounded(ax)
+    assert len(rounded) == 1
+    free, base = _free_base_corners("h", sign=1.0)
+    cps = rounded[0]._corner_pts
+    for fi in free:
+        assert cps[fi] > 0, f"free-end corner {fi} flat: {cps}"
+    for bi in base:
+        assert cps[bi] == 0, f"base-end corner {bi} rounded: {cps}"
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
 # pp.raincloudplot — auto-propagation via the internal pp.boxplot call
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `border_radius=(top_mm, bottom_mm)` now means **(free-end, base-end)** in every orientation/sign combination. Previously, the radii were always applied to the bbox's literal y-extreme corners — correct for vertical bars (sign-aware via matplotlib's signed `height`) but visually wrong for horizontal bars/boxes, where rounding landed on the long top/bottom edges instead of the end caps.
- `_RoundedBarPatch` now stores per-corner radii `(TL, TR, BR, BL)`, and `apply_border_radius` accepts an `orient="v" | "h"` parameter that rotates the `(top, bottom)` → 4-corner mapping 90° for horizontal plots.
- Sign-awareness for negative bars (vertical or horizontal) falls out automatically — the path builder walks edges with signed `(sx, sy)` deltas so the "TR/TL" labels point to the visually-free corners regardless of value sign.
- Wired through both `apply_border_radius` call sites in `pp.barplot` (using `_split.orient`) and the one in `pp.boxplot` (using `categorical_axis`); `pp.raincloudplot` inherits via its internal `pp.boxplot` call.
- Bumped to **0.12.1** with a CHANGELOG entry and a horizontal mixed-sign gallery example in `plot_01_bar_plots.py`.

Visual sanity grid (vertical+pos / vertical+neg / horizontal+pos / horizontal+neg, symmetric vs asymmetric `(1.5, 0)`) was eyeballed before opening this PR — all 8 cells round the free end correctly.

## Test plan

- [x] `pytest tests/test_border_radius.py` — 34 passed (26 existing + 8 new). New tests cover orient='v'/'h' mappings, invalid orient, horizontal symmetric, horizontal asymmetric (positive AND negative), vertical asymmetric on negatives, boxplot horizontal asymmetric.
- [x] `pytest tests/annotate/test_border_radius_annotate.py` — 4 passed. PR #175 contract preserved.
- [x] `pytest tests/` — **1071 passed** in 4m41s.
- [x] Visual eyeball verification on a 2x4 fixture grid + a horizontal mixed-sign render of the new gallery example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
