### PR TITLE
feat(legend): pp.legend(ax) adopts plot-created group; legend_kws placement

### DIFF
--- a/examples/plots/plot_24_legend_placement.py
+++ b/examples/plots/plot_24_legend_placement.py
@@ -425,24 +425,25 @@ pp.show()
 # %%
 # 13. Internal vs external per-axes legend
 # ----------------------------------------
-# The positional and keyword forms of ``pp.legend`` now have subtly
-# different semantics when scoping to a single axes — an intentional
-# asymmetry that preserves pre-0.10 behaviour across the rename:
+# The positional and keyword forms of ``pp.legend`` have subtly
+# different layout semantics when scoping to a single axes:
 #
 # - ``pp.legend(ax)`` (**positional**) — *internal* per-axes legend.
-#   The legend is measured by ``ax.get_tightbbox()``, so it counts as
-#   part of the axes' own decoration and the figure grows to
-#   accommodate it just like a tick label or title would. Matches
-#   pre-0.10 ``pp.legend(ax)`` behaviour.
+#   The plot call (``pp.scatterplot`` etc.) already created a per-axes
+#   legend group on that axes; ``pp.legend(ax)`` **adopts** that
+#   existing group rather than building a second competing one. This
+#   makes it the single source of truth — no "scope overlaps with an
+#   existing group" warning, no double render, and any ``side=`` you
+#   pass is honoured. The legend is measured by ``ax.get_tightbbox()``,
+#   so it counts as part of the axes' own decoration and the figure
+#   grows to accommodate it just like a tick label or title would.
 #
 # - ``pp.legend(anchor=ax)`` (**kwarg**) — *external* band pinned to
 #   that axes' right edge. The band is measured as an overhang past
 #   the axes rectangle and absorbs the per-cell ``right`` reservation
-#   (see section 6). Matches pre-0.10 ``pp.legend_group(anchor=ax)``
-#   behaviour.
+#   (see section 6).
 #
-# A future minor release may consolidate these — for now the 1x2
-# figure below shows both modes side by side, one per panel.
+# The 1x2 figure below shows both modes side by side, one per panel.
 
 fig, axes = pp.subplots(1, 2, axes_size=(45, 35))
 # Left panel: internal legend pinned to axes[0].
@@ -519,4 +520,54 @@ for (r, c), panel in zip([(0, 0), (0, 1), (1, 0)], "ABC"):
         title=f"Panel {panel}", ax=axes[r, c],
     )
 pp.legend(anchor=axes[1, 1], inside=True)
+pp.show()
+
+# %%
+# 16. Per-axes ``side=`` on a single axes (all four sides)
+# --------------------------------------------------------
+# ``pp.legend(ax, side=...)`` adopts the per-axes legend group the plot
+# call already created on that axes and applies the side you ask for —
+# no second group, no "scope overlaps with an existing group" warning,
+# and the ``side=`` is honoured (previously the auto-created right-side
+# group could win). All four sides work in axes-anchored mode:
+#
+# - ``side='right'`` / ``'left'`` → vertical band beside the axes.
+#   An internal **left** legend clears the y-tick labels.
+# - ``side='top'`` / ``'bottom'`` → horizontal band above/below.
+#   An internal **top** legend clears the axes title.
+#
+# The outward offset defaults are larger for the top and left sides in
+# this axes-anchored mode, so the band clears the reclaimed decoration
+# cleanly. The 2x2 figure below shows one side per panel.
+
+fig, axes = pp.subplots(2, 2, axes_size=(45, 35))
+for (r, c), side in zip([(0, 0), (0, 1), (1, 0), (1, 1)],
+                        ["top", "bottom", "left", "right"]):
+    pp.scatterplot(
+        data=_df[_df["panel"] == "A"], x="x", y="y",
+        hue="group", palette="pastel",
+        title=f'side="{side}"', ax=axes[r, c],
+    )
+    pp.legend(axes[r, c], side=side)
+pp.show()
+
+# %%
+# 17. One-call placement via ``legend_kws``
+# -----------------------------------------
+# Placement keys passed in ``legend_kws`` are forwarded straight to the
+# per-axes legend group, so you can position the legend in a single
+# ``pp.scatterplot`` call — no separate ``pp.legend(ax)`` needed. The
+# forwarded placement keys are ``side``, ``orientation``, ``align``,
+# ``x_offset``, ``y_offset``, and ``gap``. Here ``side="left"`` lands
+# the legend on the axes' left edge in one call.
+#
+# (The ``inside=True`` path is independent and ignores these placement
+# keys — see section 2.)
+
+pp.scatterplot(
+    data=_df[_df["panel"] == "A"], x="x", y="y",
+    hue="group", palette="pastel",
+    legend_kws={"side": "left"},
+    title='legend_kws={"side": "left"}',
+)
 pp.show()

--- a/src/publiplots/layout/auto_layout.py
+++ b/src/publiplots/layout/auto_layout.py
@@ -16,6 +16,8 @@ repositioned axes and re-anchors legends correctly.
 
 from typing import Dict, FrozenSet, Optional, Set, Tuple
 
+import matplotlib as mpl
+
 from publiplots.layout.figure_layout import FigureLayout
 
 
@@ -348,10 +350,30 @@ class SubplotsAutoLayout:
             return
 
         # Single-axes, in-frame groups (external_to_axis=False) are measured
-        # by ax.get_tightbbox() in _side_extent — no overhang write needed.
-        # This guard prevents double-counting against the per-cell reservation
-        # when commit 4 routes pp.legend(ax) through the same group machinery.
+        # by ax.get_tightbbox() in _side_extent — no overhang write needed
+        # for the legend itself. This guard prevents double-counting against
+        # the per-cell reservation when pp.legend(ax) routes through the same
+        # group machinery.
         if not getattr(group, "_external_to_axis", True):
+            # ... but a per-axes top legend must NOT sit between the axes
+            # and its title (Issue B). The required stacking is
+            # AXES -> LEGEND -> TITLE (title outermost). The legend renders
+            # ~2mm above the axes top; we lift the title's pad above the
+            # legend band so it clears it. The standard title_space
+            # auto-measurement (which sees the lifted title at its new
+            # position) then reserves room for both. _side_extent excludes
+            # the legend artist itself, so it never double-counts.
+            if group._anchor_kind == "axes":
+                if group._side == "top":
+                    self._lift_title_above_top_legend(group, dpi)
+                elif group._side == "left":
+                    # A per-axes left legend must clear the y-tick labels /
+                    # y-axis label dynamically (Issue B): step the band past
+                    # the already-measured ylabel_space for this column
+                    # rather than using a fixed 8mm offset.
+                    self._offset_left_legend_past_yticklabels(
+                        group, measured, axes_matrix
+                    )
             return
 
         side = group._side
