### PR TITLE
feat(legend): rcParam-controllable spacing + tighter columnspacing default

### DIFF
--- a/src/publiplots/themes/rcparams.py
+++ b/src/publiplots/themes/rcparams.py
@@ -120,6 +120,12 @@ MATPLOTLIB_RCPARAMS: Dict[str, Any] = {
     "legend.fontsize": 7,
     "legend.frameon": False,
     "legend.edgecolor": "none",
+    # Tighter than matplotlib's 2.0: publiplots' small legend.fontsize (7)
+    # makes the font-size-relative columnspacing read as loose at 2.0, so
+    # entries in a horizontal (side='top'/'bottom') legend drift apart.
+    # 1.0 keeps multi-entry bands compact. Override per-call via
+    # ``legend_kws={'columnspacing': ...}`` or globally via pp.rcParams.
+    "legend.columnspacing": 1.0,
 
     # Save settings - high quality for publications
     "savefig.dpi": 600,

--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -1095,7 +1095,7 @@ class LegendBuilder:
             'labelspacing',
             compute_min_labelspacing(handles, fontsize),
         )
-        borderpad = kwargs.get('borderpad', 0.4)
+        borderpad = resolve_param("legend.borderpad", kwargs.get('borderpad'))
 
         # Calculate rows
         n_items = len(handles)
@@ -1143,12 +1143,16 @@ class LegendBuilder:
         text_width = max_label_length * fontsize * 0.6 * self.PT2MM
 
         # Add space for handle
-        handlelength = kwargs.get('handlelength', 2)  # in font-size units
-        handletextpad = kwargs.get('handletextpad', 0.8)
+        handlelength = resolve_param(
+            "legend.handlelength", kwargs.get('handlelength')
+        )  # in font-size units
+        handletextpad = resolve_param(
+            "legend.handletextpad", kwargs.get('handletextpad')
+        )
         handle_width = (handlelength + handletextpad) * fontsize * self.PT2MM
 
         # Add padding
-        borderpad = kwargs.get('borderpad', 0.4)
+        borderpad = resolve_param("legend.borderpad", kwargs.get('borderpad'))
         padding = 2 * borderpad * fontsize * self.PT2MM
 
         return handle_width + text_width + padding
@@ -1255,8 +1259,8 @@ class LegendBuilder:
             default_labelspacing = compute_min_labelspacing(handles, fontsize)
             legend_kwargs = {
                 "frameon": frameon,
-                "borderpad": 0.4,
-                "handletextpad": 0.8,
+                "borderpad": resolve_param("legend.borderpad", None),
+                "handletextpad": resolve_param("legend.handletextpad", None),
                 "labelspacing": default_labelspacing,
                 "handler_map": kwargs.pop("handler_map", get_legend_handler_map()),
                 "alignment": "left",
@@ -1343,8 +1347,8 @@ class LegendBuilder:
             "bbox_transform": self.fig.transFigure,  # Use figure coords
             "frameon": frameon,
             "borderaxespad": 0,
-            "borderpad": 0.4,
-            "handletextpad": 0.8,
+            "borderpad": resolve_param("legend.borderpad", None),
+            "handletextpad": resolve_param("legend.handletextpad", None),
             "labelspacing": default_labelspacing,
             "handler_map": kwargs.pop("handler_map", get_legend_handler_map()),
             "alignment": "left",

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -986,3 +986,114 @@ def test_multi_panel_no_duplicate_render_or_hooks():
         "duplicate align callbacks registered"
     )
     assert len(callbacks) <= 9, f"expected <=9 align callbacks, got {len(callbacks)}"
