### PR TITLE
fix(annotate): recover capped errorbar extents for value labels

### DIFF
--- a/src/publiplots/annotate/_cache.py
+++ b/src/publiplots/annotate/_cache.py
@@ -168,34 +168,50 @@ def _iter_error_segments(ax: Axes):
     """Yield (xs, ys) arrays for every candidate errorbar segment on `ax`.
 
     Matplotlib/seaborn render errorbars as either:
-      - Line2D artists in `ax.lines` (e.g., seaborn's pre-3.x bar errorbars), or
+      - Line2D artists in `ax.lines` (e.g., seaborn's bar/point errorbars), or
       - a LineCollection in `ax.collections` (matplotlib's `ax.bar(yerr=...)`
         since ~3.6 — segments packed as (2, 2) arrays).
+
+    When ``capsize > 0``, seaborn packs the whole errorbar (bottom cap +
+    vertical stem + top cap) into a SINGLE Line2D whose data is separated by
+    ``nan`` between sub-segments. We split each line on those ``nan`` breaks
+    and yield each finite contiguous run independently, so the vertical stem
+    run survives for the matcher. A run shorter than two points (or an
+    all-``nan`` line, as seaborn emits for single-sample groups) yields
+    nothing, leaving ``err_low/err_high`` as ``None``.
     """
     import math as _math
 
-    def _finite(values) -> bool:
-        for v in values:
-            try:
-                if _math.isnan(float(v)):
-                    return False
-            except (TypeError, ValueError):
-                return False
-        return True
+    def _isnan(v) -> bool:
+        try:
+            return _math.isnan(float(v))
+        except (TypeError, ValueError):
+            return True  # non-numeric → treat as a break, never emit
+
+    def _finite_runs(xs, ys):
+        """Split (xs, ys) into contiguous runs free of nan on either axis."""
+        run_xs: List[float] = []
+        run_ys: List[float] = []
+        for x, y in zip(xs, ys):
+            if _isnan(x) or _isnan(y):
+                if len(run_xs) >= 2:
+                    yield run_xs, run_ys
+                run_xs, run_ys = [], []
+            else:
+                run_xs.append(x)
+                run_ys.append(y)
+        if len(run_xs) >= 2:
+            yield run_xs, run_ys
 
     for ln in ax.lines:
-        xs, ys = ln.get_xdata(), ln.get_ydata()
-        if len(xs) >= 2 and _finite(xs) and _finite(ys):
-            yield xs, ys
+        yield from _finite_runs(ln.get_xdata(), ln.get_ydata())
     for col in ax.collections:
         if not isinstance(col, LineCollection):
             continue
         for seg in col.get_segments():
             if len(seg) < 2:
                 continue