@@ -418,6 +440,123 @@ class SubplotsAutoLayout:
         # so multiple overlapping groups don't shrink it).
         existing[idx] = max(existing[idx], overhang_mm + pure_decoration_mm)
         measured[cell_field] = tuple(existing)
+
+    def _lift_title_above_top_legend(self, group, dpi) -> None:
+        """Push the anchor axes' title pad above a per-axes top legend band.
+
+        Issue B: a per-axes ``side='top'`` legend renders ~``x_offset`` mm
+        above the axes top. matplotlib ignores it when auto-positioning the
+        title (the legend is ``set_in_layout(False)``), so by default the
+        title lands ~6pt above the axes — sandwiched *under* the legend.
+
+        We compute the title pad needed to clear the whole legend band
+        (outward gap + legend height + a small breathing gap) and apply it
+        via ``ax.title`` offset. The standard ``title_space`` auto-measure
+        then sees the title at its lifted position and reserves room for
+        the legend + title together — no manual reservation arithmetic and
+        no double-counting (``_side_extent`` excludes the legend artist).
+        Idempotent: re-running over convergence iterations recomputes from
+        the same band geometry, so the pad converges instead of drifting.
+        """
+        ax = group.anchor
+        title = getattr(ax, "title", None)
+        if title is None or not title.get_text():
+            return  # no title to lift
+
+        ax_bb = ax.get_window_extent()
+        # Tallest legend band element above the axes top, in pixels.
+        band_top_px = ax_bb.y1
+        for _, obj in group._builder.elements:
+            extent = self._artist_window_extent(obj)
+            if extent is None:
+                continue
+            band_top_px = max(band_top_px, extent.y1)
+        band_above_ax_px = band_top_px - ax_bb.y1
+        if band_above_ax_px <= 0:
+            return  # band hasn't rendered above the axes yet
+
+        # pad (points) = band height above axes + a small breathing gap.
+        # matplotlib's title pad positions the title baseline; the text's
+        # own descent adds visible space below it, so a tiny nominal gap
+        # keeps the legend->title gap near ~2mm rather than ballooning.
+        breathing_mm = 1.0
+        breathing_px = breathing_mm * dpi / 25.4
+        pad_px = band_above_ax_px + breathing_px
+        pad_pt = pad_px / dpi * 72.0
+        # Preserve the user's intended ("base") title pad: stash it once,
+        # BEFORE we ever lift, so re-running over convergence iterations
+        # doesn't read our own lifted pad as the baseline (idempotent — the
+        # applied pad converges instead of drifting). Default to
+        # rcParams['axes.titlepad'] when the user never set one.
+        base_pad = getattr(ax, "_pp_base_titlepad", None)
+        if base_pad is None:
+            cur = ax.titleOffsetTrans._t[1] * 72.0  # current pad in points
+            base_pad = cur if cur > 0 else float(
+                mpl.rcParams.get("axes.titlepad", 6.0)
+            )
+            ax._pp_base_titlepad = base_pad
+        # Only lift; honour a user-set pad larger than the band lift.
+        # Apply via the title offset transform so the title's own
+        # font/color/weight styling is NOT reset (ax.set_title would
+        # re-merge the default fontdict and clobber user styling).
+        ax._set_title_offset_trans(max(base_pad, pad_pt))
+
+    def _offset_left_legend_past_yticklabels(
+        self, group, measured, axes_matrix
+    ) -> None:
+        """Step a per-axes left legend just past the y-tick labels / y-axis
+        label, dynamically.
+
+        Issue B: with the old fixed 8mm offset removed, an internal left
+        legend would render only ``x_offset`` mm left of the axes spine,
+        colliding with the y-tick labels (which live left of the axes).
+
+        Unlike a figure-anchored band, an ``external_to_axis=False`` group
+        is NOT excluded from ``ax.get_tightbbox()``, so the standard
+        ``ylabel_space`` auto-measurement ALREADY widens the column to fit
+        the legend — we must not re-add the legend width (that double-counts
+        and drifts). All we need is to position the legend just past the
+        PURE y-decoration (ticklabels + ylabel) so it doesn't overlap them.
+        We measure that pure extent directly here (excluding our own legend)
+        and bake it as the band's outward decoration offset. Idempotent.
+        """
+        cell_field = "ylabel_space"
+        if cell_field in self._locked:
+            return
+        r, c = self._find_ax_indices(group.anchor, axes_matrix)
+        if c in self._locked_positions.get(cell_field, frozenset()):
+            return
+
+        ax = group.anchor
+        dpi = self._fig.dpi
+        ax_bb = ax.get_window_extent()
+
+        # Pure y-decoration extent left of the axes, EXCLUDING our legend
+        # (and any other externally-managed overlay). Mirrors _side_extent
+        # but computed locally so it's independent of whether the legend is
+        # in-layout.
+        legend_ids = {id(obj) for _, obj in group._builder.elements}
+        # Exclude our own legend from BOTH the tightbbox and the pinned
+        # union. The group is external_to_axis=False, so its legend is NOT
+        # in _externally_managed_artist_ids() and would otherwise be unioned
+        # back in by _union_pinned_artists — re-inflating the "pure" extent
+        # by the legend's own width and causing the offset to drift.
+        managed = self._externally_managed_artist_ids() | legend_ids
+        toggled = []
+        for child in ax.get_children():
+            if id(child) in legend_ids and child.get_in_layout():
+                child.set_in_layout(False)
+                toggled.append(child)
+        try:
+            tight = ax.get_tightbbox()
+        finally:
+            for child in toggled:
+                child.set_in_layout(True)
+        if tight is None:
+            return
+        tight = self._union_pinned_artists(ax, tight, managed)
+        pure_ylabel_mm = max(0.0, (ax_bb.x0 - tight.x0) / dpi * 25.4)
+        group._set_decoration_offset(pure_ylabel_mm)
 
     def _bake_decoration_offset(self, group, measured, axes_matrix) -> None:
         """Write the decoration offset onto the group's registrations

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -1009,7 +1009,20 @@ class LegendBuilder:
 
         return x_fig, y_fig
 
-    def _measure_object_dimensions(self, obj: Union[Legend, Colorbar, Any]) -> Tuple[float, float]:
+    def _fig_canvas_draw_for_measure(self) -> None:
+        """Force a full figure redraw so artist window extents become
+        current. Isolated into its own method so callers that are already
+        mid-draw (e.g. the alignment pass, where matplotlib's renderer
+        cache is already populated) can skip it — see
+        ``_measure_object_dimensions(force_draw=...)``.
+        """
+        self.fig.canvas.draw()
+
+    def _measure_object_dimensions(
+        self,
+        obj: Union[Legend, Colorbar, Any],
+        force_draw: bool = True,
+    ) -> Tuple[float, float]:
         """
         Measure actual dimensions of matplotlib object.
 