+
+
+# --- legend spacing rcParam defaults -----------------------------------------
+
+
+def _rendered_legend_width_mm(handletextpad=None, borderpad=None):
+    """Build a horizontal side='top' 3-category legend and return its
+    rendered width in mm. Optional explicit kwargs override the rcParam."""
+    fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+    for ax in axes:
+        ax.plot([0, 1, 2], [0, 1, 0])
+    group = pp.legend(side="top")
+    kw = {}
+    if handletextpad is not None:
+        kw["handletextpad"] = handletextpad
+    if borderpad is not None:
+        kw["borderpad"] = borderpad
+    group.add_legend(handles=_sample_handles(), label="group", **kw)
+    fig.canvas.draw()
+    bb = group._builder.elements[0][1].get_window_extent()
+    return (bb.x1 - bb.x0) / fig.dpi * 25.4
+
+
+def test_legend_handletextpad_respects_rcparam():
+    """A smaller legend.handletextpad rcParam renders a narrower
+    horizontal legend (the render path must read the rcParam)."""
+    import matplotlib as mpl
+    with mpl.rc_context({"legend.handletextpad": 0.2}):
+        narrow = _rendered_legend_width_mm()
+    with mpl.rc_context({"legend.handletextpad": 2.0}):
+        wide = _rendered_legend_width_mm()
+    assert wide > narrow + 1.0, (
+        f"larger handletextpad should widen legend; "
+        f"narrow={narrow:.2f} mm wide={wide:.2f} mm"
+    )
+
+
+def test_legend_borderpad_respects_rcparam():
+    """legend.borderpad rcParam changes the rendered legend extent."""
+    import matplotlib as mpl
+    with mpl.rc_context({"legend.borderpad": 0.2}):
+        narrow = _rendered_legend_width_mm()
+    with mpl.rc_context({"legend.borderpad": 2.0}):
+        wide = _rendered_legend_width_mm()
+    assert wide > narrow + 1.0, (
+        f"larger borderpad should widen legend; "
+        f"narrow={narrow:.2f} mm wide={wide:.2f} mm"
+    )
+
+
+def test_legend_per_call_kwarg_overrides_rcparam():
+    """An explicit handletextpad passed to add_legend wins over the
+    rcParam default."""
+    import matplotlib as mpl
+    with mpl.rc_context({"legend.handletextpad": 0.2}):
+        rcparam_narrow = _rendered_legend_width_mm()
+        explicit_wide = _rendered_legend_width_mm(handletextpad=2.0)
+    assert explicit_wide > rcparam_narrow + 1.0, (
+        f"explicit handletextpad=2 should override rcParam 0.2; "
+        f"rcparam_narrow={rcparam_narrow:.2f} mm explicit_wide={explicit_wide:.2f} mm"
+    )
+
+
+def test_legend_columnspacing_still_rcparam_controllable():
+    """Regression guard: legend.columnspacing was never hard-coded and
+    must keep responding to the rcParam (multi-column horizontal legend)."""
+    import matplotlib as mpl
+
+    def _width(cs):
+        with mpl.rc_context({"legend.columnspacing": cs}):
+            fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+            for ax in axes:
+                ax.plot([0, 1, 2], [0, 1, 0])
+            group = pp.legend(side="top")
+            group.add_legend(handles=_sample_handles(), label="group")
+            fig.canvas.draw()
+            bb = group._builder.elements[0][1].get_window_extent()
+            return (bb.x1 - bb.x0) / fig.dpi * 25.4
+
+    narrow = _width(0.2)
+    wide = _width(4.0)
+    assert wide > narrow + 1.0, (
+        f"larger columnspacing should widen multi-column legend; "
+        f"narrow={narrow:.2f} mm wide={wide:.2f} mm"
+    )
+
+
+def test_legend_reservation_tracks_handletextpad_rcparam():
+    """The layout reservation must grow with the legend.handletextpad
+    rcParam, proving the width ESTIMATE and the RENDER read the same
+    rcParam (otherwise reserved != drawn). A vertical side='right'
+    legend reserves its outward extent (width) in ``legend_column``, so
+    that field tracks the handle/text padding that drives width."""
+    import matplotlib as mpl
+
+    def _reserved(htp):
+        with mpl.rc_context({"legend.handletextpad": htp}):
+            fig, axes = pp.subplots(1, 3, axes_size=(40, 30))
+            for ax in axes:
+                ax.plot([0, 1, 2], [0, 1, 0])
+            group = pp.legend(side="right")
+            group.add_legend(handles=_sample_handles(), label="group")
+            fig.canvas.draw()
+            return fig._publiplots_layout.legend_column
+
+    small = _reserved(0.2)
+    big = _reserved(3.0)
+    assert big > small + 0.5, (
+        f"reservation should grow with handletextpad rcParam; "
+        f"small={small:.2f} mm big={big:.2f} mm"
+    )