-            xs, ys = seg[:, 0], seg[:, 1]
-            if _finite(xs) and _finite(ys):
-                yield xs, ys
+            yield from _finite_runs(seg[:, 0], seg[:, 1])
 
 
 def _match_errorbars(

--- a/tests/annotate/test_barplot_integration.py
+++ b/tests/annotate/test_barplot_integration.py
@@ -129,6 +129,49 @@ def test_barplot_annotate_with_errorbars_anchors_past_cap():
         assert y >= bar.err_high
 
 
+def test_barplot_annotate_with_capped_errorbars_anchors_past_cap():
+    """capsize>0 path: the existing anchors_past_cap test uses the default
+    capsize=0 (a clean 2-point errorbar Line2D). With capsize>0 matplotlib
+    emits a single nan-separated Line2D; the cap extents must still be found
+    so labels clear the cap rather than overlapping it."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "group": pd.Categorical(np.repeat(["A", "B"], 20)),
+        "y": np.concatenate([
+            rng.normal(1.0, 0.5, 20),
+            rng.normal(2.0, 0.5, 20),
+        ]),
+    })
+    ax = pp.barplot(data=df, x="group", y="y", errorbar="se",
+                    capsize=3, annotate=True)
+    meta = ax._publiplots_bar_meta
+    for bar in meta.bars:
+        assert bar.err_high is not None
+        assert bar.err_high > bar.value
+    for bar, text in zip(meta.bars, ax.texts):
+        _, y = text.get_position()
+        assert y >= bar.err_high
+
+
+def test_pointplot_annotate_with_capped_errorbars_anchors_past_cap():
+    """Same capsize>0 regression for pointplot, which shares the errorbar
+    segment matcher."""
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame({
+        "group": pd.Categorical(np.repeat(["A", "B"], 20)),
+        "y": np.concatenate([
+            rng.normal(1.0, 0.5, 20),
+            rng.normal(2.0, 0.5, 20),
+        ]),
+    })
+    ax = pp.pointplot(data=df, x="group", y="y", errorbar="se",
+                      capsize=3, annotate=True)
+    meta = ax._publiplots_point_meta
+    for point in meta.points:
+        assert point.err_high is not None
+        assert point.err_high > point.value
+
+
 def test_barplot_annotate_hue_labels_pair_to_correct_bars():
     """Labels must match bar heights, not swap across dodge groups.
 

--- a/tests/annotate/test_cache.py
+++ b/tests/annotate/test_cache.py
@@ -95,6 +95,36 @@ def test_introspect_ignores_nan_errorbar_segments():
         assert bar.err_high is None
 
 
+def test_introspect_vertical_bars_with_capped_errorbars():
+    """With capsize>0, matplotlib draws each errorbar as ONE Line2D whose data
+    is nan-separated into [bottom cap | vertical stem | top cap]. The stem must
+    still be recovered as err_low/err_high — regression for labels overlapping
+    capped error bars."""
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2], [1.0, 2.0, 3.0], yerr=[0.1, 0.2, 0.3], width=0.8, capsize=3)
+    meta = _introspect(ax)
+    assert len(meta.bars) == 3
+    for bar, exp_low, exp_high in zip(
+        meta.bars, [0.9, 1.8, 2.7], [1.1, 2.2, 3.3]
+    ):
+        assert bar.err_high == pytest.approx(exp_high, rel=1e-2)
+        assert bar.err_low == pytest.approx(exp_low, rel=1e-2)
+
+
+def test_introspect_horizontal_bars_with_capped_errorbars():
+    """Same as above for orient='h': caps run along y, stem along x."""
+    fig, ax = plt.subplots()
+    ax.barh([0, 1, 2], [1.0, 2.0, 3.0], xerr=[0.1, 0.2, 0.3], height=0.8, capsize=3)
+    meta = _introspect(ax)
+    assert meta.orient == "h"
+    assert len(meta.bars) == 3
+    for bar, exp_low, exp_high in zip(
+        meta.bars, [0.9, 1.8, 2.7], [1.1, 2.2, 3.3]
+    ):
+        assert bar.err_high == pytest.approx(exp_high, rel=1e-2)
+        assert bar.err_low == pytest.approx(exp_low, rel=1e-2)
+
+
 def test_bar_record_has_new_public_fields():
     rect = Rectangle((0, 0), 1, 1)
     rec = BarRecord(


### PR DESCRIPTION
## Problem

`pp.barplot(..., annotate=True)` / `pp.annotate` value labels overlap the error bar instead of clearing its cap — **but only when `capsize > 0`**. The default `capsize=0` works, which is why the existing `test_barplot_annotate_with_errorbars_anchors_past_cap` test (default capsize) never caught it. `pp.pointplot` is affected identically (shared matcher).

## Root cause

`src/publiplots/annotate/_cache.py::_iter_error_segments`.

Matplotlib/seaborn draw the errorbar with two different geometries:

| `capsize` | errorbar artist geometry |
|-----------|--------------------------|
| `0` (default) | clean 2-point vertical `Line2D`: `x=[c,c], y=[low,high]` ✓ matched |
| `> 0` | **one** `Line2D` packing `[bottom cap \| vertical stem \| top cap]`, **nan-separated** |

The old code ran its `_finite()` check over the *whole* array and discarded any line containing a `nan`, so the capped errorbar was dropped entirely → `err_low/err_high = None` → `resolve_anchor` fell back to the bar top (`edge = bar.err_high if … is not None else top`).

## Fix

Split each errorbar line on `nan` into finite contiguous runs and yield each run independently. The vertical-stem run then survives for the matcher. An all-`nan` line (single-sample groups, `std` with `ddof=1`) still yields nothing, so `err_low/err_high` stay `None` — existing behavior preserved.

`resolve_anchor`'s orientation (v/h) and sign (positive/negative) logic was already correct; the extents simply never reached it. Only `anchor="outside"` consults the extents — `inside`/`base`/`center` deliberately ignore them.

## Verification

- **4 new tests**, written red-first:
  - `test_cache.py`: `test_introspect_{vertical,horizontal}_bars_with_capped_errorbars`
  - `test_barplot_integration.py`: `test_{barplot,pointplot}_annotate_with_capped_errorbars_anchors_past_cap`
- **Full suite: 1123 passed.**
- **Visually eyeballed** across V-bars / H-bars / negative bar / pointplot — labels clear the cap in every case, and the negative bar's label sits *below* the bottom cap (sign-aware):

| case | result |
|------|--------|
| V bars, capsize=3 | label clears top cap ✓ |
| H bars, capsize=3 | label clears right cap ✓ |
| negative bar | label below bottom cap ✓ |
| pointplot, capsize=3 | label clears top cap ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
