### PR TITLE
fix(legend): use plt.get_cmap (matplotlib.cm.get_cmap removed in 3.9)

### DIFF
--- a/src/publiplots/utils/legend.py
+++ b/src/publiplots/utils/legend.py
@@ -1481,12 +1481,16 @@ class LegendBuilder:
         ...     label="Log2 FC", ticks=[-2, 0, 2]
         ... )
         """
+        import matplotlib.pyplot as plt
         from matplotlib.colors import TwoSlopeNorm, Normalize
-        from matplotlib.cm import ScalarMappable as SM, get_cmap
+        from matplotlib.cm import ScalarMappable as SM
 
         # Create mappable if cmap provided (PyComplexHeatmap style)
         if mappable is None and cmap is not None:
-            cmap_obj = get_cmap(cmap)
+            # ``plt.get_cmap`` accepts a name or a Colormap instance and is
+            # the supported replacement for ``matplotlib.cm.get_cmap``, which
+            # was removed in matplotlib 3.9.
+            cmap_obj = plt.get_cmap(cmap)
             if center is not None:
                 norm = TwoSlopeNorm(vmin=vmin, vcenter=center, vmax=vmax)
             else:


### PR DESCRIPTION
## Problem

The docs gallery build (CI `build` job) fails on modern matplotlib with:

```
ImportError: cannot import name 'get_cmap' from 'matplotlib.cm'
```

`matplotlib.cm.get_cmap` was **removed in matplotlib 3.9** (deprecated in 3.7). `LegendBuilder.add_colorbar` (`src/publiplots/utils/legend.py`) still imported and called it, so any `add_colorbar(cmap=<name>, ...)` call — and the 8 gallery examples that build colorbars — crash. CI installs an unpinned newer matplotlib, so the published docs build is currently red.

This is independent of any feature work; it surfaced while building the docs for an unrelated PR.

## Fix

Replace the removed `matplotlib.cm.get_cmap` with `matplotlib.pyplot.get_cmap`, the supported replacement. It accepts both a colormap name and a `Colormap` instance (returns the instance unchanged), so behaviour is identical for `add_colorbar`'s `cmap=` argument.

The other `get_cmap` references in the codebase are **method** calls on artists (`contour_set.get_cmap()`, `collection.get_cmap()`, `mesh.get_cmap()`) — those are not the removed module function and need no change. All `matplotlib.cm` imports that remain are `ScalarMappable`, which is still present.

## Test Plan

- [x] `add_colorbar(cmap='RdBu_r', vmin=-2, vmax=2, center=0, ...)` executes and draws without error.
- [x] `plt.get_cmap` verified to accept both a name and a `Colormap` instance (idempotent on instances).
- [x] `pytest -k "colorbar or legend or heatmap"` → 355 passed.
- [x] Confirmed no remaining module-level `get_cmap` usages in `src/`.
- [ ] Reviewer: confirm the docs gallery build (CI `build`) goes green — the 8 previously-failing examples (plot_02/03/04/05/06/09/19/21) should execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)