### PR TITLE
chore(release): 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-06-11
+
+### Added
+
+- `legend.handletextpad` and `legend.borderpad` matplotlib rcParams are
+  now honoured as defaults for publiplots legends (previously hard-coded
+  in `LegendBuilder.add_legend` and its size estimators, so the rcParams
+  had no effect). Set them globally via `pp.rcParams[...]`; an explicit
+  per-call `legend_kws={...}` still overrides. The width-estimation path
+  also reads `legend.handlelength` so the reserved layout space stays
+  consistent with what matplotlib draws. `legend.columnspacing` already
+  worked; `legend.labelspacing` is unchanged (it keeps its no-overlap
+  floor) (#186).
+
+### Changed
+
+- The default `legend.columnspacing` is now `1.0` (down from
+  matplotlib's `2.0`). At publiplots' small `legend.fontsize` the
+  font-size-relative `2.0` reads as loose, so multi-entry horizontal
+  (`side='top'`/`'bottom'`) legends drifted apart; `1.0` keeps them
+  compact. This changes default output for multi-entry horizontal
+  legends; override per-call or via `pp.rcParams['legend.columnspacing']`
+  (#186).
+
 ## [0.14.1] - 2026-06-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.14.1"
+version = "0.14.2"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/skills/legend-placement/SKILL.md
+++ b/skills/legend-placement/SKILL.md
@@ -161,6 +161,22 @@ Edge behaviour for per-axes legends:
 - `side='left'` offsets the legend past the y-tick labels dynamically (no fixed gap).
 - `top`/`bottom` default to `orientation='horizontal'`, `align='center'`; `left`/`right` to `vertical`, `align='start'`.
 
+## Spacing between entries (rcParams, since 0.14.2)
+
+The gaps *within* a legend are matplotlib `Legend` kwargs — set them globally via `pp.rcParams` or per-call via `legend_kws`:
+
+- **`legend.columnspacing`** — distance between entries in a horizontal (`side='top'`/`'bottom'`) legend. publiplots defaults this to **`1.0`** (tighter than matplotlib's `2.0`, which reads loose at the small default `legend.fontsize=7`).
+- **`legend.handletextpad`** — gap between each swatch and its own label.
+- **`legend.borderpad`** — padding inside the legend frame.
+- **`legend.labelspacing`** — vertical gap between entries in a vertical (`left`/`right`) legend; publiplots clamps this to a no-overlap floor, so setting it below the floor has no effect.
+
+```python
+pp.rcParams["legend.columnspacing"] = 0.8        # global default
+pp.lineplot(..., legend_kws={"handletextpad": 0.4})   # per-call override
+```
+
+`x_offset`/`y_offset`/`gap` (the outward gap from the axes edge and inter-band spacing) are publiplots legend-group kwargs, passed via `legend_kws=` — they are NOT rcParams.
+
 ## Internal vs external per-axes legend (`pp.legend(ax)` vs `pp.legend(anchor=ax)`)
 
 The two forms have opposite layout semantics — still a real distinction:


### PR DESCRIPTION
## Release 0.14.2

Version bump + changelog + skill docs for the legend-spacing work merged in #186.

### Changes

- **Version → 0.14.2** in `pyproject.toml` (single source; `__version__` resolves via `importlib.metadata`).
- **CHANGELOG**: new `[0.14.2]` entry (Added / Changed) for #186.
- **`legend-placement` skill**: documents the rcParam-controllable spacing knobs (`legend.handletextpad`, `legend.borderpad`, `legend.columnspacing`) and the new `columnspacing=1.0` default, plus the note that `x_offset`/`y_offset`/`gap` are `legend_kws` (not rcParams).

### What 0.14.2 ships (from #186)

- `legend.handletextpad` / `legend.borderpad` matplotlib rcParams are now honoured as defaults (were hard-coded); per-call `legend_kws` still overrides. `handlelength` is read in the width estimate too, so reserved layout space matches the drawn legend.
- Default `legend.columnspacing` tightened `2.0 → 1.0` for publiplots' small `legend.fontsize` — **changes default output** for multi-entry horizontal legends.

### Why patch (0.14.2)

Per maintainer's call. The user-visible change is the tighter `columnspacing` default; the rest is rcParam plumbing that's byte-identical for default users.

### Testing

- 59 legend tests pass on this branch; #186 already passed the full suite (1129) before merge.
- `uv build` produces clean `publiplots-0.14.2` sdist + wheel.
- `import publiplots; publiplots.__version__` → `0.14.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
