### PR TITLE
fix(legend): inside=True must not shift sibling axes (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-05-28
+
+### Fixed
+
+- `pp.legend(anchor=ax, inside=True)` no longer shifts the layout
+  of sibling axes (#180). Three connected regressions in the
+  inside-mode rollout: (a) `MultiAxesLegendGroup.add_legend(...)`
+  did not auto-inject `inside=True` + `loc=` for inside groups, so
+  manual handle-add calls (e.g. `band.add_legend(handles=...,
+  ncol=2)` after `collect=[]`) fell through to the band path with
+  reactor registration; (b) even when the inside path did fire,
+  the resulting matplotlib `Legend` artist counted in
+  `axes.tightbbox`, so `SubplotsAutoLayout`'s per-cell measurement
+  pass grew the anchor cell and pushed siblings inward; (c)
+  `clear_anchor=True` was gated behind a successful collection in
+  `_materialize`, so `collect=[]` skipped both the render AND the
+  blank, leaving the cell's frame intact. Fix: route auto-injection
+  through the public `add_legend`; call `legend.set_in_layout(False)`
+  in `LegendBuilder`'s inside branch (matches matplotlib's
+  `loc=...` semantics); move `set_axis_off()` to fire at group
+  construction so it's independent of the collection path.
+
 ## [0.13.0] - 2026-05-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.13.0"
+version = "0.13.1"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -1254,6 +1254,12 @@ class LegendBuilder:
             if self.ax.legend_ is not None and id(self.ax.legend_) not in prior_ids:
                 prior.append(self.ax.legend_)
             legend = self.ax.legend(handles=handles, **legend_kwargs)
+            # Exclude the inside-axes legend from layout/tightbbox math.
+            # Without this, SubplotsAutoLayout's tightbbox-based per-cell
+            # measurement picks up the legend's extent and grows the
+            # cell, displacing siblings in the same row/column. Matches
+            # matplotlib's own loc=... legend semantics. (Fixes #180.)
+            legend.set_in_layout(False)
             for p in prior:
                 if p is not legend:
                     self.ax.add_artist(p)

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -803,6 +803,14 @@ class MultiAxesLegendGroup:
         # inside legends for a different kind) stay untouched.
         self._evict_claimed_per_axis_legends()
 
+        # Inside mode: blank the anchor cell at construction so the cell
+        # reads as a clean tile regardless of whether _materialize ever
+        # finds entries (collect=[] short-circuits _materialize before
+        # the previous gating site, leaving the anchor's frame intact).
+        # Idempotent: set_axis_off() is safe to call multiple times.
+        if self._inside and self._clear_anchor:
+            self.anchor.set_axis_off()
+
         # Alignment runs on each draw via the reactor hook so it uses
         # the current (possibly still-settling) figure geometry.
         # Absolute positioning → idempotent as geometry converges.
@@ -1035,14 +1043,6 @@ class MultiAxesLegendGroup:
             return
         self._materialized = True
 
-        # Inside mode: blank the anchor cell BEFORE rendering so the
-        # legend tile reads as a clean callout. Default-on; opt out via
-        # clear_anchor=False (e.g. the cell already holds intentional
-        # content like a logo or a colorbar that the legend should sit
-        # on top of).
-        if self._inside and self._clear_anchor:
-            self.anchor.set_axis_off()
-
         if self._collect is not None:
             # Stable sort by the user's collect order; ties (same name with
             # different kinds) stay in the order they were encountered.
@@ -1234,16 +1234,9 @@ class MultiAxesLegendGroup:
             mappable = entry.handles[0]
             self.add_colorbar(mappable=mappable, label=entry.name)
         else:
-            kwargs = {}
-            if self._inside:
-                kwargs["inside"] = True
-                kwargs["loc"] = _inside_loc_from_side_align(
-                    self._side, self._align,
-                )
             self.add_legend(
                 handles=list(entry.handles),
                 label=entry.name,
-                **kwargs,
             )
 
     def _default_target_ax(self) -> Axes:
@@ -1270,8 +1263,20 @@ class MultiAxesLegendGroup:
         The artist is attached to ``ax`` (defaults to a sensible corner
         cell for figure-anchored groups, or the anchor for axes-anchored);
         position is always computed against the anchor's chosen edge.
+
+        For inside-mode groups (``inside=True`` on the factory), this
+        method auto-injects ``inside=True`` + ``loc=`` derived from the
+        group's ``side`` / ``align`` so that manual handle-add calls
+        (e.g. ``band.add_legend(..., ncol=2)`` after ``collect=[]``)
+        render through the same axes-relative path as the auto-collect
+        branch. Explicit user kwargs win.
         """
         target_ax = ax if ax is not None else self._default_target_ax()
+        if self._inside:
+            kwargs.setdefault("inside", True)
+            kwargs.setdefault(
+                "loc", _inside_loc_from_side_align(self._side, self._align),
+            )
         original_ax = self._builder.ax
         try:
             self._builder.ax = target_ax

--- a/tests/test_legend_unified.py
+++ b/tests/test_legend_unified.py
@@ -373,3 +373,109 @@ def test_inside_does_not_grow_anchor_reservation(df):
     assert group._external_to_axis is False
     assert group._builder._external_to_axis is False
     plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# GH #180 — inside=True must not shift sibling axes' positions
+# ---------------------------------------------------------------------------
+
+
+def _build_inside_repro_figure(legend_kwargs):
+    """1x2 grid; left has data, right is blanked; optionally an in-cell legend."""
+    import numpy as np
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 35))
+    rng = np.random.default_rng(0)
+    inner = pd.DataFrame({"x": rng.normal(size=50), "y": rng.normal(size=50)})
+    pp.scatterplot(data=inner, x="x", y="y", ax=axes[0])
+    # Always blank the right cell so baseline & with-legend are comparable.
+    axes[1].set_axis_off()
+    if legend_kwargs is not None:
+        handles = pp.create_legend_handles(
+            labels=[f"item {i}" for i in range(8)],
+            colors=pp.color_palette("tab10", n_colors=8),
+            style="circle",
+        )
+        band = pp.legend(
+            anchor=axes[1], inside=True, collect=[], **legend_kwargs,
+        )
+        band.add_legend(handles=handles, label="My legend", ncol=2)
+    fig.canvas.draw()
+    return fig, axes
+
+
+def test_inside_manual_add_legend_does_not_shift_siblings():
+    """Adding `band.add_legend(...)` after `inside=True, collect=[]` must
+    leave the sibling axes' positions unchanged vs. the no-legend baseline.
+
+    Regression test for GH #180. Before the fix, the legend artist counted
+    in the layout reactor as an external overhang on `axes[1]`, growing
+    that cell's reservation and pushing `axes[0]` to the left.
+    """
+    fig_base, axes_base = _build_inside_repro_figure(None)
+    base_x1 = axes_base[0].get_position().x1
+    plt.close(fig_base)
+
+    for kw in [{}, {"side": "center"}, {"side": "right"}]:
+        fig, axes = _build_inside_repro_figure(kw)
+        x1 = axes[0].get_position().x1
+        assert abs(x1 - base_x1) < 1e-3, (
+            f"inside={kw!r}: sibling axes shifted {x1:.4f} vs baseline "
+            f"{base_x1:.4f} (delta {x1 - base_x1:+.4f})"
+        )
+        plt.close(fig)
+
+
+def test_inside_legend_artist_is_not_in_layout():
+    """The Legend artist created by inside-mode add_legend must have
+    set_in_layout(False) so it's excluded from tightbbox math."""
+    from matplotlib.legend import Legend
+    fig, axes = _build_inside_repro_figure({})
+    legends = [c for c in axes[1].get_children() if isinstance(c, Legend)]
+    assert len(legends) == 1
+    assert legends[0].get_in_layout() is False, (
+        "inside-mode Legend must have in_layout=False to avoid "
+        "displacing siblings"
+    )
+    plt.close(fig)
+
+
+def test_inside_collect_empty_still_blanks_anchor(df):
+    """clear_anchor=True must fire even when collect=[] short-circuits
+    auto-collection (regression for the third bug uncovered by #180)."""
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 35))
+    pp.scatterplot(df, x="x", y="y", hue="g", ax=axes[0])
+    pp.legend(anchor=axes[1], inside=True, collect=[])
+    fig.canvas.draw()
+    assert axes[1].axison is False, (
+        "clear_anchor must blank the anchor at construction, not gate "
+        "the blank on _materialize finding entries"
+    )
+    plt.close(fig)
+
+
+def test_inside_manual_add_legend_routes_through_inside_path(df):
+    """Manual band.add_legend() on an inside-mode group must go through
+    the LegendBuilder inside=True branch (auto-injected) — not the band
+    path with reactor registration."""
+    fig, axes = pp.subplots(1, 2, axes_size=(50, 35))
+    pp.scatterplot(df, x="x", y="y", hue="g", ax=axes[0])
+    handles = pp.create_legend_handles(
+        labels=["a", "b"],
+        colors=pp.color_palette("tab10", n_colors=2),
+        style="circle",
+    )
+    band = pp.legend(anchor=axes[1], inside=True, collect=[])
+    band.add_legend(handles=handles, label="L")
+    fig.canvas.draw()
+    # No reactor registrations should have been created for this builder.
+    reactor = getattr(fig, "_publiplots_layout_reactor", None)
+    if reactor is not None:
+        builder_regs = [
+            r for r in reactor._registrations
+            if id(r.artist) in {id(a) for _, a in band._builder.elements}
+        ]
+        assert len(builder_regs) == 0, (
+            "inside-mode manual add_legend must not register with the "
+            f"layout reactor; got {len(builder_regs)} regs"
+        )
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Fixes #180. Three connected regressions in the v0.13.0 inside-mode rollout, all rooted in inside-mode falling back to band-mode behavior on non-auto-collection code paths.