--- a/tests/test_legend_group_sides.py
+++ b/tests/test_legend_group_sides.py
@@ -1073,6 +1073,14 @@ def test_legend_columnspacing_still_rcparam_controllable():
     )
 
 
+def test_legend_columnspacing_default_is_tightened():
+    """publiplots ships a tighter legend.columnspacing default (1.0) than
+    matplotlib's 2.0, so multi-entry horizontal bands stay compact at the
+    small default legend.fontsize. Importing publiplots must apply it."""
+    import matplotlib as mpl
+    assert mpl.rcParams["legend.columnspacing"] == 1.0
+
+
 def test_legend_reservation_tracks_handletextpad_rcparam():
     """The layout reservation must grow with the legend.handletextpad
     rcParam, proving the width ESTIMATE and the RENDER read the same


### PR DESCRIPTION
## Summary

Two related legend-spacing improvements, so spacing can be tuned globally and the defaults suit publication-density figures.

### 1. `legend.handletextpad` / `legend.borderpad` now respect rcParams

`LegendBuilder.add_legend` and its two size-estimation helpers hard-coded `handletextpad=0.8` and `borderpad=0.4`, so setting the matplotlib rcParams had no effect on publiplots legends. (`legend.columnspacing` already worked — never hard-coded.)

All four sites — the two estimation helpers (`_estimate_legend_height`, `_estimate_legend_width`) and the inside/band render-path `legend_kwargs` dicts — now resolve their default via `resolve_param("legend.handletextpad" / "legend.borderpad", kwargs.get(...))`:

- The **rcParam is the default**.
- An explicit per-call `legend_kws={"handletextpad": ...}` still **overrides** (the render dicts keep their trailing `legend_kwargs.update(kwargs)`).
- `_estimate_legend_width`'s `handlelength` is likewise routed through `resolve_param("legend.handlelength", ...)` so the layout **reservation estimate stays consistent** with what matplotlib draws.

### 2. Tighter default `legend.columnspacing` (2.0 → 1.0)

publiplots uses `legend.fontsize=7`, but `columnspacing` is in font-size units, so matplotlib's default of `2.0` reads as loose — entries in a horizontal (`side='top'`/`'bottom'`) legend drift apart. publiplots now registers a default of `1.0` so multi-entry bands stay compact out of the box (chosen by eyeballing 2.0 vs 1.0 vs 0.9 at the publiplots font size). matplotlib's own default is unchanged for non-publiplots figures; per-call and `pp.rcParams` overrides still win.

### Behavior / compatibility

- `handletextpad`/`borderpad`/`handlelength`: matplotlib's defaults (`0.8` / `0.4` / `2.0`) are unchanged, so default output is byte-identical — only users who set the rcParams see a difference.
- `columnspacing`: this **does** change default publiplots output (tighter horizontal legends). Verified no test had baked in the old 2.0 spacing.
- `labelspacing` is untouched (it keeps its `compute_min_labelspacing` no-overlap floor).

### Usage

```python
import publiplots as pp
pp.rcParams["legend.columnspacing"] = 0.8   # entry ↔ entry  (default now 1.0)
pp.rcParams["legend.handletextpad"] = 0.4   # swatch ↔ label  (NEW)
pp.rcParams["legend.borderpad"]     = 0.3   # frame padding   (NEW)
# per-call override still wins:
pp.lineplot(..., legend_kws={"handletextpad": 2})
```

### Testing

- **1129 tests pass** (full suite; +6 new).
- New tests: `handletextpad`/`borderpad` respond to rcParams, per-call kwarg overrides the rcParam, `columnspacing` regression guard, layout reservation tracks the `handletextpad` rcParam (estimate == render), and the tightened `columnspacing=1.0` default applies on import.
- Visually verified (rasterized): default vs tight vs loose spacing, and the 2.0 → 1.0 default change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
