### PR TITLE
chore(release): 0.15.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.schema.json",
   "name": "publiplots",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Claude Code skills for the publiplots publication-ready plotting library.",
   "author": {
     "name": "Jorge Botas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3] - 2026-07-21
+
 ### Fixed
 
 - `pp.pointplot(..., annotate=...)` now labels each point at the value it is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "publiplots"
-version = "0.15.2"
+version = "0.15.3"
 description = "Publication-ready plotting with a clean, modular API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1969,7 +1969,7 @@ wheels = [
 
 [[package]]
 name = "publiplots"
-version = "0.15.2"
+version = "0.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
Release the pointplot `annotate` estimator fix (#194 sibling, merged via #197).

- Bump version **0.15.2 → 0.15.3** in `pyproject.toml` (single-sourced; `__version__` reads it via `importlib.metadata`).
- Sync `.claude-plugin/plugin.json` 0.15.2 → 0.15.3 (kept in lockstep with the package version).
- `CHANGELOG.md`: promote the `Fixed` entry to a dated `## [0.15.3]` section.
- Regenerate `uv.lock` (publiplots → 0.15.3).

### Skills
No skill refresh needed: pure bugfix, no new plot function, no public-API signature change, no new gallery example that skills reference. Neither `publiplots-guide` nor `legend-placement` references `estimator` or the pointplot annotate path — confirmed by grep.

## Test Plan
- [x] `__version__` resolves to `0.15.3` after `uv sync`.
- [x] Pointplot annotate suite (18 tests) + full suite (1194 passed, 1 skipped) green on the merged fix.
- [x] Pure version-bump release PR (fix already merged via #197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)