### PR TITLE
chore(release): 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-06-10
+
+### Fixed
+
+- `pp.barplot`/`pp.pointplot` value labels (`annotate=True`/`pp.annotate`)
+  no longer overlap the error bar when `capsize > 0`. With a non-zero
+  capsize, seaborn packs the whole errorbar (bottom cap + vertical stem +
+  top cap) into a single `Line2D` whose data is `nan`-separated between
+  sub-segments; `_iter_error_segments` checked finiteness over the whole
+  array and discarded any line containing a `nan`, so `err_low/err_high`
+  came back `None` and labels anchored on the bar top instead of clearing
+  the cap. The default `capsize=0` (a clean 2-point `Line2D`) was
+  unaffected, which is why it slipped past the existing anchor test.
+  Errorbar lines are now split on `nan` into finite contiguous runs so
+  the vertical-stem run survives the matcher; all-`nan` lines
+  (single-sample groups) still yield nothing. Fixes both orientations and
+  is sign-aware (negative bars label below the bottom cap) (#184).
+
 ## [0.14.0] - 2026-06-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.14.0"
+version = "0.14.1"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.12.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Pure version bump to **0.14.1** for the annotate capped-errorbar fix (#184).

## Changes

- `pyproject.toml`: `0.14.0` → `0.14.1` (sole version source; `__version__` resolves from package metadata).
- `CHANGELOG.md`: add the `0.14.1` **Fixed** entry for #184.
- `uv.lock`: refresh the self-pin (was stale at `0.12.0`) to `0.14.1`.

No public API change — the fix is internal to the errorbar segment matcher — so the `publiplots-guide` / `legend-placement` skills need no refresh.

## What 0.14.1 ships (#184)

`pp.barplot`/`pp.pointplot` value labels (`annotate=True` / `pp.annotate`) no longer overlap the error bar when `capsize > 0`. Both orientations, sign-aware. Full suite: 1123 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