@@ -1017,13 +1030,22 @@ class LegendBuilder:
         ----------
         obj : Legend or Colorbar or Text
             Matplotlib object to measure
+        force_draw : bool, default True
+            When True, force a full ``fig.canvas.draw()`` first so the
+            artist's cached window extent is current. Callers that are
+            already inside a draw (e.g. the legend_group alignment pass,
+            which runs as a post-refresh reactor callback) pass
+            ``force_draw=False``: matplotlib's renderer cache is already
+            populated at that point, so ``get_window_extent()`` returns
+            sensible values without an O(panels) nested figure redraw.
 
         Returns
         -------
         width_mm, height_mm : float
             Object dimensions in millimeters
         """
-        self.fig.canvas.draw()
+        if force_draw:
+            self._fig_canvas_draw_for_measure()
 
         # Get bounding box. Call get_window_extent() without a renderer:
         # the draw() above populates matplotlib's cached renderer on the

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -640,16 +640,13 @@ class MultiAxesLegendGroup:
         )
         self._align = default_align if align == "auto" else align
         if x_offset is None:
+            # Use the normal 2mm outward gap for every side. The legend's
+            # clearance past the axes decorations (title for 'top',
+            # y-tick labels for 'left') is now handled DYNAMICALLY by the
+            # layout's decoration-offset measurement, not by a fixed gap
+            # baked in here (Issue B: the old fixed 7/8mm left empty
+            # padding with no title and sandwiched the title when present).
             x_offset = default_x_offset
-            # Internal-mode (axes-anchored) top/left legends reserve NO
-            # band (auto_layout short-circuits external_to_axis=False
-            # groups), so clearance from the axes title (top) and y-tick
-            # labels (left) must come from a larger outward offset.
-            # ``anchor is not None`` ⇒ axes-anchored; _GridAnchor /
-            # figure-anchored bands (anchor is None) keep the 2mm default
-            # so figure-band gap tests stay green.
-            if anchor is not None and side in ("top", "left"):
-                x_offset = 8 if side == "left" else 7
         # In inside mode, side='center' silently coerces align to 'center'
         # because matplotlib's loc='center' has no notion of start/end.
         if self._inside and self._side == "center":
@@ -1205,7 +1202,14 @@ class MultiAxesLegendGroup:
             # Measure each legend's along-edge extent.
             extents = []
             for reg in row_regs:
-                w, h = self._builder._measure_object_dimensions(reg.artist)
+                # force_draw=False: this runs as a post-refresh reactor
+                # callback, so matplotlib's renderer cache is already
+                # current. Forcing a fresh fig.canvas.draw() here would
+                # trigger O(panels) nested full redraws on every settle
+                # iteration (Issue A: side='top'/'bottom' 5x slowdown).
+                w, h = self._builder._measure_object_dimensions(
+                    reg.artist, force_draw=False
+                )
                 extents.append(w if orient == "horizontal" else h)
             total = sum(extents) + gap_mm * (len(row_regs) - 1)
             if total >= edge_length_mm:
@@ -1321,9 +1325,10 @@ class MultiAxesLegendGroup:
 
         Any kwarg left at its sentinel default ("auto" for
         orientation/align, ``None`` for x_offset) is filled from the
-        per-side default tables; ``x_offset`` applies the Change-3
-        internal-mode gate (axes-anchored top/left get a larger outward
-        gap to clear the title / y-tick labels). Returns concrete values.
+        per-side default tables. ``x_offset`` defaults to the normal 2mm
+        outward gap for every side; clearance past axes decorations
+        (title / y-tick labels) is handled dynamically by the layout's
+        decoration-offset measurement. Returns concrete values.
         """
         if side == "center":
             default_orientation = "vertical"
@@ -1338,12 +1343,10 @@ class MultiAxesLegendGroup:
         )
         resolved_align = default_align if align == "auto" else align
         if x_offset is None:
+            # Normal 2mm outward gap for every side; clearance past axes
+            # decorations is handled dynamically by the layout's
+            # decoration-offset measurement (Issue B).
             x_offset = default_x_offset
