### PR TITLE
chore(release): re-sync plugin version to 0.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.11.3",
+  "version": "0.15.0",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",


### PR DESCRIPTION
## Problem

The Claude Code plugin (`.claude-plugin/plugin.json`) advertises **0.11.3**, but the PyPI package is at **0.15.0**. In the Claude UI, 0.11.3 shows as the latest available plugin version.

The two versions historically moved in **lockstep** — PR #161 bumped both `pyproject.toml` and `.claude-plugin/plugin.json` to 0.11.3. But subsequent release PRs (#176, #183, #187, #190) bumped only `pyproject.toml`, so the plugin manifest fell four releases behind. The marketplace tracks `main` (no pinned ref), so the *skill content* Claude serves is already current — it's only the declared `version` field that's stale, which is what the UI surfaces.

## Fix

Bump `.claude-plugin/plugin.json` `version` **0.11.3 → 0.15.0**, re-syncing it with the package.

No skill edits needed — the shipped skills are already current on `main`:
- `publiplots-guide` documents `pp.label_outer`, the `label_outer` kwarg on `pp.subplots`, and references the new `examples/plots/plot_25_shared_axes_labels.py` (from #188).
- `legend-placement` carries the expanded grid-scope / inside-legend guidance from earlier releases.

## Test Plan

- [x] `plugin.json` is valid JSON; `version == "0.15.0"`.
- [x] Confirmed the drift cause: #176/#183/#187/#190 did not touch `plugin.json`; #161 set both files together.
- [x] Confirmed shipped skills already document the 0.15.0 API surface (`label_outer` present in `publiplots-guide`).
- [ ] Reviewer: after merge, the plugin in the Claude UI should report 0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)