### PR TITLE
fix(annotate): label barplot bars at the drawn estimator, not the mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `pp.barplot(..., annotate=...)` now labels the value the bar is actually
+  drawn at for any `estimator`. Previously the annotation always showed the
+  group **mean**, even when `estimator="median"` (or a custom callable) drew
+  the bars at a different height, so the label and its bar silently disagreed.
+  Bar values now come from the drawn patch (`get_height()` / `get_width()`),
+  matching the reconstruct-from-patches path, so `bar_values` and
+  `bar_custom`'s default `value_source` stay consistent with the plot (#194).
+
 ## [0.15.1] - 2026-06-18
 
 ### Added

--- a/src/publiplots/annotate/_builders.py
+++ b/src/publiplots/annotate/_builders.py
@@ -34,7 +34,7 @@ from publiplots.annotate._cache import (
 from publiplots.annotate._splits import BarSplitSpec, _categories_in_draw_order
 
 
-def _aggregate_means(
+def _aggregate_group_keys(
     data,
     x: str,
     y: str,
@@ -43,11 +43,14 @@ def _aggregate_means(
     hatch: Optional[str] = None,
     source_frame=None,
 ) -> List[Dict]:
-    """Group by (categorical_axis [, hue [, hatch]]) and return means.
+    """Group by (categorical_axis [, hue [, hatch]]) and return group keys.
 
     Each row carries its draw-order category/hue/hatch keys and the
     frame row index of the first matching source row, so downstream
-    label lookups can align by group without re-deriving the spec.
+    label lookups can align by group without re-deriving the spec. The
+    aggregated *value* (bar height) is deliberately NOT computed here —
+    seaborn draws bars at whatever ``estimator`` was requested, so the
+    labeled value is read from the drawn patch instead (see issue #194).
 
     ``frame_row_index`` is a *position* (integer offset) into
     ``source_frame``, not a pandas label, so ``source_frame.iloc[idx]``
@@ -55,7 +58,6 @@ def _aggregate_means(
     index, sliced, MultiIndex, ...). When ``source_frame`` is omitted
     the field is ``None``.
     """
-    value_col = y if categorical_axis == x else x
     spec = BarSplitSpec.resolve(
         x=x, y=y, hue=hue, hatch=hatch, categorical_axis=categorical_axis,
     )
@@ -70,7 +72,6 @@ def _aggregate_means(
         mask = parts[0]
         for p in parts[1:]:
             mask = mask & p
-        vals = data.loc[mask, value_col].to_numpy()
         # Position within source_frame of the first row matching this group.
         # We resolve against source_frame (not the prepared `data`) because the
         # meta's `source_frame` is the pre-copy caller frame; `iloc` on the
@@ -86,7 +87,6 @@ def _aggregate_means(
                 # Prepared data diverged from source_frame's index (rare).
                 frame_row_index = None
         row: Dict = {
-            "mean": float(np.mean(vals)) if len(vals) else float("nan"),
             "category": cat,
             "hue_value": h_val,
             "hatch_value": ht_val,
@@ -248,10 +248,14 @@ def build_from_barplot_call(
 ) -> BarValueMeta:
     """Build a `BarValueMeta` paired with the barplot's Rectangles.
 
-    Means come from a groupby of the raw data; errorbar extents are pulled
-    from the drawn errorbar artists via `_match_errorbars`, so they match
-    seaborn exactly for every errorbar spec (`"ci"`, `"pi"`, tuples,
-    callables, `None`). Records are paired with Rectangles in draw order,
+    Bar values are read from the drawn patches (`get_height()` /
+    `get_width()`), so labels match seaborn's `estimator` (mean, median,
+    or any callable) exactly — see issue #194. Group bookkeeping
+    (category / hue / hatch / source-row index) comes from a groupby of
+    the raw data. Errorbar extents are pulled from the drawn errorbar
+    artists via `_match_errorbars`, so they match seaborn exactly for
+    every errorbar spec (`"ci"`, `"pi"`, tuples, callables, `None`).
+    Records are paired with Rectangles in draw order,
     which under hue + hatch double-split is hue-outer / hatch-middle /
     cat-inner. Hue colors come from the resolved palette map.
 
@@ -266,9 +270,16 @@ def build_from_barplot_call(
     """
     orient = "v" if categorical_axis == x else "h"
 
-    agg = _aggregate_means(data, x=x, y=y, hue=hue, hatch=hatch,
-                           categorical_axis=categorical_axis,
-                           source_frame=source_frame)
+    # `_aggregate_group_keys` supplies group bookkeeping (category / hue_value /
+    # hatch_value / frame_row_index) in seaborn's draw order. The bar *value*
+    # is NOT taken from this aggregation — seaborn draws bars at whatever
+    # `estimator` was requested (mean by default, but also median or a custom
+    # callable), so the labeled value must come from the drawn patch itself
+    # (`rect.get_height()` / `get_width()`), matching the reconstruct-from-
+    # patches path in `_cache._introspect`. See issue #194.
+    agg = _aggregate_group_keys(data, x=x, y=y, hue=hue, hatch=hatch,
+                                categorical_axis=categorical_axis,
+                                source_frame=source_frame)
     # `_is_bar_rect` treats signed extents as valid so negative-valued bars
     # (matplotlib emits them as rects with negative height/width) are kept.
     rects = [p for p in ax.patches if _is_bar_rect(p)]
@@ -289,9 +300,10 @@ def build_from_barplot_call(
             # rather than inheriting the bar's translucency.
             r, g, b, _ = rect.get_facecolor()
             hue_color = (r, g, b, 1.0)
+        value = rect.get_height() if orient == "v" else rect.get_width()
         bars.append(BarRecord(
             patch=rect,
-            value=float(row["mean"]),
+            value=float(value),
             err_low=err_low,
             err_high=err_high,
             hue_color=hue_color,
@@ -371,7 +383,7 @@ def build_from_stacked_barplot_call(
 
     orient: Literal["v", "h"] = "v" if categorical_axis == x else "h"
 
-    agg = _aggregate_means(
+    agg = _aggregate_group_keys(
         data, x=x, y=y, hue=hue, hatch=hatch,
         categorical_axis=categorical_axis,
         source_frame=source_frame,

--- a/tests/annotate/test_barplot_integration.py
+++ b/tests/annotate/test_barplot_integration.py
@@ -443,3 +443,20 @@ def test_barplot_annotate_default_mean_estimator_still_correct():
     label = [t.get_text() for t in ax.texts if t.get_text().strip()][0]
     assert drawn == pytest.approx(float(df.y.mean()), abs=1e-6)
     assert float(label) == pytest.approx(drawn, abs=5e-4)
+
+
+def test_barplot_annotate_median_estimator_horizontal_labels_the_median():
+    """Horizontal bars exercise the get_width() branch: the median label
+    must match the drawn bar width, not the mean. Regression for #194."""
+    df = _skewed_df()
+    med, mean = float(df.y.median()), float(df.y.mean())
+    assert abs(med - mean) > 0.1, "fixture must have median != mean"
+
+    # Categorical on y => horizontal bars, value on the width axis.
+    ax = pp.barplot(df, x="y", y="g", estimator="median", errorbar=None,
+                    annotate={"fmt": ".3f"})
+    drawn = [p.get_width() for p in ax.patches if p.get_width() > 0][0]
+    label = [t.get_text() for t in ax.texts if t.get_text().strip()][0]
+
+    assert drawn == pytest.approx(med, abs=1e-6)
+    assert float(label) == pytest.approx(drawn, abs=5e-4)

--- a/tests/annotate/test_barplot_integration.py
+++ b/tests/annotate/test_barplot_integration.py
@@ -371,3 +371,75 @@ def test_barplot_annotate_bar_custom_inline():
     )
     labels = [t.get_text() for t in ax.texts]
     assert labels == ["n=12", "n=34", "n=56"]
+
+
+def _skewed_df():
+    """Right-skewed single group where median != mean (issue #194 repro)."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "g": ["a"] * 200,
+        "y": rng.exponential(1.0, 200),
+    })
+    df["g"] = pd.Categorical(df["g"])
+    return df
+
+
+def test_barplot_annotate_median_estimator_labels_the_median():
+    """estimator='median': the label must match the drawn (median) bar,
+    not a recomputed mean. Regression for issue #194."""
+    df = _skewed_df()
+    med, mean = float(df.y.median()), float(df.y.mean())
+    # Guard: the fixture must actually separate median from mean, else the
+    # test can't distinguish the bug.
+    assert abs(med - mean) > 0.1, "fixture must have median != mean"
+
+    ax = pp.barplot(df, x="g", y="y", estimator="median", errorbar=None,
+                    annotate={"fmt": ".3f"})
+    drawn = [p.get_height() for p in ax.patches if p.get_height() > 0][0]
+    label = [t.get_text() for t in ax.texts if t.get_text().strip()][0]
+
+    assert drawn == pytest.approx(med, abs=1e-6)
+    assert float(label) == pytest.approx(drawn, abs=5e-4)
+
+
+def test_barplot_annotate_median_estimator_with_hue_labels_the_median():
+    """estimator='median' on the hue dodge path also labels the median."""
+    rng = np.random.default_rng(1)
+    rows = []
+    for cond in ("ctrl", "trt"):
+        # Right-skewed so per-group median != mean.
+        scale = 1.0 if cond == "ctrl" else 2.0
+        for v in rng.exponential(scale, 200):
+            rows.append({"g": "a", "cond": cond, "y": float(v)})
+    df = pd.DataFrame(rows)
+    df["g"] = pd.Categorical(df["g"])
+    df["cond"] = pd.Categorical(df["cond"])
+
+    ax = pp.barplot(df, x="g", y="y", hue="cond", estimator="median",
+                    errorbar=None, annotate={"fmt": ".3f"})
+    rects = [p for p in ax.patches if p.get_height() > 0]
+    assert len(rects) == 2
+    assert len(ax.texts) == 2
+    for rect, text in zip(rects, ax.texts):
+        assert float(text.get_text()) == pytest.approx(rect.get_height(), abs=5e-4)
+
+
+def test_barplot_annotate_callable_estimator_labels_drawn_bar():
+    """A custom callable estimator (e.g. max) is honored by the label."""
+    df = _skewed_df()
+    ax = pp.barplot(df, x="g", y="y", estimator=np.max, errorbar=None,
+                    annotate={"fmt": ".3f"})
+    drawn = [p.get_height() for p in ax.patches if p.get_height() > 0][0]
+    label = [t.get_text() for t in ax.texts if t.get_text().strip()][0]
+    assert drawn == pytest.approx(float(df.y.max()), abs=1e-6)
+    assert float(label) == pytest.approx(drawn, abs=5e-4)
+
+
+def test_barplot_annotate_default_mean_estimator_still_correct():
+    """Default (mean) estimator: label still matches the drawn bar."""
+    df = _skewed_df()
+    ax = pp.barplot(df, x="g", y="y", errorbar=None, annotate={"fmt": ".3f"})
+    drawn = [p.get_height() for p in ax.patches if p.get_height() > 0][0]
+    label = [t.get_text() for t in ax.texts if t.get_text().strip()][0]
+    assert drawn == pytest.approx(float(df.y.mean()), abs=1e-6)
+    assert float(label) == pytest.approx(drawn, abs=5e-4)


### PR DESCRIPTION
## Summary

Fixes #194. `pp.barplot(..., estimator="median", annotate=...)` drew bars at the median (seaborn honours `estimator`) but labeled them with the group **mean**, so every label silently disagreed with the bar it sat on. Any non-mean `estimator` (median or a custom callable) was affected, with and without `hue`.

## Root cause

`build_from_barplot_call` in `annotate/_builders.py` hardcoded `BarRecord.value` as a recomputed group mean, independent of the estimator seaborn actually used to draw the bars. The reconstruct-from-patches path (`_cache._introspect`) already sourced the value from the drawn patch — only the barplot-call builder diverged.

## Fix

- `BarRecord.value` now comes from the drawn patch (`rect.get_height()` for vertical / `rect.get_width()` for horizontal), matching `_introspect`. Labels track whatever `estimator` seaborn used.
- `_aggregate_means` → renamed to `_aggregate_group_keys`; it no longer computes the now-unused per-group `"mean"` field and supplies only category / hue / hatch / source-row bookkeeping. The stacked/gain builder already read values from patches, so the shared-helper rename is safe.
- Docstrings updated to reflect patch-sourced values.

## Tests

New regression tests in `tests/annotate/test_barplot_integration.py`, all verified to fail on the pre-fix behavior:
- `estimator="median"` vertical (no hue) and with `hue` dodge
- custom callable estimator (`np.max`)
- horizontal orientation with `estimator="median"` (exercises the `get_width()` branch)
- default mean estimator remains correct (guard against regression)

Full suite green: **1179 passed**; annotate suite **248 passed**.

## Verification

Issue repro now prints `annotation label: 0.808` matching the drawn median (was `1.129`, the mean). Figure eyeballed — label sits correctly atop the bar.

## Notes / follow-ups (out of scope)

- `build_from_pointplot_call` has the same class of bug (hardcodes `np.mean` while `pp.pointplot` accepts `estimator=`, and forces `"median"` in one branch). Worth a separate tracking issue.
- A version-bump PR (0.15.2) + release will follow separately, per release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)