-            # Mirror __init__'s internal-mode gate: an axes-anchored
-            # (per-axes) top/left legend needs a larger outward offset
-            # because it reserves no band.
-            if self._anchor_kind == "axes" and side in ("top", "left"):
-                x_offset = 8 if side == "left" else 7
         return resolved_orientation, resolved_align, x_offset
 
     def _reconfigure_for_adopt(

--- a/src/publiplots/utils/legend_group.py
+++ b/src/publiplots/utils/legend_group.py
@@ -641,6 +641,15 @@ class MultiAxesLegendGroup:
         self._align = default_align if align == "auto" else align
         if x_offset is None:
             x_offset = default_x_offset
+            # Internal-mode (axes-anchored) top/left legends reserve NO
+            # band (auto_layout short-circuits external_to_axis=False
+            # groups), so clearance from the axes title (top) and y-tick
+            # labels (left) must come from a larger outward offset.
+            # ``anchor is not None`` ⇒ axes-anchored; _GridAnchor /
+            # figure-anchored bands (anchor is None) keep the 2mm default
+            # so figure-band gap tests stay green.
+            if anchor is not None and side in ("top", "left"):
+                x_offset = 8 if side == "left" else 7
         # In inside mode, side='center' silently coerces align to 'center'
         # because matplotlib's loc='center' has no notion of start/end.
         if self._inside and self._side == "center":
@@ -877,6 +886,11 @@ class MultiAxesLegendGroup:
 
     def _collect_overlap(self, other: "MultiAxesLegendGroup") -> bool:
         """True if ``self`` and ``other`` could claim the same entry name."""
+        # A collect=[] group is a render-nothing stash (the plot-created
+        # per-axes cache); it claims no entry names, so it can never
+        # compete with another group. Short-circuit before the None check.
+        if self._collect == [] or other._collect == []:
+            return False
         if self._collect is None or other._collect is None:
             return True
         return bool(set(self._collect) & set(other._collect))
@@ -1302,6 +1316,152 @@ class MultiAxesLegendGroup:
             self._builder.ax = original_ax
         return cbar
 
+    def _resolve_side_defaults(self, side, orientation, align, x_offset):
+        """Resolve (orientation, align, x_offset) per-side, mirroring __init__.
+
+        Any kwarg left at its sentinel default ("auto" for
+        orientation/align, ``None`` for x_offset) is filled from the
+        per-side default tables; ``x_offset`` applies the Change-3
+        internal-mode gate (axes-anchored top/left get a larger outward
+        gap to clear the title / y-tick labels). Returns concrete values.
+        """
+        if side == "center":
+            default_orientation = "vertical"
+            default_align = "center"
+            default_x_offset = 0.0
+        else:
+            default_orientation = self._DEFAULT_ORIENTATION[side]
+            default_align = self._DEFAULT_ALIGN[side]
+            default_x_offset = self._DEFAULT_X_OFFSET_MM[side]
+        resolved_orientation = (
+            default_orientation if orientation == "auto" else orientation
+        )
+        resolved_align = default_align if align == "auto" else align
+        if x_offset is None:
+            x_offset = default_x_offset
+            # Mirror __init__'s internal-mode gate: an axes-anchored
+            # (per-axes) top/left legend needs a larger outward offset
+            # because it reserves no band.
+            if self._anchor_kind == "axes" and side in ("top", "left"):
+                x_offset = 8 if side == "left" else 7
+        return resolved_orientation, resolved_align, x_offset
+
+    def _reconfigure_for_adopt(
+        self,
+        *,
+        collect,
+        side,
+        orientation,
+        align,
+        x_offset,
+        y_offset,
+        gap,
+        column_spacing,
+        vpad,
+        max_width,
+    ) -> None:
+        """Reconfigure this plot-created (``collect=[]``) per-axes group
+        in place for a ``pp.legend(ax)`` adoption.
+
+        Tears down the already-rendered artists (the cached group's
+        builder rendered the hue entry on the default RIGHT side), rebuilds
+        the LegendBuilder under the requested placement, flips ``collect``
+        so the stashed entries are re-collected, and re-materializes so a
+        single set of artists renders under the new side. Never appends a
+        second group to ``fig._publiplots_legend_groups`` — the cached
+        group is already registered.
+        """
+        # --- 1. Tear down the already-rendered artists --------------------
+        reactor = self._builder._reactor
+        old_artist_ids = set()
+        for kind, artist in self._builder.elements:
+            old_artist_ids.add(id(artist))
+            if kind == "colorbar":
+                # Colorbar: remove its dedicated axes from the figure.
+                cbar_ax = getattr(artist, "ax", None)
+                try:
+                    artist.remove()
+                except Exception:
+                    pass
+                if cbar_ax is not None:
+                    try:
+                        cbar_ax.remove()
+                    except Exception:
+                        pass
+            else:
+                # Legend artist or colorbar title Text.
+                parent_ax = getattr(artist, "axes", None)
+                try:
+                    artist.remove()
+                except Exception:
+                    pass
+                if parent_ax is not None and getattr(parent_ax, "legend_", None) is artist:
+                    parent_ax.legend_ = None
+        # Purge those artists' reactor registrations (match by id).
+        if old_artist_ids:
+            reactor._registrations = [
+                r for r in reactor._registrations
+                if id(r.artist) not in old_artist_ids
+            ]
+        self._builder.elements = []
+
+        # --- 2. Re-resolve placement + rebuild the builder ----------------
+        resolved_orientation, resolved_align, resolved_x_offset = (
+            self._resolve_side_defaults(side, orientation, align, x_offset)
+        )
+        self._side = side
+        self._orientation = resolved_orientation
+        self._align = resolved_align
+
+        # Mirror __init__'s builder_ax / builder_anchor_ax selection for the
+        # per-axes (single-axes, axes-anchored) case.
+        builder_ax = self.anchor if self._anchor_kind == "axes" \
+            else self._pick_builder_ax()
+        if (
+            self._anchor_kind == "axes"
+            and self._scope_axes is not None
+            and len(self._scope_axes) > 1
+        ):
+            builder_anchor_ax = self._scope_anchor
+        else:
+            builder_anchor_ax = self.anchor
+        builder_side = "right" if (self._inside and side == "center") else side
+        self._builder = LegendBuilder(
+            ax=builder_ax,
+            anchor_ax=builder_anchor_ax,
+            x_offset=resolved_x_offset,
+            y_offset=y_offset,
+            gap=gap,
+            column_spacing=column_spacing,
+            vpad=vpad,
+            max_width=max_width,
+            external_to_axis=False,  # per-axes in-frame semantics
+            side=builder_side,
+            orientation=self._orientation,
+        )
+        self._external_to_axis = False
+
+        # --- 3. Flip collect so stashed entries are re-collected ----------
+        if collect is not None:
+            if isinstance(collect, str) or not hasattr(collect, "__iter__"):
+                raise TypeError(
+                    "collect must be None or a list/tuple of names; "
+                    "got a bare string. Wrap in a list: collect=['name']"
+                )
+            collect = list(collect)
+        self._collect = collect
+
+        # --- 4. Reset materialization + re-render under the new side ------
+        self._materialized = False
+        self._materialize()
+
+        # --- 5. Manage the align hook (connect at most once) --------------
+        # The builder was rebuilt, so its reactor reference is current; the
+        # _align_connected flag tracks per-group connection state. Only
+        # connect when the final align is non-default ("start").
+        if self._align != "start" and not self._align_connected:
+            self._connect_align_hook()
+
 
 _SIDE_SENTINEL = object()
 
@@ -1525,6 +1685,45 @@ def legend(
         resolved_anchor = axes
         resolved_axes = [axes]
         axes_triggered_single_scope = True
+        # Adopt the plot-created cached per-axes group instead of building
+        # a second competing one. Every plot call funnels its legend
+        # output through ``ax._legend_group`` (a collect=[] group whose
+        # builder has already rendered the hue entry on the RIGHT). Reusing
+        # it makes pp.legend(ax, side=...) the single source of truth,
+        # eliminates the spurious "scope overlaps" warning, and removes the
+        # double render + redundant per-draw align hook. Inside mode never
+        # adopts (it short-circuits to a plain LegendBuilder and never
+        # creates a cached group).
+        cached = getattr(axes, "_legend_group", None)
+        # ``ax._legend_group`` is assigned ONLY by
+        # ``_get_or_create_per_axes_group``, so anything stored there is a
+        # per-axes cache safe to adopt. Gate on identity/kind, NOT on the
+        # mutable ``_collect`` value: the first adopt flips ``_collect`` from
+        # ``[]`` to the requested value (default ``None``), so keying on
+        # ``_collect == []`` would make a SECOND ``pp.legend(ax)`` call (e.g.
+        # to change ``side=``) fall through and build a duplicate competing
+        # group — re-introducing the overlap warning and per-draw overhead.
+        if (
+            not inside
+            and isinstance(cached, MultiAxesLegendGroup)
+            and cached is axes._legend_group
+            and cached._anchor_kind == "axes"
+            and cached._scope_axes is not None
+            and len(cached._scope_axes) == 1
+        ):
+            cached._reconfigure_for_adopt(
+                collect=collect,
+                side=side,
+                orientation=orientation,
+                align=align,
+                x_offset=x_offset,
+                y_offset=y_offset,
+                gap=gap,
+                column_spacing=column_spacing,
+                vpad=vpad,
+                max_width=max_width,
+            )
+            return cached
     elif isinstance(axes, Axes) and anchor is not None:
         # axes=ax, anchor=other_ax → explicit anchor override, single-axes scope.
         resolved_axes = [axes]
@@ -1577,7 +1776,7 @@ def legend(
     return group
 
 
-def _get_or_create_per_axes_group(ax: Axes) -> MultiAxesLegendGroup:
+def _get_or_create_per_axes_group(ax: Axes, **placement_kwargs) -> MultiAxesLegendGroup:
     """Return (or create) the single-axes legend group cached on ``ax``.
 
     Used by ``render_entries`` to funnel every plot function's legend
@@ -1596,12 +1795,22 @@ def _get_or_create_per_axes_group(ax: Axes) -> MultiAxesLegendGroup:
 
     Also preserves the ``ax._legend_builder`` alias so the existing
     ``_evict_claimed_per_axis_legends`` read path keeps working.
+
+    ``**placement_kwargs`` (``side`` / ``orientation`` / ``align`` /
+    ``x_offset`` / ``y_offset`` / ``gap``) are forwarded from
+    ``legend_kws`` so a plot call can position its own legend in one shot
+    (e.g. ``pp.scatterplot(..., legend_kws={"side": "left"})``). They take
+    effect only when the group is FIRST created — once cached, the
+    existing configuration is reused (a single plot call's repeated
+    render_entries passes share one group).
     """
     existing = getattr(ax, "_legend_group", None)
     if existing is not None:
         return existing
     # collect=[] — see docstring; render_entries owns the add_legend calls.
-    group = legend(ax, collect=[])
+    # The group is built with the requested placement BEFORE render_entries
+    # issues its add_legend/add_colorbar calls on group._builder.
+    group = legend(ax, collect=[], **placement_kwargs)
     ax._legend_group = group
     ax._legend_builder = group._builder  # back-compat alias
     return group

--- a/src/publiplots/utils/plot_legend.py
+++ b/src/publiplots/utils/plot_legend.py
@@ -394,6 +394,15 @@ _BUILDER_FORWARD_KEYS = frozenset({
     "labelspacing", "markerscale", "markerfirst",
 })
 
+# Placement-family keys that configure the per-axes MultiAxesLegendGroup
+# (not matplotlib's ax.legend()). Forwarded from ``legend_kws`` so a single
+# plot call can position its legend, e.g.
+# ``pp.scatterplot(..., legend_kws={"side": "left"})``. Ignored in
+# inside=True mode (placement is matplotlib loc-driven there).
+_GROUP_PLACEMENT_KEYS = frozenset({
+    "side", "orientation", "align", "x_offset", "y_offset", "gap",
+})
+
 
 def _builder_kwargs(legend_kws: Optional[Dict]) -> Dict:
     """Extract the subset of ``legend_kws`` meant for ``LegendBuilder``.
@@ -451,7 +460,15 @@ def render_entries(
         builder = LegendBuilder(ax, external_to_axis=False)
     else:
         from publiplots.utils.legend_group import _get_or_create_per_axes_group
-        group = _get_or_create_per_axes_group(ax)
+        # Split out placement-family keys so they configure the per-axes
+        # group (side / orientation / align / offsets / gap) rather than
+        # being forwarded to ax.legend(). The cached group must be built
+        # with the requested placement BEFORE the add_legend calls below.
+        placement_kwargs = {
+            k: v for k, v in (legend_kws or {}).items()
+            if k in _GROUP_PLACEMENT_KEYS
+        }
+        group = _get_or_create_per_axes_group(ax, **placement_kwargs)
         builder = group._builder
     for entry in to_render:
         if entry.kind == "hue" and is_continuous_hue(entry.handles):

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -578,3 +578,280 @@ def test_legend_group_saves_to_pdf_without_renderer_error(tmp_path):
     assert (tmp_path / "ok.pdf").exists()
     assert (tmp_path / "ok.svg").exists()
     assert (tmp_path / "ok.png").exists()
+
+
+# --- per-axes adopt: pp.legend(ax) reuses the plot-created group ------------
+
+
+def _scatter_df(n=40, seed=0):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({
+        "x": rng.normal(size=n),
+        "y": rng.normal(size=n),
+        "g": np.tile(list("AB"), n // 2),
+    })
+
+
+def test_per_axis_legend_adopts_cached_group():
+    """pp.legend(ax) after a plot adopts the cached per-axes group rather
+    than building a second competing one. Exactly one group on the figure,
+    and it IS the cached group on the axes."""
+    from matplotlib.legend import Legend
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(40, 30))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    cached = ax._legend_group
+    g = pp.legend(ax, side="left")
+    fig.canvas.draw()
+    assert len(fig._publiplots_legend_groups) == 1
+    assert g is cached
+    assert g is ax._legend_group
+    # Exactly one Legend artist rendered (no double render).
+    n_legends = sum(1 for c in ax.get_children() if isinstance(c, Legend))
+    assert n_legends == 1, f"expected one Legend, got {n_legends}"
+
+
+def test_per_axis_legend_repeated_call_re_adopts():
+    """Calling pp.legend(ax) twice (e.g. to change side=) must re-adopt the
+    same cached group, not build a second competing one. Regression: the
+    adopt guard used to key on the mutable ``_collect == []`` which the
+    first adopt flips to None, so repeats fell through to construction —
+    duplicating groups, re-emitting the overlap warning, and stacking
+    align callbacks."""
+    import warnings as _w
+    from matplotlib.legend import Legend
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(40, 30))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    cached = ax._legend_group
+    g1 = pp.legend(ax, side="top")
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        g2 = pp.legend(ax, side="left")
+        fig.canvas.draw()
+    overlap = [w for w in caught if "scope overlaps" in str(w.message)]
+    assert g1 is cached and g2 is cached
+    assert len(fig._publiplots_legend_groups) == 1
+    assert overlap == [], f"repeat adopt must not warn; got {len(overlap)}"
+    assert g2._side == "left"
+    n_legends = sum(1 for c in ax.get_children() if isinstance(c, Legend))
+    assert n_legends == 1, f"expected one Legend after re-adopt, got {n_legends}"
+
+
+def test_per_axis_legend_no_prior_plot_constructs_fresh():
+    """pp.legend(ax) on an axes that never plotted through publiplots
+    (no cached group) must still construct a fresh group."""
+    fig, ax = pp.subplots(1, 1, axes_size=(40, 30))
+    ax.plot([0, 1, 2], [0, 1, 0])
+    assert getattr(ax, "_legend_group", None) is None
+    g = pp.legend(ax, side="left")
+    g.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    assert g is not None
+    assert g._side == "left"
+    assert len(fig._publiplots_legend_groups) == 1
+
+
+@pytest.mark.parametrize("side", ["right", "left", "top", "bottom"])
+def test_per_axis_internal_side_places_on_correct_edge(side):
+    """An adopted per-axes legend lands on the correct edge of the axes."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    g = pp.legend(ax, side=side)
+    fig.canvas.draw()
+    legend = g._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    axb = ax.get_window_extent()
+    if side == "right":
+        assert lb.x0 >= axb.x1 - 2, (lb.x0, axb.x1)
+    elif side == "left":
+        assert lb.x1 <= axb.x0 + 2, (lb.x1, axb.x0)
+    elif side == "top":
+        assert lb.y0 >= axb.y1 - 2, (lb.y0, axb.y1)
+    else:  # bottom
+        assert lb.y1 <= axb.y0 + 2, (lb.y1, axb.y0)
+
+
+def test_per_axis_internal_top_clears_title():
+    """An adopted top legend sits above (clears) the axes title."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax,
+                   title="my title")
+    g = pp.legend(ax, side="top")
+    fig.canvas.draw()
+    legend = g._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    title_bb = ax.title.get_window_extent()
+    # Legend's bottom must be at/above the title's top (no overlap).
+    assert lb.y0 >= title_bb.y1 - 1.0, (
+        f"top legend y0={lb.y0:.1f} should clear title y1={title_bb.y1:.1f}"
+    )
+
+
+def test_per_axis_internal_left_clears_yticklabels():
+    """An adopted left legend sits left of (clears) the y-tick labels."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    g = pp.legend(ax, side="left")
+    fig.canvas.draw()
+    legend = g._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    ytick_x0s = [
+        t.get_window_extent().x0
+        for t in ax.get_yticklabels() if t.get_text()
+    ]
+    if ytick_x0s:
+        min_x0 = min(ytick_x0s)
+        assert lb.x1 <= min_x0 + 1.0, (
+            f"left legend x1={lb.x1:.1f} should clear y-ticklabel x0={min_x0:.1f}"
+        )
+
+
+def test_per_axis_right_still_top_aligned():
+    """Regression: an adopted internal right legend keeps its top within
+    ~1.5mm of the axes top (mirrors test_per_axis_outside_right_*)."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax,
+                   title="t")
+    g = pp.legend(ax, side="right")
+    fig.canvas.draw()
+    ax_top_px = ax.get_window_extent().y1
+    legend_top_px = g._builder.elements[0][1].get_window_extent().y1
+    delta_mm = (ax_top_px - legend_top_px) / fig.dpi * 25.4
+    assert abs(delta_mm) < 1.5, (
+        f"right legend top should be within ~1.5mm of axes top; "
+        f"got delta={delta_mm:.2f} mm"
+    )
+
+
+def test_no_overlap_warning_on_scatter_then_per_axis_legend():
+    """scatter then pp.legend(ax) emits zero 'scope overlaps' warnings."""
+    import warnings as _w
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(40, 30))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        pp.legend(ax, side="left")
+        fig.canvas.draw()
+    overlap = [w for w in caught if "scope overlaps" in str(w.message)]
+    assert len(overlap) == 0, [str(w.message) for w in overlap]
+
+
+def test_overlap_warning_still_fires_for_two_figure_groups():
+    """Two figure-level collect=None groups on a grid genuinely compete →
+    one 'scope overlaps' warning. And two overlapping collect=['g'] groups
+    also warn."""
+    import warnings as _w
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    pp.legend(side="right")
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        pp.legend(side="left")
+    overlap = [w for w in caught if "scope overlaps" in str(w.message)]
+    assert len(overlap) == 1, [str(w.message) for w in caught]
+
+    # Two groups with the same explicit collect on the same scope.
+    fig2, axes2 = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes2).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    pp.legend(figure=fig2, side="right", collect=["g"])
+    with _w.catch_warnings(record=True) as caught2:
+        _w.simplefilter("always")
+        pp.legend(figure=fig2, side="left", collect=["g"])
+    overlap2 = [w for w in caught2 if "scope overlaps" in str(w.message)]
+    assert len(overlap2) == 1, [str(w.message) for w in caught2]
+
+
+def test_legend_kws_side_places_per_axis_legend():
+    """pp.scatterplot(..., legend_kws={'side': 'left'}) places the legend
+    on the left in a single group with no overlap warning."""
+    import warnings as _w
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel",
+                       ax=ax, legend_kws={"side": "left"})
+        fig.canvas.draw()
+    overlap = [w for w in caught if "scope overlaps" in str(w.message)]
+    assert len(overlap) == 0, [str(w.message) for w in overlap]
+    assert len(fig._publiplots_legend_groups) == 1
+    g = ax._legend_group
+    assert g._side == "left"
+    legend = g._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    axb = ax.get_window_extent()
+    assert lb.x1 <= axb.x0 + 2, (lb.x1, axb.x0)
+
+
+def test_per_axis_external_band_side_reserves():
+    """pp.legend(anchor=axes[0,0], side=...) (external-band form) grows the
+    correct per-cell reservation while figure legend bands stay ~0."""
+    fig, axes = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+        ax.set_title("t")
+        ax.set_ylabel("yl")
+    group = pp.legend(anchor=axes[0, 0], side="top")
+    group.add_legend(handles=_sample_handles(), label="group")
+    fig.canvas.draw()
+    layout = fig._publiplots_layout
+    assert layout.title_space[0] > 10.0, (
+        f"title_space[0] should absorb the top band; "
+        f"got {layout.title_space[0]:.1f}"
+    )
+    assert layout.legend_band_top < 0.5, (
+        f"legend_band_top should stay zero; got {layout.legend_band_top:.1f}"
+    )
+
+    fig2, axes2 = pp.subplots(2, 2, axes_size=(35, 25))
+    for ax in np.atleast_2d(axes2).flat:
+        ax.plot([0, 1, 2], [0, 1, 0])
+        ax.set_ylabel("yl")
+    group2 = pp.legend(anchor=axes2[0, 0], side="left")
+    group2.add_legend(handles=_sample_handles(), label="group")
+    fig2.canvas.draw()
+    layout2 = fig2._publiplots_layout
+    assert layout2.ylabel_space[0] > 10.0, (
+        f"ylabel_space[0] should absorb the left band; "
+        f"got {layout2.ylabel_space[0]:.1f}"
+    )
+    assert layout2.legend_band_left < 0.5, (
+        f"legend_band_left should stay zero; got {layout2.legend_band_left:.1f}"
+    )
+
+
+def test_multi_panel_no_duplicate_render_or_hooks():
+    """3x3 grid, plot each panel, pp.legend(ax) per panel. Exactly one
+    Legend artist per panel (no double render) and the reactor registers
+    at most one align callback per axes (no duplicate hook)."""
+    from matplotlib.legend import Legend
+    df = _scatter_df(n=60)
+    fig, axes = pp.subplots(3, 3, axes_size=(30, 22))
+    flat = list(np.atleast_2d(axes).flat)
+    for ax in flat:
+        pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    groups = [pp.legend(ax, side="top") for ax in flat]
+    fig.canvas.draw()
+    # One group per axes; no duplicate groups on the figure.
+    assert len(fig._publiplots_legend_groups) == 9
+    total_legends = sum(
+        1 for ax in flat
+        for c in ax.get_children() if isinstance(c, Legend)
+    )
+    assert total_legends == 9, f"expected 9 Legend artists, got {total_legends}"
+    # The reactor wraps _refresh_all once; each group contributes exactly
+    # one align callback (side='top' default align='center' connects).
+    reactor = groups[0]._builder._reactor
+    callbacks = getattr(reactor, "_align_callbacks", [])
+    assert len(callbacks) == len(set(id(c) for c in callbacks)), (
+        "duplicate align callbacks registered"
+    )
+    assert len(callbacks) <= 9, f"expected <=9 align callbacks, got {len(callbacks)}"

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -673,25 +673,80 @@ def test_per_axis_internal_side_places_on_correct_edge(side):
         assert lb.y1 <= axb.y0 + 2, (lb.y1, axb.y0)
 
 
-def test_per_axis_internal_top_clears_title():
-    """An adopted top legend sits above (clears) the axes title."""
+def test_per_axis_internal_top_title_is_outermost():
+    """Issue B: for side='top', stacking from the axes outward must be
+    AXES -> LEGEND -> TITLE (title OUTERMOST, above the legend), with no
+    overlaps. The legend sits between the axes top and the title.
+    """
     df = _scatter_df()
     fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
     pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax,
                    title="my title")
     g = pp.legend(ax, side="top")
-    fig.canvas.draw()
+    # Settle: the title lift converges over a couple of draws, so assert on
+    # the STEADY state, not the transient first-draw geometry.
+    for _ in range(3):
+        fig.canvas.draw()
     legend = g._builder.elements[0][1]
     lb = legend.get_window_extent()
+    axb = ax.get_window_extent()
     title_bb = ax.title.get_window_extent()
-    # Legend's bottom must be at/above the title's top (no overlap).
-    assert lb.y0 >= title_bb.y1 - 1.0, (
-        f"top legend y0={lb.y0:.1f} should clear title y1={title_bb.y1:.1f}"
+    # Legend sits above the axes top.
+    assert lb.y0 >= axb.y1 - 1.0, (
+        f"legend y0={lb.y0:.1f} should be above axes top y1={axb.y1:.1f}"
+    )
+    # Title sits ABOVE the legend (title outermost), no overlap at steady
+    # state (no negative tolerance — the gap must be genuinely positive).
+    assert title_bb.y0 >= lb.y1, (
+        f"title y0={title_bb.y0:.1f} should be above legend top "
+        f"y1={lb.y1:.1f} (title must be outermost)"
     )
 
 
+def test_per_axis_internal_top_no_gap_without_title():
+    """Issue B/C: without a title, a top legend sits ~2mm above the axes
+    top — no fixed 7mm empty padding."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    g = pp.legend(ax, side="top")
+    fig.canvas.draw()
+    legend = g._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    axb = ax.get_window_extent()
+    gap_mm = (lb.y0 - axb.y1) / fig.dpi * 25.4
+    assert -0.5 <= gap_mm <= 4.0, (
+        f"top legend gap above axes should be ~2mm, got {gap_mm:.2f}mm"
+    )
+
+
+def test_per_axis_top_title_lift_preserves_title_styling():
+    """Issue B regression: lifting the title above a side='top' legend must
+    NOT reset the title's font/color/weight. The lift uses the title offset
+    transform, not ax.set_title (which re-merges the default fontdict). Also
+    a user-set title pad LARGER than the band lift must be preserved, and
+    neither must drift across repeated draws."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
+    ax.set_title("styled", color="red", fontsize=20, fontweight="bold", pad=40)
+    g = pp.legend(ax, side="top")
+    pads = []
+    for _ in range(4):
+        fig.canvas.draw()
+        pads.append(ax.titleOffsetTrans._t[1] * 72.0)
+    # Styling survives every draw.
+    assert ax.title.get_color() in ("red", (1.0, 0.0, 0.0, 1.0))
+    assert ax.title.get_fontsize() == 20.0
+    assert ax.title.get_fontweight() == "bold"
+    # User pad (40pt) is honoured (>= 40) and converges (no drift).
+    assert all(p >= 40.0 - 0.5 for p in pads), f"user pad lost: {pads}"
+    assert abs(pads[-1] - pads[-2]) < 0.5, f"title pad drifts: {pads}"
+
+
 def test_per_axis_internal_left_clears_yticklabels():
-    """An adopted left legend sits left of (clears) the y-tick labels."""
+    """An adopted left legend sits left of (clears) the y-tick labels,
+    with no large fixed gap (Issue B: dynamic offset)."""
     df = _scatter_df()
     fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
     pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax)
@@ -705,9 +760,42 @@ def test_per_axis_internal_left_clears_yticklabels():
     ]
     if ytick_x0s:
         min_x0 = min(ytick_x0s)
+        # Clears the y-ticklabels (legend right edge at/left of them).
         assert lb.x1 <= min_x0 + 1.0, (
             f"left legend x1={lb.x1:.1f} should clear y-ticklabel x0={min_x0:.1f}"
         )
+        # ... but not by a large fixed gap (dynamic, ~2mm).
+        gap_mm = (min_x0 - lb.x1) / fig.dpi * 25.4
+        assert gap_mm <= 5.0, (
+            f"left legend gap to y-ticklabels should be small/dynamic, "
+            f"got {gap_mm:.2f}mm"
+        )
+
+
+def test_per_axis_top_title_space_reserves_legend_plus_title():
+    """Issue C: the reserved title_space for a per-axes top legend should
+    be ~ legend_height + gap + title_height — not extra vertical-stacking
+    padding."""
+    df = _scatter_df()
+    fig, ax = pp.subplots(1, 1, axes_size=(50, 40))
+    pp.scatterplot(data=df, x="x", y="y", hue="g", palette="pastel", ax=ax,
+                   title="my title")
+    g = pp.legend(ax, side="top")
+    fig.canvas.draw()
+    legend = g._builder.elements[0][1]
+    lb = legend.get_window_extent()
+    axb = ax.get_window_extent()
+    title_bb = ax.title.get_window_extent()
+    # Total decoration above the axes top, in mm.
+    decoration_mm = (title_bb.y1 - axb.y1) / fig.dpi * 25.4
+    legend_h_mm = lb.height / fig.dpi * 25.4
+    title_h_mm = title_bb.height / fig.dpi * 25.4
+    # Expected: legend + ~2mm gap + title + a small slack for inter-gaps.
+    expected = legend_h_mm + title_h_mm + 2.0
+    assert decoration_mm <= expected + 5.0, (
+        f"reserved decoration {decoration_mm:.2f}mm exceeds "
+        f"legend+title+gap ~= {expected:.2f}mm (excess padding)"
+    )
 
 
 def test_per_axis_right_still_top_aligned():
@@ -826,6 +914,49 @@ def test_per_axis_external_band_side_reserves():
     assert layout2.legend_band_left < 0.5, (
         f"legend_band_left should stay zero; got {layout2.legend_band_left:.1f}"
     )
+
+
+def test_top_align_does_not_force_per_panel_canvas_draws():
+    """Issue A (perf): one fig.canvas.draw() on an N-panel grid of
+    side='top' per-axes legends must NOT trigger O(panels) nested full
+    canvas.draws via _measure_object_dimensions. The align pass should
+    measure without forcing a fresh figure redraw per element.
+
+    Structural (not wall-clock): count _measure_object_dimensions calls
+    that hit a real fig.canvas.draw() during a single user draw and
+    assert it stays small and constant w.r.t. panel count.
+    """
+    from publiplots.utils.legend import LegendBuilder
+
+    df = _scatter_df(n=40)
+
+    def count_draws_in_one_draw(n):
+        orig_draw = LegendBuilder._fig_canvas_draw_for_measure
+        calls = {"n": 0}
+
+        def counting(self):
+            calls["n"] += 1
+            return orig_draw(self)
+
+        LegendBuilder._fig_canvas_draw_for_measure = counting
+        try:
+            fig, axes = pp.subplots(n, n, axes_size=(30, 22))
+            for ax in np.atleast_2d(axes).flat:
+                pp.scatterplot(data=df, x="x", y="y", hue="g",
+                               palette="pastel", ax=ax, title="t")
+                pp.legend(ax, side="top")
+            calls["n"] = 0  # reset; count only the explicit draw below
+            fig.canvas.draw()
+            return calls["n"]
+        finally:
+            LegendBuilder._fig_canvas_draw_for_measure = orig_draw
+
+    n2 = count_draws_in_one_draw(2)  # 4 panels
+    n3 = count_draws_in_one_draw(3)  # 9 panels
+    # Must not scale with panel count and must be small (ideally 0).
+    assert n2 <= 1, f"2x2 forced {n2} nested canvas.draws in align measure"
+    assert n3 <= 1, f"3x3 forced {n3} nested canvas.draws in align measure"
+    assert n3 <= n2, f"draw count scales with panels: 2x2={n2}, 3x3={n3}"
 
 
 def test_multi_panel_no_duplicate_render_or_hooks():


### PR DESCRIPTION
## Summary

Per-axes legend placement (`pp.legend(ax, side=...)` and `legend_kws={"side": ...}` on plot functions) was broken in three ways that all traced to a single architectural issue, plus follow-on placement/perf bugs surfaced while testing on real `lineplot` usage. This PR fixes all of them.

### Root cause

Every plot call auto-creates a cached per-axes legend group on `ax._legend_group` (right side, holding the hue entry). The public `pp.legend(ax)` factory previously **always built a second competing group** instead of reusing it, which caused:

- the user's `side=` to be silently dropped ("first group wins")
- a spurious `scope overlaps with an existing group` warning on the plain `pp.scatterplot(...); pp.legend(ax)` flow
- a **7×+ slowdown** scaling with panel count (double render + a redundant per-draw align hook)

## Changes

### 1 — `pp.legend(ax)` adopts the plot-created group (`0b83734`)
Reconfigures the cached group in place (tears down the rendered artists, rebuilds under the requested `side`/`orientation`/`align`/offset, re-collects once). One group per axes → placement applies, no warning, no double work (**7× → 1.2×**). Repeat calls (e.g. to change `side=`) re-adopt the same group rather than stacking duplicates — gated on a stable single-axes per-axes marker, not the mutable `_collect`.

### 2 — `legend_kws` placement keys (`0b83734`)
Forwards `side, orientation, align, x_offset, y_offset, gap` so a single plot call can position its legend, e.g. `pp.scatterplot(..., legend_kws={"side": "left"})`. The `inside=True` path is unchanged.

### 3 — `side='top'`/`'bottom'` align performance (`949820c`)
`align='center'` (the top/bottom default) wired a per-draw hook that called `_measure_object_dimensions` per element — each forcing a **full `fig.canvas.draw()`** (9 nested redraws on a 3×3). The align pass now reuses the already-current renderer cache (`force_draw=False`); it runs as a post-refresh reactor callback so the cache is populated. **3×3 `side='top'` now within ~1.07× of `side='right'`.**

### 4 — top/left placement, padding, and title stacking (`949820c`)
The earlier fixed 7mm/8mm top/left offset left empty padding (no title) and sandwiched the axes title between the axes and the legend. Reverted to the normal 2mm gap. For `side='top'` the axes title is now lifted **above** the legend band (stacking: axes → legend → title) with `title_space` grown to fit both; for `side='left'` the legend is offset past the y-tick labels dynamically (measured, not fixed), with no double-counting. The lift uses the title offset transform (not `ax.set_title()`), so it no longer resets the title's color/fontsize/weight, and a user-set title pad larger than the band lift is preserved.

### 5 — supporting fixes
- `_collect_overlap` treats `collect=[]` (render-nothing stash) as disjoint, so it never triggers the overlap warning.
- internal-mode offset defaults gated to axes-anchored groups only (figure bands keep 2mm).

## Testing

- **1119 tests pass** (full suite). New/updated coverage: per-side placement, adoption, repeat-call re-adopt, no-spurious-warning, genuine-warning-still-fires, `legend_kws` placement, external-band reservation, multi-panel no-duplicate-render/hook guard, title-outermost (asserted at steady state), title-styling preservation, no-gap-without-title, left clears y-tick labels, and an align-does-not-force-per-panel-canvas-draws perf guard.
- All four sides + title/no-title cases **visually verified** via rasterized PNGs (no overlaps, correct stacking, no excess padding).
- Two additional bugs (title styling clobbered; user title pad shrunk) were caught by an adversarial code-review pass and fixed before this push.
- Docs refreshed: `examples/plots/plot_24_legend_placement.py` (per-axes `side=` + one-call `legend_kws` sections).

## Notes

- The converged title→legend gap for `side='top'` is tight (~0.3mm bbox); visually clean at default fonts. The regression test asserts steady-state non-overlap (after settle), not the transient first-draw geometry.
- The `legend-placement` skill lives in the plugin cache (not this repo), so its doc sync belongs with the next release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
