### PR TITLE
chore(release): 0.15.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-07-21
+
 ### Fixed
 
 - `pp.barplot(..., annotate=...)` now labels the value the bar is actually

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.15.1"
+version = "0.15.2"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
Release the barplot `annotate` estimator fix (#194, merged via #195).

- Bump version **0.15.1 → 0.15.2** in `pyproject.toml` (single-sourced; `__version__` reads it via `importlib.metadata`).
- Sync `.claude-plugin/plugin.json` 0.15.1 → 0.15.2 (kept in lockstep with the package version).
- `CHANGELOG.md`: promote the `Fixed` entry to a dated `## [0.15.2]` section.
- Regenerate `uv.lock` (publiplots → 0.15.2).

### Skills
No skill refresh needed this release: this is a pure bugfix with no new plot function, no public-API signature change, and no new gallery example. Neither `publiplots-guide` nor `legend-placement` references `estimator` or the affected annotate path, so the Plots inventory / gallery refs stay in sync.

## Test Plan
- [x] `__version__` resolves to `0.15.2` after `uv sync`.
- [x] `tests/annotate/test_barplot_integration.py -k estimator` — 5 passed (the #194 regression tests, now on main).
- [x] Pure version-bump release PR (fix already merged via #195).

## Follow-up (not in this release)
`pp.pointplot` has the same class of bug (labels/positions the mean regardless of `estimator=`), but the fix is a non-trivial rewrite of the point builder (it recomputes the estimate for both the label text *and* its position, and there's a pre-existing dodge x-position quirk). Deferred to a separate PR + future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)