### PR TITLE
chore(release): 0.15.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-06-18
+
+### Added
+
+- Vertical orientation for 2-way Venn diagrams. `pp.venn(...)` accepts a new
+  `orientation` argument (`"horizontal"`, the default, or `"vertical"`).
+  Vertical stacks the two circles with the first set on top, the intersection
+  in the middle, and the set-name labels at the outer ends. Computed as a 90°
+  rotation of the existing horizontal layout, so the two orientations stay in
+  lockstep. Supported for 2 sets only — `orientation="vertical"` with 3 or more
+  sets raises `ValueError`.
+
 ## [0.15.0] - 2026-06-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.15.0"
+version = "0.15.1"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.14.1"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
Release the vertical 2-way Venn orientation work (#192).

- Bump version **0.15.0 → 0.15.1** in `pyproject.toml` (single-sourced; `__version__` reads it via `importlib.metadata`).
- Sync `.claude-plugin/plugin.json` 0.15.0 → 0.15.1 (kept in lockstep with the package version).
- `CHANGELOG.md`: new `## [0.15.1]` entry under Added.
- Regenerate `uv.lock` (publiplots → 0.15.1).

### Skills
No skill refresh needed this release: neither `publiplots-guide` nor `legend-placement` documents `venn`'s signature or references the venn gallery example, and 0.15.1 adds no new plot function or cross-reference. (venn is already in the Plots inventory by name.)

## Test Plan
- [x] `__version__` resolves to `0.15.1` after `uv sync`.
- [x] `tests/test_venn_orientation.py` — 11 passed.
- [x] Pure version-bump release PR (feature already merged via #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)