### What was broken

| # | Bug | Where |
|---|-----|-------|
| 1 | `MultiAxesLegendGroup.add_legend(...)` didn't auto-inject `inside=True` + `loc=` for inside-mode groups, so manual handle-add calls (e.g. `band.add_legend(handles=..., ncol=2)` after `collect=[]`) fell through to the band path with reactor registration. | `legend_group.py` |
| 2 | Even when `inside=True` reached `LegendBuilder`, the resulting `matplotlib.Legend` artist counted in `axes.tightbbox`, so `SubplotsAutoLayout`'s per-cell measurement pass grew the anchor cell and pushed siblings inward. | `legend.py` |
| 3 | `clear_anchor=True` was gated behind a successful collection in `_materialize`, so `collect=[]` (the manual handle-add path) skipped both the render AND the blank, leaving the cell's frame intact. | `legend_group.py` |

### What changed

| File | Fix |
|------|-----|
| `src/publiplots/utils/legend_group.py` | `add_legend` auto-injects `inside=True` + `loc=` for inside-mode groups (chokepoint for both `_render_entry` and external callers); `set_axis_off()` moved from `_materialize` to construction time so it fires regardless of `collect=` value. |
| `src/publiplots/utils/legend.py` | `legend.set_in_layout(False)` in the `LegendBuilder` `inside=True` branch — matches matplotlib's own `loc=...` legend semantics (purely decorative inside the axes rectangle). |

### Repro before vs after

Reporter's script — `axes[0].get_position().x1`:

| Variant | Before | After |
|---|---|---|
| baseline (no legend) | 0.4761 | 0.5065 |
| `inside=True` (default `side='left'`) | 0.3771 | **0.5065** |
| `inside=True, side='center'` | 0.3741 | **0.5065** |
| `inside=True, side='right'` | 0.3692 | **0.5065** |

After the fix, the with-legend variants are byte-identical to the no-legend baseline (the baseline shifts from 0.4761→0.5065 because the repro now blanks the right cell in both branches — fair comparison; the auto-blank is what the `inside=True` API contractually does anyway).

## Test plan

- [x] `pytest tests/test_legend_unified.py` — 39 passed (35 existing + 4 new). New tests cover: sibling-position invariance vs baseline (1e-3 tolerance across all 3 inside variants), `Legend.get_in_layout() is False`, `clear_anchor` blanks anchor with `collect=[]`, no reactor registrations created on inside-manual path.
- [x] `pytest tests/test_legend*.py tests/test_legend_group*.py` — 255 passed.
- [x] `pytest tests/` — **1100 passed** in 4m56s.
- [x] Visual eyeball on `side='right'` variant + baseline rasterized via `pdftocairo` — left panel sits at full natural size, no compression; legend renders inside the (blanked) right cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
